### PR TITLE
Find CUDA OOM batches before starting training

### DIFF
--- a/egs/librispeech/ASR/conformer_ctc/train.py
+++ b/egs/librispeech/ASR/conformer_ctc/train.py
@@ -503,7 +503,9 @@ def train_one_epoch(
                 loss_info.write_summary(
                     tb_writer, "train/current_", params.batch_idx_train
                 )
-                tot_loss.write_summary(tb_writer, "train/tot_", params.batch_idx_train)
+                tot_loss.write_summary(
+                    tb_writer, "train/tot_", params.batch_idx_train
+                )
 
         if batch_idx > 0 and batch_idx % params.valid_interval == 0:
             logging.info("Computing validation loss")
@@ -617,7 +619,9 @@ def run(rank, world_size, args):
 
         cur_lr = optimizer._rate
         if tb_writer is not None:
-            tb_writer.add_scalar("train/learning_rate", cur_lr, params.batch_idx_train)
+            tb_writer.add_scalar(
+                "train/learning_rate", cur_lr, params.batch_idx_train
+            )
             tb_writer.add_scalar("train/epoch", epoch, params.batch_idx_train)
 
         if rank == 0:


### PR DESCRIPTION
I wanted to add this to snowfall/icefall for some time now. It should help quickly determine if the `max_duration` setting is appropriate and assist in tuning it to get max juice of out the GPU.

This is how the log looks like when everything goes OK:

```
2021-10-14 21:26:06,827 INFO [asr_datamodule.py:275] About to create dev dataloader
2021-10-14 21:26:06,828 INFO [train.py:610] Sanity check -- see if any of the batches in epoch 0 would cause OOM.
2021-10-14 21:26:17,320 INFO [train.py:613] * criterion: single_longest_cut (=33.038875) ...
2021-10-14 21:26:18,913 INFO [train.py:616] OK!
2021-10-14 21:26:18,914 INFO [train.py:613] * criterion: single_longest_supervision (=33.038875) ...
2021-10-14 21:26:19,400 INFO [train.py:616] OK!
2021-10-14 21:26:19,400 INFO [train.py:613] * criterion: largest_batch_cuts_duration (=129.9999375) ...
2021-10-14 21:26:20,461 INFO [train.py:616] OK!
2021-10-14 21:26:20,462 INFO [train.py:613] * criterion: largest_batch_supervisions_duration (=129.9999375) ...
2021-10-14 21:26:20,782 INFO [train.py:616] OK!
2021-10-14 21:26:20,782 INFO [train.py:613] * criterion: max_num_cuts (=39) ...
2021-10-14 21:26:24,340 INFO [train.py:616] OK!
2021-10-14 21:26:24,340 INFO [train.py:613] * criterion: max_num_supervisions (=39) ...
2021-10-14 21:26:25,216 INFO [train.py:616] OK!
2021-10-14 21:26:25,217 INFO [train.py:629] epoch 0, learning rate 0
```

This is how the log looks like when max_duration is set too high:

```
2021-10-14 21:31:15,603 INFO [train.py:610] Sanity check -- see if any of the batches in epoch 0 would cause OOM.
2021-10-14 21:31:25,188 INFO [train.py:613] * criterion: single_longest_cut (=33.038875) ...
2021-10-14 21:31:26,908 ERROR [train.py:620] Your GPU ran out of memory with the current max_duration setting. We recommend decreasing max_duration and trying again.
Traceback (most recent call last):
  File "conformer_ctc/train.py", line 685, in <module>
    main()
  File "conformer_ctc/train.py", line 678, in main
    run(rank=0, world_size=1, args=args)
  File "conformer_ctc/train.py", line 616, in run
    compute_loss(params=params, model=model, batch=batch, graph_compiler=graph_compiler, is_training=True)
  File "conformer_ctc/train.py", line 335, in compute_loss
    nnet_output, encoder_memory, memory_mask = model(feature, supervisions)
  File "/home/hltcoe/pzelasko/miniconda3/envs/icefall/lib/python3.8/site-packages/torch/nn/modules/module.py", line 889, in _call_impl
    result = self.forward(*input, **kwargs)
  File "/exp/pzelasko/icefall/egs/librispeech/ASR/conformer_ctc/transformer.py", line 185, in forward
    encoder_memory, memory_key_padding_mask = self.run_encoder(
  File "/exp/pzelasko/icefall/egs/librispeech/ASR/conformer_ctc/conformer.py", line 121, in run_encoder
    x = self.encoder(x, pos_emb, src_key_padding_mask=mask)  # (T, B, F)
  File "/home/hltcoe/pzelasko/miniconda3/envs/icefall/lib/python3.8/site-packages/torch/nn/modules/module.py", line 889, in _call_impl
    result = self.forward(*input, **kwargs)
  File "/exp/pzelasko/icefall/egs/librispeech/ASR/conformer_ctc/conformer.py", line 317, in forward
    output = mod(
  File "/home/hltcoe/pzelasko/miniconda3/envs/icefall/lib/python3.8/site-packages/torch/nn/modules/module.py", line 889, in _call_impl
    result = self.forward(*input, **kwargs)
  File "/exp/pzelasko/icefall/egs/librispeech/ASR/conformer_ctc/conformer.py", line 234, in forward
    src_att = self.self_attn(
  File "/home/hltcoe/pzelasko/miniconda3/envs/icefall/lib/python3.8/site-packages/torch/nn/modules/module.py", line 889, in _call_impl
    result = self.forward(*input, **kwargs)
  File "/exp/pzelasko/icefall/egs/librispeech/ASR/conformer_ctc/conformer.py", line 514, in forward
    return self.multi_head_attention_forward(
  File "/exp/pzelasko/icefall/egs/librispeech/ASR/conformer_ctc/conformer.py", line 771, in multi_head_attention_forward
    matrix_bd = torch.matmul(
RuntimeError: CUDA out of memory. Tried to allocate 186.00 MiB (GPU 0; 10.76 GiB total capacity; 9.42 GiB already allocated; 22.56 MiB free; 9.65 GiB reserved in total by PyTorch)
```