### PR TITLE
Fix code style and add copyright.

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -2,6 +2,9 @@
 show-source=true
 statistics=true
 max-line-length = 80
+per-file-ignores =
+    # line too long
+    egs/librispeech/ASR/conformer_ctc/conformer.py: E501,
 
 exclude =
   .git,

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,15 +47,10 @@ jobs:
 
       - name: Install Python dependencies
         run: |
-          python3 -m pip install --upgrade pip pytest kaldialign
+          python3 -m pip install --upgrade pip pytest kaldialign torch==${{ matrix.torch }}
           pip install k2==${{ matrix.k2-version }}+cpu.torch${{ matrix.torch }} -f https://k2-fsa.org/nightly/
 
-          # Don't use: pip install lhotse
-          # since it installs a version of PyTorch that is not predictable
-          git clone --depth 1 https://github.com/lhotse-speech/lhotse
-          cd lhotse
-          sed -i.bak "/torch/d" requirements.txt
-          pip install -r ./requirements.txt
+          pip install lhotse
 
 
       - name: Run tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,9 @@ jobs:
           python3 -m pip install --upgrade pip pytest kaldialign torch==${{ matrix.torch }}
           pip install k2==${{ matrix.k2-version }}+cpu.torch${{ matrix.torch }} -f https://k2-fsa.org/nightly/
 
-          pip install lhotse
+          git clone https://github.com/lhotse-speech/lhotse
+          cd lhotse
+          python setup.py install
 
 
       - name: Run tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
         os: [ubuntu-18.04, macos-10.15]
         python-version: [3.6, 3.7, 3.8, 3.9]
         torch: ["1.8.1"]
-        k2-version: ["1.2.dev20210724"]
+        k2-version: ["1.4.dev20210822"]
       fail-fast: false
 
     steps:
@@ -47,15 +47,10 @@ jobs:
 
       - name: Install Python dependencies
         run: |
-          python3 -m pip install --upgrade pip pytest kaldialign torch==${{ matrix.torch }}
+          python3 -m pip install --upgrade pip pytest
           pip install k2==${{ matrix.k2-version }}+cpu.torch${{ matrix.torch }} -f https://k2-fsa.org/nightly/
           # icefall requirements
           pip install -r requirements.txt
-
-          git clone https://github.com/lhotse-speech/lhotse
-          cd lhotse
-          python setup.py install
-
 
       - name: Run tests
         if: startsWith(matrix.os, 'ubuntu')

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,6 +49,8 @@ jobs:
         run: |
           python3 -m pip install --upgrade pip pytest kaldialign torch==${{ matrix.torch }}
           pip install k2==${{ matrix.k2-version }}+cpu.torch${{ matrix.torch }} -f https://k2-fsa.org/nightly/
+          # icefall requirements
+          pip install -r requirements.txt
 
           git clone https://github.com/lhotse-speech/lhotse
           cd lhotse

--- a/egs/librispeech/ASR/conformer_ctc/conformer.py
+++ b/egs/librispeech/ASR/conformer_ctc/conformer.py
@@ -1,7 +1,20 @@
 #!/usr/bin/env python3
-
 # Copyright (c)  2021  University of Chinese Academy of Sciences (author: Han Zhu)
-# Apache 2.0
+#
+# See ../../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 
 import math
 import warnings

--- a/egs/librispeech/ASR/conformer_ctc/conformer.py
+++ b/egs/librispeech/ASR/conformer_ctc/conformer.py
@@ -41,7 +41,7 @@ class Conformer(Transformer):
       cnn_module_kernel (int): Kernel size of convolution module
       normalize_before (bool): whether to use layer_norm before the first block.
       vgg_frontend (bool): whether to use vgg frontend.
