### PR TITLE
setup.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+icefall.egg-info/
 data
 __pycache__
 path.sh

--- a/setup.py
+++ b/setup.py
@@ -4,15 +4,15 @@ from setuptools import find_packages, setup
 from pathlib import Path
 
 icefall_dir = Path(__file__).parent
-install_requires = (icefall_dir / 'requirements.txt').read_text().splitlines()
+install_requires = (icefall_dir / "requirements.txt").read_text().splitlines()
 
 setup(
-    name='icefall',
-    version='1.0',
-    python_requires='>=3.6.0',
-    description='Speech processing recipes using k2 and Lhotse.',
-    author='The k2 and Lhotse Development Team',
-    license='Apache-2.0 License',
+    name="icefall",
+    version="1.0",
+    python_requires=">=3.6.0",
+    description="Speech processing recipes using k2 and Lhotse.",
+    author="The k2 and Lhotse Development Team",
+    license="Apache-2.0 License",
     packages=find_packages(),
     install_requires=install_requires,
     classifiers=[
@@ -26,6 +26,6 @@ setup(
         "Topic :: Multimedia :: Sound/Audio :: Speech",
         "Topic :: Scientific/Engineering :: Artificial Intelligence",
         "Topic :: Software Development :: Libraries :: Python Modules",
-        "Typing :: Typed"
+        "Typing :: Typed",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+
+from setuptools import find_packages, setup
+from pathlib import Path
+
+icefall_dir = Path(__file__).parent
+install_requires = (icefall_dir / 'requirements.txt').read_text().splitlines()
+
+setup(
+    name='icefall',
+    version='1.0',
+    python_requires='>=3.6.0',
+    description='Speech processing recipes using k2 and Lhotse.',
+    author='The k2 and Lhotse Development Team',
+    license='Apache-2.0 License',
+    packages=find_packages(),
+    install_requires=install_requires,
+    classifiers=[
+        "Development Status :: 3 - Alpha",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Intended Audience :: Science/Research",
+        "Operating System :: POSIX :: Linux",
+        "License :: OSI Approved :: Apache Software License",
+        "Topic :: Multimedia :: Sound/Audio :: Speech",
+        "Topic :: Scientific/Engineering :: Artificial Intelligence",
+        "Topic :: Software Development :: Libraries :: Python Modules",
+        "Typing :: Typed"
+    ],
+)


### PR DESCRIPTION
I saw that the documentation mentions not needing setup.py and recommends setting PYTHONPATH instead, but I found it inconvenient and I think for some users it's simpler to run the dev installation once and not have to set the env vars in new terminals/sessions. We definitely don't lose anything by providing a setup.py.