### PR TITLE
Remove duplicated token seq in rescoring.

### DIFF
--- a/icefall/decode.py
+++ b/icefall/decode.py
@@ -871,6 +871,7 @@ def rescore_with_attention_decoder(
         ngram_lm_scale_list = [0.01, 0.05, 0.08]
         ngram_lm_scale_list += [0.1, 0.3, 0.5, 0.6, 0.7, 0.9, 1.0]
         ngram_lm_scale_list += [1.1, 1.2, 1.3, 1.5, 1.7, 1.9, 2.0]
+        ngram_lm_scale_list += [2.1, 2.2, 2.3, 2.5, 3.0, 4.0, 5.0]
     else:
         ngram_lm_scale_list = [ngram_lm_scale]
 
@@ -878,6 +879,7 @@ def rescore_with_attention_decoder(
         attention_scale_list = [0.01, 0.05, 0.08]
         attention_scale_list += [0.1, 0.3, 0.5, 0.6, 0.7, 0.9, 1.0]
         attention_scale_list += [1.1, 1.2, 1.3, 1.5, 1.7, 1.9, 2.0]
+        attention_scale_list += [2.1, 2.2, 2.3, 2.5, 3.0, 4.0, 5.0]
     else:
         attention_scale_list = [attention_scale]
 

--- a/icefall/decode.py
+++ b/icefall/decode.py
@@ -224,6 +224,7 @@ class Nbest(object):
         else:
             word_seq = lattice.aux_labels.index(path)
             word_seq = word_seq.remove_axis(word_seq.num_axes - 2)
+        word_seq = word_seq.remove_values_leq(0)
 
         # Each utterance has `num_paths` paths but some of them transduces
         # to the same word sequence, so we need to remove repeated word


### PR DESCRIPTION
Closes #105

It becomes slightly faster after this fix.

## Decoding time comparison
With this PR,
- test-clean: 11 minutes
- test-other: 11 minutes

Before this PR
- test-clean: 14 minutes
- test-other: 13 minutes

Here are some decoding logs with and without this PR.

## Decoding log with this PR
```
2021-11-05 20:46:37,389 INFO [decode.py:656] Number of model parameters: 109226120
2021-11-05 20:46:38,633 INFO [decode.py:476] batch 0/?, cuts processed until now is 6
/ceph-fj/fangjun/open-source-2/lhotse-bpe-500/lhotse/dataset/sampling/single_cut.py:237: UserWarning: The first cut drawn in batch co
llection violates the max_frames, max_cuts, or max_duration constraints - we'll return it anyway. Consider increasing max_frames/max_
cuts/max_duration.
  warnings.warn(
2021-11-05 20:47:52,494 INFO [decode.py:476] batch 100/?, cuts processed until now is 398
2021-11-05 20:49:01,835 INFO [decode.py:476] batch 200/?, cuts processed until now is 792
2021-11-05 20:50:08,042 INFO [decode.py:476] batch 300/?, cuts processed until now is 1160
2021-11-05 20:51:13,273 INFO [decode.py:476] batch 400/?, cuts processed until now is 1574
2021-11-05 20:52:20,301 INFO [decode.py:476] batch 500/?, cuts processed until now is 1965
2021-11-05 20:53:27,511 INFO [decode.py:476] batch 600/?, cuts processed until now is 2308
2021-11-05 20:54:44,667 INFO [decode.py:476] batch 700/?, cuts processed until now is 2498
2021-11-05 20:56:09,111 INFO [decode.py:476] batch 800/?, cuts processed until now is 2614
2021-11-05 20:57:50,167 INFO [decode.py:525]
For test-clean, WER of different settings are:
ngram_lm_scale_1.1_attention_scale_0.7  2.47    best for test-clean
ngram_lm_scale_1.1_attention_scale_0.9  2.47
ngram_lm_scale_1.1_attention_scale_1.3  2.47
ngram_lm_scale_1.1_attention_scale_1.7  2.47

...

2021-11-05 20:57:51,217 INFO [decode.py:476] batch 0/?, cuts processed until now is 6
2021-11-05 20:59:04,086 INFO [decode.py:476] batch 100/?, cuts processed until now is 434
2021-11-05 21:00:11,700 INFO [decode.py:476] batch 200/?, cuts processed until now is 885
2021-11-05 21:01:17,804 INFO [decode.py:476] batch 300/?, cuts processed until now is 1327
2021-11-05 21:01:22,835 INFO [decode.py:732] Caught exception:
CUDA out of memory. Tried to allocate 8.00 GiB (GPU 0; 31.75 GiB total capacity; 20.19 GiB already allocated; 7.14 GiB free; 23.38 Gi
B reserved in total by PyTorch)

2021-11-05 21:01:22,835 INFO [decode.py:733] num_arcs before pruning: 242615
2021-11-05 21:01:22,836 INFO [decode.py:736] This OOM is not an error. You can ignore it. If your model does not converge well, or --
max-duration is too large, or the input sound file is difficult to decode, you will meet this exception.
2021-11-05 21:01:22,857 INFO [decode.py:746] num_arcs after pruning: 7971
2021-11-05 21:02:21,258 INFO [decode.py:476] batch 400/?, cuts processed until now is 1807
2021-11-05 21:03:28,572 INFO [decode.py:476] batch 500/?, cuts processed until now is 2238
2021-11-05 21:04:31,848 INFO [decode.py:476] batch 600/?, cuts processed until now is 2584
2021-11-05 21:05:50,169 INFO [decode.py:476] batch 700/?, cuts processed until now is 2785
2021-11-05 21:08:37,987 INFO [decode.py:525]
For test-other, WER of different settings are:
ngram_lm_scale_1.3_attention_scale_1.1  5.91    best for test-other
ngram_lm_scale_1.2_attention_scale_1.2  5.93
ngram_lm_scale_1.3_attention_scale_0.9  5.93
ngram_lm_scale_1.3_attention_scale_1.0  5.93
```

## Decoding log before this PR
```
2021-11-05 21:21:49,778 INFO [decode.py:656] Number of model parameters: 109226120
2021-11-05 21:21:51,265 INFO [decode.py:476] batch 0/?, cuts processed until now is 6
/ceph-fj/fangjun/open-source-2/lhotse-bpe-500/lhotse/dataset/sampling/single_cut.py:237: UserWarning: The first cut drawn in batch co
llection violates the max_frames, max_cuts, or max_duration constraints - we'll return it anyway. Consider increasing max_frames/max_
cuts/max_duration.
  warnings.warn(
2021-11-05 21:23:24,575 INFO [decode.py:476] batch 100/?, cuts processed until now is 398
2021-11-05 21:24:50,699 INFO [decode.py:476] batch 200/?, cuts processed until now is 792
2021-11-05 21:26:12,553 INFO [decode.py:476] batch 300/?, cuts processed until now is 1160
2021-11-05 21:27:33,020 INFO [decode.py:476] batch 400/?, cuts processed until now is 1574
2021-11-05 21:28:55,519 INFO [decode.py:476] batch 500/?, cuts processed until now is 1965
2021-11-05 21:30:21,903 INFO [decode.py:476] batch 600/?, cuts processed until now is 2308
2021-11-05 21:31:58,051 INFO [decode.py:476] batch 700/?, cuts processed until now is 2498
2021-11-05 21:33:38,409 INFO [decode.py:476] batch 800/?, cuts processed until now is 2614
2021-11-05 21:35:21,491 INFO [decode.py:525]
For test-clean, WER of different settings are:
ngram_lm_scale_1.1_attention_scale_0.6  2.48    best for test-clean
ngram_lm_scale_1.1_attention_scale_0.7  2.48
ngram_lm_scale_1.1_attention_scale_0.9  2.48
ngram_lm_scale_1.3_attention_scale_0.9  2.48

...

2021-11-05 21:35:22,693 INFO [decode.py:476] batch 0/?, cuts processed until now is 6
2021-11-05 21:36:53,264 INFO [decode.py:476] batch 100/?, cuts processed until now is 434
2021-11-05 21:38:14,706 INFO [decode.py:476] batch 200/?, cuts processed until now is 885
2021-11-05 21:39:35,649 INFO [decode.py:476] batch 300/?, cuts processed until now is 1327
2021-11-05 21:39:41,705 INFO [decode.py:732] Caught exception:
CUDA out of memory. Tried to allocate 8.00 GiB (GPU 0; 31.75 GiB total capacity; 20.19 GiB already allocated; 7.14 GiB free; 23.38 Gi
B reserved in total by PyTorch)

2021-11-05 21:39:41,706 INFO [decode.py:733] num_arcs before pruning: 242615
2021-11-05 21:39:41,706 INFO [decode.py:736] This OOM is not an error. You can ignore it. If your model does not converge well, or --
max-duration is too large, or the input sound file is difficult to decode, you will meet this exception.
2021-11-05 21:39:41,727 INFO [decode.py:746] num_arcs after pruning: 7971
2021-11-05 21:40:54,277 INFO [decode.py:476] batch 400/?, cuts processed until now is 1807
2021-11-05 21:42:11,480 INFO [decode.py:476] batch 500/?, cuts processed until now is 2238
2021-11-05 21:43:30,811 INFO [decode.py:476] batch 600/?, cuts processed until now is 2584
2021-11-05 21:45:03,460 INFO [decode.py:476] batch 700/?, cuts processed until now is 2785
2021-11-05 21:48:12,859 INFO [decode.py:525]
For test-other, WER of different settings are:
ngram_lm_scale_1.3_attention_scale_1.1  5.9     best for test-other
ngram_lm_scale_1.5_attention_scale_1.5  5.9
ngram_lm_scale_1.7_attention_scale_2.0  5.9
```
