### PR TITLE
Minor fix to maximum number of symbols per frame for RNN-T decoding.

### DIFF
--- a/egs/librispeech/ASR/transducer_stateless/decode.py
+++ b/egs/librispeech/ASR/transducer_stateless/decode.py
@@ -114,6 +114,13 @@ def get_parser():
         help="Used only when --decoding-method is beam_search",
     )
 
+    parser.add_argument(
+        "--max-sym-per-frame",
+        type=int,
+        default=3,
+        help="Maximum number of symbols per frame",
+    )
+
     return parser
 
 
@@ -237,7 +244,11 @@ def decode_one_batch(
         encoder_out_i = encoder_out[i:i+1, :encoder_out_lens[i]]
         # fmt: on
         if params.decoding_method == "greedy_search":
-            hyp = greedy_search(model=model, encoder_out=encoder_out_i)
+            hyp = greedy_search(
+                model=model,
+                encoder_out=encoder_out_i,
+                max_sym_per_frame=params.max_sym_per_frame,
+            )
         elif params.decoding_method == "beam_search":
             hyp = beam_search(
                 model=model, encoder_out=encoder_out_i, beam=params.beam_size
@@ -381,6 +392,8 @@ def main():
     params.suffix = f"epoch-{params.epoch}-avg-{params.avg}"
     if params.decoding_method == "beam_search":
         params.suffix += f"-beam-{params.beam_size}"
+    else:
+        params.suffix += f"-max-sym-per-frame-{params.max_sym_per_frame}"
 
     setup_logger(f"{params.res_dir}/log-decode-{params.suffix}")
     logging.info("Decoding started")

--- a/egs/librispeech/ASR/transducer_stateless/pretrained.py
+++ b/egs/librispeech/ASR/transducer_stateless/pretrained.py
@@ -110,6 +110,15 @@ def get_parser():
         help="Used only when --method is beam_search",
     )
 
+    parser.add_argument(
+        "--max-sym-per-frame",
+        type=int,
+        default=3,
+        help="""Maximum number of symbols per frame. Used only when
+        --method is greedy_search.
+        """,
+    )
+
     return parser
 
 
@@ -279,7 +288,11 @@ def main():
         encoder_out_i = encoder_out[i:i+1, :encoder_out_lens[i]]
         # fmt: on
         if params.method == "greedy_search":
-            hyp = greedy_search(model=model, encoder_out=encoder_out_i)
+            hyp = greedy_search(
+                model=model,
+                encoder_out=encoder_out_i,
+                max_sym_per_frame=params.max_sym_per_frame,
+            )
         elif params.method == "beam_search":
             hyp = beam_search(
                 model=model, encoder_out=encoder_out_i, beam=params.beam_size


### PR DESCRIPTION
Some results when changing `--max-sym-per-frame`

You can see that when its value is >=2, the WERs for the LibriSpeech test datasets will not change.

## --max-sym-per-frame = 0
```
./transducer_stateless/decode.py --epoch 20 --avg 10 --exp-dir ./transducer_stateless/exp-full --max-sym-per-frame 0 --max-duration 100
[test-clean-greedy_search] %WER 100.00% [52576 / 52576, 0 ins, 52576 del, 0 sub ]
[test-other-greedy_search] %WER 100.00% [52343 / 52343, 0 ins, 52343 del, 0 sub ]
```

## --max-sym-per-frame = 1
```
./transducer_stateless/decode.py --epoch 20 --avg 10 --exp-dir ./transducer_stateless/exp-full --max-sym-per-frame 1 --max-duration 100

[test-clean-greedy_search] %WER 3.01% [1583 / 52576, 161 ins, 136 del, 1286 sub ]
[test-other-greedy_search] %WER 7.58% [3966 / 52343, 422 ins, 368 del, 3176 sub ]
```

## --max-sym-per-frame = 2
It has few substitution errors than `--max-sym-per-frame=1`.
```
./transducer_stateless/decode.py --epoch 20 --avg 10 --exp-dir ./transducer_stateless/exp-full --max-sym-per-frame 2 --max-duration 100

[test-clean-greedy_search] %WER 2.99% [1571 / 52576, 162 ins, 135 del, 1274 sub ]
[test-other-greedy_search] %WER 7.52% [3935 / 52343, 422 ins, 359 del, 3154 sub ]
```

## --max-sym-per-frame = 3
```
./transducer_stateless/decode.py --epoch 20 --avg 10 --exp-dir ./transducer_stateless/exp-full --max-sym-per-frame 3 --max-duration 100

[test-clean-greedy_search] %WER 2.99% [1571 / 52576, 162 ins, 135 del, 1274 sub ]
[test-other-greedy_search] %WER 7.52% [3936 / 52343, 423 ins, 359 del, 3154 sub ]
```

## --max-sym-per-frame = 4
```
./transducer_stateless/decode.py --epoch 20 --avg 10 --exp-dir ./transducer_stateless/exp-full --max-sym-per-frame 4 --max-duration 100

[test-clean-greedy_search] %WER 2.99% [1571 / 52576, 162 ins, 135 del, 1274 sub ]
[test-other-greedy_search] %WER 7.52% [3937 / 52343, 424 ins, 359 del, 3154 sub ]
```