### PR TITLE
Set fsa.properties to None after changing its labels in-place.

### DIFF
--- a/egs/librispeech/ASR/conformer_ctc/decode.py
+++ b/egs/librispeech/ASR/conformer_ctc/decode.py
@@ -607,6 +607,9 @@ def main():
                 # Arcs entering the back-off state have label equal to #0.
                 # We have to change it to 0 here.
                 G.labels[G.labels >= first_word_disambig_id] = 0
+                # See https://github.com/k2-fsa/k2/issues/874
+                # for why we need to set G.properties to None
+                G.__dict__["_properties"] = None
                 G = k2.Fsa.from_fsas([G]).to(device)
                 G = k2.arc_sort(G)
                 # Save a dummy value so that it can be loaded in C++.

--- a/egs/librispeech/ASR/conformer_mmi/decode.py
+++ b/egs/librispeech/ASR/conformer_mmi/decode.py
@@ -603,6 +603,9 @@ def main():
                 # Arcs entering the back-off state have label equal to #0.
                 # We have to change it to 0 here.
                 G.labels[G.labels >= first_word_disambig_id] = 0
+                # See https://github.com/k2-fsa/k2/issues/874
+                # for why we need to set G.properties to None
+                G.__dict__["_properties"] = None
                 G = k2.Fsa.from_fsas([G]).to(device)
                 G = k2.arc_sort(G)
                 torch.save(G.as_dict(), params.lm_dir / "G_4_gram.pt")

--- a/egs/librispeech/ASR/local/compile_hlg.py
+++ b/egs/librispeech/ASR/local/compile_hlg.py
@@ -101,6 +101,9 @@ def compile_HLG(lang_dir: str) -> k2.Fsa:
     logging.info("Removing disambiguation symbols on LG")
 
     LG.labels[LG.labels >= first_token_disambig_id] = 0
+    # See https://github.com/k2-fsa/k2/issues/874
+    # for why we need to set LG.properties to None
+    LG.__dict__["_properties"] = None
 
     assert isinstance(LG.aux_labels, k2.RaggedTensor)
     LG.aux_labels.values[LG.aux_labels.values >= first_word_disambig_id] = 0

--- a/egs/librispeech/ASR/tdnn_lstm_ctc/decode.py
+++ b/egs/librispeech/ASR/tdnn_lstm_ctc/decode.py
@@ -422,6 +422,9 @@ def main():
                 # Arcs entering the back-off state have label equal to #0.
                 # We have to change it to 0 here.
                 G.labels[G.labels >= first_word_disambig_id] = 0
+                # See https://github.com/k2-fsa/k2/issues/874
+                # for why we need to set G.properties to None
+                G.__dict__["_properties"] = None
                 G = k2.Fsa.from_fsas([G]).to(device)
                 G = k2.arc_sort(G)
                 torch.save(G.as_dict(), params.lm_dir / "G_4_gram.pt")

--- a/egs/yesno/ASR/local/compile_hlg.py
+++ b/egs/yesno/ASR/local/compile_hlg.py
@@ -79,6 +79,9 @@ def compile_HLG(lang_dir: str) -> k2.Fsa:
     logging.info("Removing disambiguation symbols on LG")
 
     LG.labels[LG.labels >= first_token_disambig_id] = 0
+    # See https://github.com/k2-fsa/k2/issues/874
+    # for why we need to set LG.properties to None
+    LG.__dict__["_properties"] = None
 
     assert isinstance(LG.aux_labels, k2.RaggedTensor)
     LG.aux_labels.values[LG.aux_labels.values >= first_word_disambig_id] = 0


### PR DESCRIPTION
See https://github.com/k2-fsa/k2/issues/874

Note: It is not a problem in icefall since we don't use the `properties` attribute after changing its `labels` in-place.