-    """  # noqa E501
+    """
 
     def __init__(
         self,
@@ -872,7 +872,7 @@ class ConvolutionModule(nn.Module):
         kernel_size (int): Kernerl size of conv layers.
         bias (bool): Whether to use bias in conv layers (default=True).
 
-    """  # noqa
+    """
 
     def __init__(
         self, channels: int, kernel_size: int, bias: bool = True

--- a/egs/librispeech/ASR/conformer_ctc/conformer.py
+++ b/egs/librispeech/ASR/conformer_ctc/conformer.py
@@ -1,21 +1,7 @@
 #!/usr/bin/env python3
-# Copyright    2021  Xiaomi Corp.        (authors: Fangjun Kuang)
-#              2021  University of Chinese Academy of Sciences (author: Han Zhu)
-#
-# See ../../../../LICENSE for clarification regarding multiple authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 
+# Copyright (c)  2021  University of Chinese Academy of Sciences (author: Han Zhu)
+# Apache 2.0
 
 import math
 import warnings
@@ -29,18 +15,18 @@ from transformer import Supervisions, Transformer, encoder_padding_mask
 class Conformer(Transformer):
     """
     Args:
-      num_features (int): Number of input features
-      num_classes (int): Number of output classes
-      subsampling_factor (int): subsampling factor of encoder (the convolution layers before transformers)
-      d_model (int): attention dimension
-      nhead (int): number of head
-      dim_feedforward (int): feedforward dimention
-      num_encoder_layers (int): number of encoder layers
-      num_decoder_layers (int): number of decoder layers
-      dropout (float): dropout rate
-      cnn_module_kernel (int): Kernel size of convolution module
-      normalize_before (bool): whether to use layer_norm before the first block.
-      vgg_frontend (bool): whether to use vgg frontend.
+        num_features (int): Number of input features
+        num_classes (int): Number of output classes
+        subsampling_factor (int): subsampling factor of encoder (the convolution layers before transformers)
+        d_model (int): attention dimension
+        nhead (int): number of head
+        dim_feedforward (int): feedforward dimention
+        num_encoder_layers (int): number of encoder layers
+        num_decoder_layers (int): number of decoder layers
+        dropout (float): dropout rate
+        cnn_module_kernel (int): Kernel size of convolution module
+        normalize_before (bool): whether to use layer_norm before the first block.
+        vgg_frontend (bool): whether to use vgg frontend.
     """
 
     def __init__(
@@ -94,8 +80,8 @@ class Conformer(Transformer):
         if self.normalize_before and self.is_espnet_structure:
             self.after_norm = nn.LayerNorm(d_model)
         else:
-            # Note: TorchScript detects that self.after_norm could be used
-            #       inside forward() and throws an error without this change.
+            # Note: TorchScript detects that self.after_norm could be used inside forward()
+            #       and throws an error without this change.
             self.after_norm = identity
 
     def run_encoder(
@@ -107,7 +93,7 @@ class Conformer(Transformer):
             The model input. Its shape is [N, T, C].
           supervisions:
             Supervision in lhotse format.
-            See https://github.com/lhotse-speech/lhotse/blob/master/lhotse/dataset/speech_recognition.py#L32
+            See https://github.com/lhotse-speech/lhotse/blob/master/lhotse/dataset/speech_recognition.py#L32  # noqa
             CAUTION: It contains length information, i.e., start and number of
             frames, before subsampling
             It is read directly from the batch, without any sorting. It is used
@@ -133,18 +119,17 @@ class Conformer(Transformer):
 
 
 class ConformerEncoderLayer(nn.Module):
-    """ConformerEncoderLayer is made up of self-attn, feedforward and
-    convolution networks.
-
+    """
+    ConformerEncoderLayer is made up of self-attn, feedforward and convolution networks.
     See: "Conformer: Convolution-augmented Transformer for Speech Recognition"
 
     Args:
-      d_model: the number of expected features in the input (required).
-      nhead: the number of heads in the multiheadattention models (required).
-      dim_feedforward: the dimension of the feedforward network model (default=2048).
-      dropout: the dropout value (default=0.1).
-      cnn_module_kernel (int): Kernel size of convolution module.
-      normalize_before: whether to use layer_norm before the first block.
+        d_model: the number of expected features in the input (required).
+        nhead: the number of heads in the multiheadattention models (required).
+        dim_feedforward: the dimension of the feedforward network model (default=2048).
+        dropout: the dropout value (default=0.1).
+        cnn_module_kernel (int): Kernel size of convolution module.
+        normalize_before: whether to use layer_norm before the first block.
 
     Examples::
         >>> encoder_layer = ConformerEncoderLayer(d_model=512, nhead=8)
@@ -208,7 +193,8 @@ class ConformerEncoderLayer(nn.Module):
         src_mask: Optional[Tensor] = None,
         src_key_padding_mask: Optional[Tensor] = None,
     ) -> Tensor:
-        """Pass the input through the encoder layer.
+        """
+        Pass the input through the encoder layer.
 
         Args:
             src: the sequence to the encoder layer (required).
@@ -315,8 +301,7 @@ class ConformerEncoder(nn.TransformerEncoder):
             pos_emb: (N, 2*S-1, E)
             mask: (S, S).
             src_key_padding_mask: (N, S).
-            S is the source sequence length, T is the target sequence length,
-            N is the batch size, E is the feature number
+            S is the source sequence length, T is the target sequence length, N is the batch size, E is the feature number
 
         """
         output = src
@@ -411,7 +396,7 @@ class RelPositionalEncoding(torch.nn.Module):
             :,
             self.pe.size(1) // 2
             - x.size(1)
-            + 1: self.pe.size(1) // 2
+            + 1 : self.pe.size(1) // 2  # noqa E203
             + x.size(1),
         ]
         return self.dropout(x), self.dropout(pos_emb)
@@ -485,48 +470,42 @@ class RelPositionMultiheadAttention(nn.Module):
         Args:
             query, key, value: map a query and a set of key-value pairs to an output.
             pos_emb: Positional embedding tensor
-            key_padding_mask: if provided, specified padding elements in the key
-                will be ignored by the attention. When given a binary mask and
-                a value is True, the corresponding value on the attention layer
-                will be ignored. When given a byte mask and a value is non-zero,
-                the corresponding value on the attention layer will be ignored.
+            key_padding_mask: if provided, specified padding elements in the key will
+                be ignored by the attention. When given a binary mask and a value is True,
+                the corresponding value on the attention layer will be ignored. When given
+                a byte mask and a value is non-zero, the corresponding value on the attention
+                layer will be ignored
             need_weights: output attn_output_weights.
-            attn_mask: 2D or 3D mask that prevents attention to certain positions.
-                A 2D mask will be broadcasted for all the batches while a 3D mask
-                allows to specify a different mask for the entries of each batch.
+            attn_mask: 2D or 3D mask that prevents attention to certain positions. A 2D mask will be broadcasted for all
+                the batches while a 3D mask allows to specify a different mask for the entries of each batch.
 
         Shape:
             - Inputs:
-            - query: :math:`(L, N, E)` where L is the target sequence length,
-                N is the batch size, E is the embedding dimension.
-            - key: :math:`(S, N, E)`, where S is the source sequence length,
-                N is the batch size, E is the embedding dimension.
-            - value: :math:`(S, N, E)` where S is the source sequence length,
-                N is the batch size, E is the embedding dimension.
-            - pos_emb: :math:`(N, 2*L-1, E)` where L is the target sequence length,
-                N is the batch size, E is the embedding dimension.
-            - key_padding_mask: :math:`(N, S)` where N is the batch size,
-                S is the source sequence length. If a ByteTensor is provided,
-                the non-zero positions will be ignored while the position
-                with the zero positions will be unchanged. If a BoolTensor is provided,
-                the positions with the value of ``True`` will be ignored while
-                the position with the value of ``False`` will be unchanged.
-            - attn_mask: 2D mask :math:`(L, S)` where L is the target sequence length,
-                S is the source sequence length. 3D mask :math:`(N*num_heads, L, S)`
-                where N is the batch size, L is the target sequence length,
-                S is the source sequence length. attn_mask ensure that position
-                i is allowed to attend the unmasked positions.
-                If a ByteTensor is provided, the non-zero positions are not
-                allowed to attend while the zero positions will be unchanged.
-                If a BoolTensor is provided, positions with ``True`` is not allowed
-                to attend while ``False`` values will be unchanged.
-                If a FloatTensor is provided, it will be added to the attention weight.
+            - query: :math:`(L, N, E)` where L is the target sequence length, N is the batch size, E is
+            the embedding dimension.
+            - key: :math:`(S, N, E)`, where S is the source sequence length, N is the batch size, E is
+            the embedding dimension.
+            - value: :math:`(S, N, E)` where S is the source sequence length, N is the batch size, E is
+            the embedding dimension.
+            - pos_emb: :math:`(N, 2*L-1, E)` where L is the target sequence length, N is the batch size, E is
+            the embedding dimension.
+            - key_padding_mask: :math:`(N, S)` where N is the batch size, S is the source sequence length.
+            If a ByteTensor is provided, the non-zero positions will be ignored while the position
+            with the zero positions will be unchanged. If a BoolTensor is provided, the positions with the
+            value of ``True`` will be ignored while the position with the value of ``False`` will be unchanged.
+            - attn_mask: 2D mask :math:`(L, S)` where L is the target sequence length, S is the source sequence length.
+            3D mask :math:`(N*num_heads, L, S)` where N is the batch size, L is the target sequence length,
+            S is the source sequence length. attn_mask ensure that position i is allowed to attend the unmasked
+            positions. If a ByteTensor is provided, the non-zero positions are not allowed to attend
+            while the zero positions will be unchanged. If a BoolTensor is provided, positions with ``True``
+            is not allowed to attend while ``False`` values will be unchanged. If a FloatTensor
+            is provided, it will be added to the attention weight.
 
             - Outputs:
-            - attn_output: :math:`(L, N, E)` where L is the target sequence length,
-                N is the batch size, E is the embedding dimension.
+            - attn_output: :math:`(L, N, E)` where L is the target sequence length, N is the batch size,
+            E is the embedding dimension.
             - attn_output_weights: :math:`(N, L, S)` where N is the batch size,
-                L is the target sequence length, S is the source sequence length.
+            L is the target sequence length, S is the source sequence length.
         """
         return self.multi_head_attention_forward(
             query,
@@ -603,43 +582,36 @@ class RelPositionMultiheadAttention(nn.Module):
                 be ignored by the attention. This is an binary mask. When the value is True,
                 the corresponding value on the attention layer will be filled with -inf.
             need_weights: output attn_output_weights.
-            attn_mask: 2D or 3D mask that prevents attention to certain positions.
-                A 2D mask will be broadcasted for all the batches while a 3D mask
-                allows to specify a different mask for the entries of each batch.
+            attn_mask: 2D or 3D mask that prevents attention to certain positions. A 2D mask will be broadcasted for all
+                the batches while a 3D mask allows to specify a different mask for the entries of each batch.
 
         Shape:
             Inputs:
-            - query: :math:`(L, N, E)` where L is the target sequence length,
-                N is the batch size, E is the embedding dimension.
-            - key: :math:`(S, N, E)`, where S is the source sequence length,
-                N is the batch size, E is the embedding dimension.
-            - value: :math:`(S, N, E)` where S is the source sequence length,
-                N is the batch size, E is the embedding dimension.
-            - pos_emb: :math:`(N, 2*L-1, E)` or :math:`(1, 2*L-1, E)` where
-                L is the target sequencelength, N is the batch size,
-                E is the embedding dimension.
-            - key_padding_mask: :math:`(N, S)` where N is the batch size,
-                S is the source sequence length. If a ByteTensor is provided,
-                the non-zero positions will be ignored while the zero positions
-                will be unchanged. If a BoolTensor is provided, the positions with the
-                value of ``True`` will be ignored while the position with the
-                value of ``False`` will be unchanged.
-            - attn_mask: 2D mask :math:`(L, S)` where L is the target sequence length,
-                S is the source sequence length. 3D mask :math:`(N*num_heads, L, S)`
-                where N is the batch size, L is the target sequence length,
-                S is the source sequence length. attn_mask ensures that position
-                i is allowed to attend the unmasked positions.
-                If a ByteTensor is provided, the non-zero positions are not
-                allowed to attend while the zero positions will be unchanged.
-                If a BoolTensor is provided, positions with ``True`` are not
-                allowed to attend while ``False`` values will be unchanged.
-                If a FloatTensor is provided, it will be added to the attention weight.
+            - query: :math:`(L, N, E)` where L is the target sequence length, N is the batch size, E is
+            the embedding dimension.
+            - key: :math:`(S, N, E)`, where S is the source sequence length, N is the batch size, E is
+            the embedding dimension.
+            - value: :math:`(S, N, E)` where S is the source sequence length, N is the batch size, E is
+            the embedding dimension.
+            - pos_emb: :math:`(N, 2*L-1, E)` or :math:`(1, 2*L-1, E)` where L is the target sequence
+            length, N is the batch size, E is the embedding dimension.
+            - key_padding_mask: :math:`(N, S)` where N is the batch size, S is the source sequence length.
+            If a ByteTensor is provided, the non-zero positions will be ignored while the zero positions
+            will be unchanged. If a BoolTensor is provided, the positions with the
+            value of ``True`` will be ignored while the position with the value of ``False`` will be unchanged.
+            - attn_mask: 2D mask :math:`(L, S)` where L is the target sequence length, S is the source sequence length.
+            3D mask :math:`(N*num_heads, L, S)` where N is the batch size, L is the target sequence length,
+            S is the source sequence length. attn_mask ensures that position i is allowed to attend the unmasked
+            positions. If a ByteTensor is provided, the non-zero positions are not allowed to attend
+            while the zero positions will be unchanged. If a BoolTensor is provided, positions with ``True``
+            are not allowed to attend while ``False`` values will be unchanged. If a FloatTensor
+            is provided, it will be added to the attention weight.
 
             Outputs:
-            - attn_output: :math:`(L, N, E)` where L is the target sequence length,
-                N is the batch size, E is the embedding dimension.
+            - attn_output: :math:`(L, N, E)` where L is the target sequence length, N is the batch size,
+            E is the embedding dimension.
             - attn_output_weights: :math:`(N, L, S)` where N is the batch size,
-                L is the target sequence length, S is the source sequence length.
+            L is the target sequence length, S is the source sequence length.
         """
 
         tgt_len, bsz, embed_dim = query.size()

--- a/egs/librispeech/ASR/conformer_ctc/conformer.py
+++ b/egs/librispeech/ASR/conformer_ctc/conformer.py
@@ -1,7 +1,21 @@
 #!/usr/bin/env python3
+# Copyright    2021  Xiaomi Corp.        (authors: Fangjun Kuang)
+#              2021  University of Chinese Academy of Sciences (author: Han Zhu)
+#
+# See ../../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-# Copyright (c)  2021  University of Chinese Academy of Sciences (author: Han Zhu)
-# Apache 2.0
 
 import math
 import warnings
@@ -15,19 +29,19 @@ from transformer import Supervisions, Transformer, encoder_padding_mask
 class Conformer(Transformer):
     """
     Args:
-        num_features (int): Number of input features
-        num_classes (int): Number of output classes
-        subsampling_factor (int): subsampling factor of encoder (the convolution layers before transformers)
-        d_model (int): attention dimension
-        nhead (int): number of head
-        dim_feedforward (int): feedforward dimention
-        num_encoder_layers (int): number of encoder layers
-        num_decoder_layers (int): number of decoder layers
-        dropout (float): dropout rate
-        cnn_module_kernel (int): Kernel size of convolution module
-        normalize_before (bool): whether to use layer_norm before the first block.
-        vgg_frontend (bool): whether to use vgg frontend.
-    """
+      num_features (int): Number of input features
+      num_classes (int): Number of output classes
+      subsampling_factor (int): subsampling factor of encoder (the convolution layers before transformers)
+      d_model (int): attention dimension
+      nhead (int): number of head
+      dim_feedforward (int): feedforward dimention
+      num_encoder_layers (int): number of encoder layers
+      num_decoder_layers (int): number of decoder layers
+      dropout (float): dropout rate
+      cnn_module_kernel (int): Kernel size of convolution module
+      normalize_before (bool): whether to use layer_norm before the first block.
+      vgg_frontend (bool): whether to use vgg frontend.
+    """  # noqa E501
 
     def __init__(
         self,
@@ -80,8 +94,8 @@ class Conformer(Transformer):
         if self.normalize_before and self.is_espnet_structure:
             self.after_norm = nn.LayerNorm(d_model)
         else:
-            # Note: TorchScript detects that self.after_norm could be used inside forward()
-            #       and throws an error without this change.
+            # Note: TorchScript detects that self.after_norm could be used
+            #       inside forward() and throws an error without this change.
             self.after_norm = identity
 
     def run_encoder(
@@ -93,7 +107,7 @@ class Conformer(Transformer):
             The model input. Its shape is [N, T, C].
           supervisions:
             Supervision in lhotse format.
-            See https://github.com/lhotse-speech/lhotse/blob/master/lhotse/dataset/speech_recognition.py#L32  # noqa
+            See https://github.com/lhotse-speech/lhotse/blob/master/lhotse/dataset/speech_recognition.py#L32
             CAUTION: It contains length information, i.e., start and number of
             frames, before subsampling
             It is read directly from the batch, without any sorting. It is used
@@ -119,17 +133,18 @@ class Conformer(Transformer):
 
 
 class ConformerEncoderLayer(nn.Module):
-    """
-    ConformerEncoderLayer is made up of self-attn, feedforward and convolution networks.
+    """ConformerEncoderLayer is made up of self-attn, feedforward and
+    convolution networks.
+
     See: "Conformer: Convolution-augmented Transformer for Speech Recognition"
 
     Args:
-        d_model: the number of expected features in the input (required).
-        nhead: the number of heads in the multiheadattention models (required).
-        dim_feedforward: the dimension of the feedforward network model (default=2048).
-        dropout: the dropout value (default=0.1).
-        cnn_module_kernel (int): Kernel size of convolution module.
-        normalize_before: whether to use layer_norm before the first block.
+      d_model: the number of expected features in the input (required).
+      nhead: the number of heads in the multiheadattention models (required).
+      dim_feedforward: the dimension of the feedforward network model (default=2048).
+      dropout: the dropout value (default=0.1).
+      cnn_module_kernel (int): Kernel size of convolution module.
+      normalize_before: whether to use layer_norm before the first block.
 
     Examples::
         >>> encoder_layer = ConformerEncoderLayer(d_model=512, nhead=8)
@@ -193,8 +208,7 @@ class ConformerEncoderLayer(nn.Module):
         src_mask: Optional[Tensor] = None,
         src_key_padding_mask: Optional[Tensor] = None,
     ) -> Tensor:
-        """
-        Pass the input through the encoder layer.
+        """Pass the input through the encoder layer.
 
         Args:
             src: the sequence to the encoder layer (required).
@@ -301,7 +315,8 @@ class ConformerEncoder(nn.TransformerEncoder):
             pos_emb: (N, 2*S-1, E)
             mask: (S, S).
             src_key_padding_mask: (N, S).
-            S is the source sequence length, T is the target sequence length, N is the batch size, E is the feature number
+            S is the source sequence length, T is the target sequence length,
+            N is the batch size, E is the feature number
 
         """
         output = src
@@ -396,7 +411,7 @@ class RelPositionalEncoding(torch.nn.Module):
             :,
             self.pe.size(1) // 2
             - x.size(1)
-            + 1 : self.pe.size(1) // 2
+            + 1: self.pe.size(1) // 2
             + x.size(1),
         ]
         return self.dropout(x), self.dropout(pos_emb)
@@ -470,42 +485,48 @@ class RelPositionMultiheadAttention(nn.Module):
         Args:
             query, key, value: map a query and a set of key-value pairs to an output.
             pos_emb: Positional embedding tensor
-            key_padding_mask: if provided, specified padding elements in the key will
-                be ignored by the attention. When given a binary mask and a value is True,
-                the corresponding value on the attention layer will be ignored. When given
-                a byte mask and a value is non-zero, the corresponding value on the attention
-                layer will be ignored
+            key_padding_mask: if provided, specified padding elements in the key
+                will be ignored by the attention. When given a binary mask and
+                a value is True, the corresponding value on the attention layer
+                will be ignored. When given a byte mask and a value is non-zero,
+                the corresponding value on the attention layer will be ignored.
             need_weights: output attn_output_weights.
-            attn_mask: 2D or 3D mask that prevents attention to certain positions. A 2D mask will be broadcasted for all
-                the batches while a 3D mask allows to specify a different mask for the entries of each batch.
+            attn_mask: 2D or 3D mask that prevents attention to certain positions.
+                A 2D mask will be broadcasted for all the batches while a 3D mask
+                allows to specify a different mask for the entries of each batch.
 
         Shape:
             - Inputs:
-            - query: :math:`(L, N, E)` where L is the target sequence length, N is the batch size, E is
-            the embedding dimension.
-            - key: :math:`(S, N, E)`, where S is the source sequence length, N is the batch size, E is
-            the embedding dimension.
-            - value: :math:`(S, N, E)` where S is the source sequence length, N is the batch size, E is
-            the embedding dimension.
-            - pos_emb: :math:`(N, 2*L-1, E)` where L is the target sequence length, N is the batch size, E is
-            the embedding dimension.
-            - key_padding_mask: :math:`(N, S)` where N is the batch size, S is the source sequence length.
-            If a ByteTensor is provided, the non-zero positions will be ignored while the position
-            with the zero positions will be unchanged. If a BoolTensor is provided, the positions with the
-            value of ``True`` will be ignored while the position with the value of ``False`` will be unchanged.
-            - attn_mask: 2D mask :math:`(L, S)` where L is the target sequence length, S is the source sequence length.
-            3D mask :math:`(N*num_heads, L, S)` where N is the batch size, L is the target sequence length,
-            S is the source sequence length. attn_mask ensure that position i is allowed to attend the unmasked
-            positions. If a ByteTensor is provided, the non-zero positions are not allowed to attend
-            while the zero positions will be unchanged. If a BoolTensor is provided, positions with ``True``
-            is not allowed to attend while ``False`` values will be unchanged. If a FloatTensor
-            is provided, it will be added to the attention weight.
+            - query: :math:`(L, N, E)` where L is the target sequence length,
+                N is the batch size, E is the embedding dimension.
+            - key: :math:`(S, N, E)`, where S is the source sequence length,
+                N is the batch size, E is the embedding dimension.
+            - value: :math:`(S, N, E)` where S is the source sequence length,
+                N is the batch size, E is the embedding dimension.
+            - pos_emb: :math:`(N, 2*L-1, E)` where L is the target sequence length,
+                N is the batch size, E is the embedding dimension.
+            - key_padding_mask: :math:`(N, S)` where N is the batch size,
+                S is the source sequence length. If a ByteTensor is provided,
+                the non-zero positions will be ignored while the position
+                with the zero positions will be unchanged. If a BoolTensor is provided,
+                the positions with the value of ``True`` will be ignored while
+                the position with the value of ``False`` will be unchanged.
+            - attn_mask: 2D mask :math:`(L, S)` where L is the target sequence length,
+                S is the source sequence length. 3D mask :math:`(N*num_heads, L, S)`
+                where N is the batch size, L is the target sequence length,
+                S is the source sequence length. attn_mask ensure that position
+                i is allowed to attend the unmasked positions.
+                If a ByteTensor is provided, the non-zero positions are not
+                allowed to attend while the zero positions will be unchanged.
+                If a BoolTensor is provided, positions with ``True`` is not allowed
+                to attend while ``False`` values will be unchanged.
+                If a FloatTensor is provided, it will be added to the attention weight.
 
             - Outputs:
-            - attn_output: :math:`(L, N, E)` where L is the target sequence length, N is the batch size,
-            E is the embedding dimension.
+            - attn_output: :math:`(L, N, E)` where L is the target sequence length,
+                N is the batch size, E is the embedding dimension.
             - attn_output_weights: :math:`(N, L, S)` where N is the batch size,
-            L is the target sequence length, S is the source sequence length.
+                L is the target sequence length, S is the source sequence length.
         """
         return self.multi_head_attention_forward(
             query,
@@ -582,36 +603,43 @@ class RelPositionMultiheadAttention(nn.Module):
                 be ignored by the attention. This is an binary mask. When the value is True,
                 the corresponding value on the attention layer will be filled with -inf.
             need_weights: output attn_output_weights.
-            attn_mask: 2D or 3D mask that prevents attention to certain positions. A 2D mask will be broadcasted for all
-                the batches while a 3D mask allows to specify a different mask for the entries of each batch.
+            attn_mask: 2D or 3D mask that prevents attention to certain positions.
+                A 2D mask will be broadcasted for all the batches while a 3D mask
+                allows to specify a different mask for the entries of each batch.
 
         Shape:
             Inputs:
-            - query: :math:`(L, N, E)` where L is the target sequence length, N is the batch size, E is
-            the embedding dimension.
-            - key: :math:`(S, N, E)`, where S is the source sequence length, N is the batch size, E is
-            the embedding dimension.
-            - value: :math:`(S, N, E)` where S is the source sequence length, N is the batch size, E is
-            the embedding dimension.
-            - pos_emb: :math:`(N, 2*L-1, E)` or :math:`(1, 2*L-1, E)` where L is the target sequence
-            length, N is the batch size, E is the embedding dimension.
-            - key_padding_mask: :math:`(N, S)` where N is the batch size, S is the source sequence length.
-            If a ByteTensor is provided, the non-zero positions will be ignored while the zero positions
-            will be unchanged. If a BoolTensor is provided, the positions with the
-            value of ``True`` will be ignored while the position with the value of ``False`` will be unchanged.
-            - attn_mask: 2D mask :math:`(L, S)` where L is the target sequence length, S is the source sequence length.
-            3D mask :math:`(N*num_heads, L, S)` where N is the batch size, L is the target sequence length,
-            S is the source sequence length. attn_mask ensures that position i is allowed to attend the unmasked
-            positions. If a ByteTensor is provided, the non-zero positions are not allowed to attend
-            while the zero positions will be unchanged. If a BoolTensor is provided, positions with ``True``
-            are not allowed to attend while ``False`` values will be unchanged. If a FloatTensor
-            is provided, it will be added to the attention weight.
+            - query: :math:`(L, N, E)` where L is the target sequence length,
+                N is the batch size, E is the embedding dimension.
+            - key: :math:`(S, N, E)`, where S is the source sequence length,
+                N is the batch size, E is the embedding dimension.
+            - value: :math:`(S, N, E)` where S is the source sequence length,
+                N is the batch size, E is the embedding dimension.
+            - pos_emb: :math:`(N, 2*L-1, E)` or :math:`(1, 2*L-1, E)` where
+                L is the target sequencelength, N is the batch size,
+                E is the embedding dimension.
+            - key_padding_mask: :math:`(N, S)` where N is the batch size,
+                S is the source sequence length. If a ByteTensor is provided,
+                the non-zero positions will be ignored while the zero positions
+                will be unchanged. If a BoolTensor is provided, the positions with the
+                value of ``True`` will be ignored while the position with the
+                value of ``False`` will be unchanged.
+            - attn_mask: 2D mask :math:`(L, S)` where L is the target sequence length,
+                S is the source sequence length. 3D mask :math:`(N*num_heads, L, S)`
+                where N is the batch size, L is the target sequence length,
+                S is the source sequence length. attn_mask ensures that position
+                i is allowed to attend the unmasked positions.
+                If a ByteTensor is provided, the non-zero positions are not
+                allowed to attend while the zero positions will be unchanged.
+                If a BoolTensor is provided, positions with ``True`` are not
+                allowed to attend while ``False`` values will be unchanged.
+                If a FloatTensor is provided, it will be added to the attention weight.
 
             Outputs:
-            - attn_output: :math:`(L, N, E)` where L is the target sequence length, N is the batch size,
-            E is the embedding dimension.
+            - attn_output: :math:`(L, N, E)` where L is the target sequence length,
+                N is the batch size, E is the embedding dimension.
             - attn_output_weights: :math:`(N, L, S)` where N is the batch size,
-            L is the target sequence length, S is the source sequence length.
+                L is the target sequence length, S is the source sequence length.
         """
 
         tgt_len, bsz, embed_dim = query.size()
@@ -844,7 +872,7 @@ class ConvolutionModule(nn.Module):
         kernel_size (int): Kernerl size of conv layers.
         bias (bool): Whether to use bias in conv layers (default=True).
 
-    """
+    """  # noqa
 
     def __init__(
         self, channels: int, kernel_size: int, bias: bool = True

--- a/egs/librispeech/ASR/conformer_ctc/decode.py
+++ b/egs/librispeech/ASR/conformer_ctc/decode.py
@@ -1,8 +1,20 @@
 #!/usr/bin/env python3
-
 # Copyright 2021 Xiaomi Corporation (Author: Liyong Guo, Fangjun Kuang)
+#
+# See ../../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-# (still working in progress)
 
 import argparse
 import logging

--- a/egs/librispeech/ASR/conformer_ctc/pretrained.py
+++ b/egs/librispeech/ASR/conformer_ctc/pretrained.py
@@ -261,7 +261,6 @@ def main():
     if params.method in ["whole-lattice-rescoring", "attention-decoder"]:
         logging.info(f"Loading G from {params.G}")
         G = k2.Fsa.from_dict(torch.load(params.G, map_location="cpu"))
-        G = G.to(device)
         # Add epsilon self-loops to G as we will compose
         # it with the whole lattice later
         G = G.to(device)

--- a/egs/librispeech/ASR/conformer_ctc/pretrained.py
+++ b/egs/librispeech/ASR/conformer_ctc/pretrained.py
@@ -1,4 +1,20 @@
 #!/usr/bin/env python3
+# Copyright      2021  Xiaomi Corp.        (authors: Fangjun Kuang)
+#
+# See ../../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 
 import argparse
 import logging
@@ -59,7 +75,7 @@ def get_parser():
             decoding lattice and then use 1best to decode the
             rescored lattice.
             We call it HLG decoding + n-gram LM rescoring.
-        (3) attention-decoder - Extract n paths from he rescored
+        (3) attention-decoder - Extract n paths from the rescored
             lattice and use the transformer attention decoder for
             rescoring.
             We call it HLG decoding + n-gram LM rescoring + attention
@@ -248,6 +264,7 @@ def main():
         G = G.to(device)
         # Add epsilon self-loops to G as we will compose
         # it with the whole lattice later
+        G = G.to(device)
         G = k2.add_epsilon_self_loops(G)
         G = k2.arc_sort(G)
         G.lm_scores = G.scores.clone()
@@ -268,7 +285,7 @@ def main():
     )
     waves = [w.to(device) for w in waves]
 
-    logging.info(f"Decoding started")
+    logging.info("Decoding started")
     features = fbank(waves)
 
     features = pad_sequence(
@@ -338,7 +355,7 @@ def main():
         s += f"{filename}:\n{words}\n\n"
     logging.info(s)
 
-    logging.info(f"Decoding Done")
+    logging.info("Decoding Done")
 
 
 if __name__ == "__main__":

--- a/egs/librispeech/ASR/conformer_ctc/subsampling.py
+++ b/egs/librispeech/ASR/conformer_ctc/subsampling.py
@@ -1,3 +1,20 @@
+# Copyright    2021  Xiaomi Corp.        (authors: Fangjun Kuang)
+#
+# See ../../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 import torch
 import torch.nn as nn
 

--- a/egs/librispeech/ASR/conformer_ctc/test_subsampling.py
+++ b/egs/librispeech/ASR/conformer_ctc/test_subsampling.py
@@ -1,4 +1,20 @@
 #!/usr/bin/env python3
+# Copyright    2021  Xiaomi Corp.        (authors: Fangjun Kuang)
+#
+# See ../../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 
 from subsampling import Conv2dSubsampling
 from subsampling import VggSubsampling

--- a/egs/librispeech/ASR/conformer_ctc/test_transformer.py
+++ b/egs/librispeech/ASR/conformer_ctc/test_transformer.py
@@ -1,4 +1,20 @@
 #!/usr/bin/env python3
+# Copyright    2021  Xiaomi Corp.        (authors: Fangjun Kuang)
+#
+# See ../../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 
 import torch
 from transformer import (

--- a/egs/librispeech/ASR/conformer_ctc/train.py
+++ b/egs/librispeech/ASR/conformer_ctc/train.py
@@ -1,6 +1,20 @@
 #!/usr/bin/env python3
+# Copyright    2021  Xiaomi Corp.        (authors: Fangjun Kuang)
+#
+# See ../../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-# This is just at the very beginning ...
 
 import argparse
 import logging

--- a/egs/librispeech/ASR/conformer_ctc/transformer.py
+++ b/egs/librispeech/ASR/conformer_ctc/transformer.py
@@ -1,5 +1,19 @@
-# Copyright (c) 2021 University of Chinese Academy of Sciences (author: Han Zhu)
-# Apache 2.0
+# Copyright    2021 University of Chinese Academy of Sciences (author: Han Zhu)
+#
+# See ../../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 
 import math
 from typing import Dict, List, Optional, Tuple
@@ -779,7 +793,8 @@ class Noam(object):
 
 class LabelSmoothingLoss(nn.Module):
     """
-    Label-smoothing loss. KL-divergence between q_{smoothed ground truth prob.}(w)
+    Label-smoothing loss. KL-divergence between
+    q_{smoothed ground truth prob.}(w)
     and p_{prob. computed by model}(w) is minimized.
     Modified from
     https://github.com/espnet/espnet/blob/master/espnet/nets/pytorch_backend/transformer/label_smoothing_loss.py  # noqa
@@ -864,7 +879,8 @@ def encoder_padding_mask(
          frames, before subsampling)
 
     Returns:
-        Tensor: Mask tensor of dimension (batch_size, input_length), True denote the masked indices.
+        Tensor: Mask tensor of dimension (batch_size, input_length),
+        True denote the masked indices.
     """
     if supervisions is None:
         return None

--- a/egs/librispeech/ASR/local/compile_hlg.py
+++ b/egs/librispeech/ASR/local/compile_hlg.py
@@ -1,4 +1,20 @@
 #!/usr/bin/env python3
+# Copyright    2021  Xiaomi Corp.        (authors: Fangjun Kuang)
+#
+# See ../../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 
 """
 This script takes as input lang_dir and generates HLG from

--- a/egs/librispeech/ASR/local/compute_fbank_librispeech.py
+++ b/egs/librispeech/ASR/local/compute_fbank_librispeech.py
@@ -70,7 +70,8 @@ def compute_fbank_librispeech():
                 continue
             logging.info(f"Processing {partition}")
             cut_set = CutSet.from_manifests(
-                recordings=m["recordings"], supervisions=m["supervisions"],
+                recordings=m["recordings"],
+                supervisions=m["supervisions"],
             )
             if "train" in partition:
                 cut_set = (

--- a/egs/librispeech/ASR/local/compute_fbank_librispeech.py
+++ b/egs/librispeech/ASR/local/compute_fbank_librispeech.py
@@ -1,4 +1,20 @@
 #!/usr/bin/env python3
+# Copyright    2021  Xiaomi Corp.        (authors: Fangjun Kuang)
+#
+# See ../../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 
 """
 This file computes fbank features of the LibriSpeech dataset.
@@ -17,8 +33,9 @@ from lhotse.recipes.utils import read_manifests_if_cached
 
 from icefall.utils import get_executor
 
-# Torch's multithreaded behavior needs to be disabled or it wastes a lot of CPU and
-# slow things down.  Do this outside of main() in case it needs to take effect
+# Torch's multithreaded behavior needs to be disabled or
+# it wastes a lot of CPU and slow things down.
+# Do this outside of main() in case it needs to take effect
 # even when we are not invoking the main (e.g. when spawning subprocesses).
 torch.set_num_threads(1)
 torch.set_num_interop_threads(1)

--- a/egs/librispeech/ASR/local/compute_fbank_musan.py
+++ b/egs/librispeech/ASR/local/compute_fbank_musan.py
@@ -1,4 +1,20 @@
 #!/usr/bin/env python3
+# Copyright    2021  Xiaomi Corp.        (authors: Fangjun Kuang)
+#
+# See ../../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 
 """
 This file computes fbank features of the musan dataset.
@@ -17,8 +33,9 @@ from lhotse.recipes.utils import read_manifests_if_cached
 
 from icefall.utils import get_executor
 
-# Torch's multithreaded behavior needs to be disabled or it wastes a lot of CPU and
-# slow things down.  Do this outside of main() in case it needs to take effect
+# Torch's multithreaded behavior needs to be disabled or
+# it wastes a lot of CPU and slow things down.
+# Do this outside of main() in case it needs to take effect
 # even when we are not invoking the main (e.g. when spawning subprocesses).
 torch.set_num_threads(1)
 torch.set_num_interop_threads(1)

--- a/egs/librispeech/ASR/local/download_lm.py
+++ b/egs/librispeech/ASR/local/download_lm.py
@@ -1,6 +1,21 @@
 #!/usr/bin/env python3
+# Copyright    2021  Xiaomi Corp.        (authors: Fangjun Kuang)
+#
+# See ../../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-# Copyright (c)  2021  Xiaomi Corporation (authors: Fangjun Kuang)
+
 """
 This file downloads the following LibriSpeech LM files:
 

--- a/egs/librispeech/ASR/local/prepare_lang.py
+++ b/egs/librispeech/ASR/local/prepare_lang.py
@@ -1,6 +1,20 @@
 #!/usr/bin/env python3
+# Copyright    2021  Xiaomi Corp.        (authors: Fangjun Kuang)
+#
+# See ../../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-# Copyright (c)  2021  Xiaomi Corporation (authors: Fangjun Kuang)
 
 """
 This script takes as input a lexicon file "data/lang_phone/lexicon.txt"

--- a/egs/librispeech/ASR/local/prepare_lang_bpe.py
+++ b/egs/librispeech/ASR/local/prepare_lang_bpe.py
@@ -1,4 +1,20 @@
 #!/usr/bin/env python3
+# Copyright    2021  Xiaomi Corp.        (authors: Fangjun Kuang)
+#
+# See ../../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 
 # Copyright (c)  2021  Xiaomi Corporation (authors: Fangjun Kuang)
 

--- a/egs/librispeech/ASR/local/test_prepare_lang.py
+++ b/egs/librispeech/ASR/local/test_prepare_lang.py
@@ -1,4 +1,20 @@
 #!/usr/bin/env python3
+# Copyright    2021  Xiaomi Corp.        (authors: Fangjun Kuang)
+#
+# See ../../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 
 # Copyright (c)  2021  Xiaomi Corporation (authors: Fangjun Kuang)
 

--- a/egs/librispeech/ASR/local/train_bpe_model.py
+++ b/egs/librispeech/ASR/local/train_bpe_model.py
@@ -1,4 +1,20 @@
 #!/usr/bin/env python3
+# Copyright    2021  Xiaomi Corp.        (authors: Fangjun Kuang)
+#
+# See ../../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 
 # You can install sentencepiece via:
 #

--- a/egs/librispeech/ASR/tdnn_lstm_ctc/asr_datamodule.py
+++ b/egs/librispeech/ASR/tdnn_lstm_ctc/asr_datamodule.py
@@ -1,3 +1,20 @@
+# Copyright      2021  Xiaomi Corp.        (authors: Fangjun Kuang)
+#
+# See ../../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 import argparse
 import logging
 from functools import lru_cache

--- a/egs/librispeech/ASR/tdnn_lstm_ctc/decode.py
+++ b/egs/librispeech/ASR/tdnn_lstm_ctc/decode.py
@@ -1,4 +1,19 @@
 #!/usr/bin/env python3
+# Copyright      2021  Xiaomi Corp.        (authors: Fangjun Kuang)
+#
+# See ../../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 
 import argparse

--- a/egs/librispeech/ASR/tdnn_lstm_ctc/model.py
+++ b/egs/librispeech/ASR/tdnn_lstm_ctc/model.py
@@ -1,3 +1,20 @@
+# Copyright      2021  Xiaomi Corp.        (authors: Fangjun Kuang)
+#
+# See ../../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 import torch
 import torch.nn as nn
 

--- a/egs/librispeech/ASR/tdnn_lstm_ctc/train.py
+++ b/egs/librispeech/ASR/tdnn_lstm_ctc/train.py
@@ -1,4 +1,20 @@
 #!/usr/bin/env python3
+# Copyright      2021  Xiaomi Corp.        (authors: Fangjun Kuang)
+#
+# See ../../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 
 import argparse
 import logging

--- a/icefall/bpe_graph_compiler.py
+++ b/icefall/bpe_graph_compiler.py
@@ -74,7 +74,9 @@ class BpeCtcTrainingGraphCompiler(object):
         return self.sp.encode(texts, out_type=int)
 
     def compile(
-        self, piece_ids: List[List[int]], modified: bool = False,
+        self,
+        piece_ids: List[List[int]],
+        modified: bool = False,
     ) -> k2.Fsa:
         """Build a ctc graph from a list-of-list piece IDs.
 

--- a/icefall/bpe_graph_compiler.py
+++ b/icefall/bpe_graph_compiler.py
@@ -1,3 +1,20 @@
+# Copyright      2021  Xiaomi Corp.        (authors: Fangjun Kuang)
+#
+# See ../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 from pathlib import Path
 from typing import List, Union
 

--- a/icefall/checkpoint.py
+++ b/icefall/checkpoint.py
@@ -1,3 +1,20 @@
+# Copyright      2021  Xiaomi Corp.        (authors: Fangjun Kuang)
+#
+# See ../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 import logging
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union

--- a/icefall/dataset/datamodule.py
+++ b/icefall/dataset/datamodule.py
@@ -1,3 +1,20 @@
+# Copyright      2021  Xiaomi Corp.        (authors: Fangjun Kuang)
+#
+# See ../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 import argparse
 from typing import List, Union
 

--- a/icefall/decode.py
+++ b/icefall/decode.py
@@ -1,3 +1,19 @@
+# Copyright      2021  Xiaomi Corp.        (authors: Fangjun Kuang)
+#
+# See ../../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import logging
 from typing import Dict, List, Optional, Tuple, Union
 

--- a/icefall/dist.py
+++ b/icefall/dist.py
@@ -1,3 +1,20 @@
+# Copyright      2021  Xiaomi Corp.        (authors: Fangjun Kuang)
+#
+# See ../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 import os
 
 import torch

--- a/icefall/graph_compiler.py
+++ b/icefall/graph_compiler.py
@@ -1,3 +1,20 @@
+# Copyright      2021  Xiaomi Corp.        (authors: Fangjun Kuang)
+#
+# See ../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 from typing import List
 
 import k2

--- a/icefall/graph_compiler.py
+++ b/icefall/graph_compiler.py
@@ -25,7 +25,10 @@ from icefall.lexicon import Lexicon
 
 class CtcTrainingGraphCompiler(object):
     def __init__(
-        self, lexicon: Lexicon, device: torch.device, oov: str = "<UNK>",
+        self,
+        lexicon: Lexicon,
+        device: torch.device,
+        oov: str = "<UNK>",
     ):
         """
         Args:

--- a/icefall/lexicon.py
+++ b/icefall/lexicon.py
@@ -1,3 +1,20 @@
+# Copyright      2021  Xiaomi Corp.        (authors: Fangjun Kuang)
+#
+# See ../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 import logging
 import re
 import sys

--- a/icefall/utils.py
+++ b/icefall/utils.py
@@ -1,3 +1,20 @@
+# Copyright      2021  Xiaomi Corp.        (authors: Fangjun Kuang)
+#
+# See ../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 import argparse
 import logging
 import os

--- a/test/test_bpe_graph_compiler.py
+++ b/test/test_bpe_graph_compiler.py
@@ -1,6 +1,20 @@
 #!/usr/bin/env python3
+# Copyright      2021  Xiaomi Corp.        (authors: Fangjun Kuang)
+#
+# See ../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-# Copyright (c)  2021  Xiaomi Corporation (authors: Fangjun Kuang)
 
 from icefall.bpe_graph_compiler import BpeCtcTrainingGraphCompiler
 from icefall.lexicon import BpeLexicon
@@ -15,7 +29,7 @@ def test():
 
     compiler = BpeCtcTrainingGraphCompiler(lang_dir)
     ids = compiler.texts_to_ids(["HELLO", "WORLD ZZZ"])
-    fsa = compiler.compile(ids)
+    compiler.compile(ids)
 
     lexicon = BpeLexicon(lang_dir)
     ids0 = lexicon.words_to_piece_ids(["HELLO"])

--- a/test/test_checkpoint.py
+++ b/test/test_checkpoint.py
@@ -1,4 +1,20 @@
 #!/usr/bin/env python3
+# Copyright      2021  Xiaomi Corp.        (authors: Fangjun Kuang)
+#
+# See ../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 
 import pytest
 import torch

--- a/test/test_graph_compiler.py
+++ b/test/test_graph_compiler.py
@@ -1,6 +1,20 @@
 #!/usr/bin/env python3
+# Copyright      2021  Xiaomi Corp.        (authors: Fangjun Kuang)
+#
+# See ../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-# Copyright (c)  2021  Xiaomi Corporation (authors: Fangjun Kuang)
 
 import re
 

--- a/test/test_lexicon.py
+++ b/test/test_lexicon.py
@@ -1,4 +1,20 @@
 #!/usr/bin/env python3
+# Copyright      2021  Xiaomi Corp.        (authors: Fangjun Kuang)
+#
+# See ../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 
 from pathlib import Path
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,4 +1,21 @@
 #!/usr/bin/env python3
+# Copyright      2021  Xiaomi Corp.        (authors: Fangjun Kuang)
+#
+# See ../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 import k2
 import pytest
 import torch


### PR DESCRIPTION
@csukuangfj I disabled the E501 rule of flake8 for file `egs/librispeech/ASR/conformer_ctc/conformer.py` as it will cut the comments into annoying pieces, especially the example code.