### PR TITLE
[WIP] Replace torchaudio rnnt_loss with k2 pruned rnnt loss

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -6,6 +6,8 @@ per-file-ignores =
     # line too long
     egs/librispeech/ASR/*/conformer.py: E501,
     egs/aishell/ASR/*/conformer.py: E501,
+    # invalid escape sequence (cause by tex formular), W605
+    icefall/utils.py: E501, W605
 
 exclude =
   .git,

--- a/egs/librispeech/ASR/transducer_stateless/beam_search.py
+++ b/egs/librispeech/ASR/transducer_stateless/beam_search.py
@@ -294,7 +294,7 @@ def beam_search(
             cached_key += f"-t-{t}"
             if cached_key not in joint_cache:
                 logits = model.joiner(
-                        current_encoder_out, decoder_out.unsqueeze(1)
+                    current_encoder_out, decoder_out.unsqueeze(1)
                 )
 
                 # TODO(fangjun): Cache the blank posterior

--- a/egs/librispeech/ASR/transducer_stateless/beam_search.py
+++ b/egs/librispeech/ASR/transducer_stateless/beam_search.py
@@ -73,9 +73,9 @@ def greedy_search(
             continue
 
         # fmt: off
-        current_encoder_out = encoder_out[:, t:t+1, :]
+        current_encoder_out = encoder_out[:, t:t+1, :].unsqueeze(2)
         # fmt: on
-        logits = model.joiner(current_encoder_out, decoder_out)
+        logits = model.joiner(current_encoder_out, decoder_out.unsqueeze(1))
         # logits is (1, 1, 1, vocab_size)
 
         y = logits.argmax().item()

--- a/egs/librispeech/ASR/transducer_stateless/beam_search.py
+++ b/egs/librispeech/ASR/transducer_stateless/beam_search.py
@@ -128,7 +128,6 @@ class HypothesisList(object):
     def data(self):
         return self._data
 
-    #  def add(self, ys: List[int], log_prob: float):
     def add(self, hyp: Hypothesis):
         """Add a Hypothesis to `self`.
 
@@ -266,7 +265,7 @@ def beam_search(
 
     while t < T and sym_per_utt < max_sym_per_utt:
         # fmt: off
-        current_encoder_out = encoder_out[:, t:t+1, :]
+        current_encoder_out = encoder_out[:, t:t+1, :].unsqueeze(2)
         # fmt: on
         A = B
         B = HypothesisList()
@@ -294,9 +293,11 @@ def beam_search(
 
             cached_key += f"-t-{t}"
             if cached_key not in joint_cache:
-                logits = model.joiner(current_encoder_out, decoder_out)
+                logits = model.joiner(
+                        current_encoder_out, decoder_out.unsqueeze(1)
+                )
 
-                # TODO(fangjun): Ccale the blank posterior
+                # TODO(fangjun): Cache the blank posterior
 
                 log_prob = logits.log_softmax(dim=-1)
                 # log_prob is (1, 1, 1, vocab_size)

--- a/egs/librispeech/ASR/transducer_stateless/joiner.py
+++ b/egs/librispeech/ASR/transducer_stateless/joiner.py
@@ -30,21 +30,14 @@ class Joiner(nn.Module):
         """
         Args:
           encoder_out:
-            Output from the encoder. Its shape is (N, T, C).
+            Output from the encoder. Its shape is (N, T, s_range, C).
           decoder_out:
-            Output from the decoder. Its shape is (N, U, C).
+            Output from the decoder. Its shape is (N, T, s_range, C).
         Returns:
-          Return a tensor of shape (N, T, U, C).
+          Return a tensor of shape (N, T, s_range, C).
         """
-        assert encoder_out.ndim == decoder_out.ndim == 3
-        assert encoder_out.size(0) == decoder_out.size(0)
-        assert encoder_out.size(2) == decoder_out.size(2)
-
-        encoder_out = encoder_out.unsqueeze(2)
-        # Now encoder_out is (N, T, 1, C)
-
-        decoder_out = decoder_out.unsqueeze(1)
-        # Now decoder_out is (N, 1, U, C)
+        assert encoder_out.ndim == decoder_out.ndim == 4
+        assert encoder_out.shape == decoder_out.shape
 
         logit = encoder_out + decoder_out
         logit = torch.tanh(logit)

--- a/egs/librispeech/ASR/transducer_stateless/model.py
+++ b/egs/librispeech/ASR/transducer_stateless/model.py
@@ -1,4 +1,4 @@
-# Copyright    2021  Xiaomi Corp.        (authors: Fangjun Kuang)
+# Copyright    2021  Xiaomi Corp.        (authors: Fangjun Kuang, Wei Kang)
 #
 # See ../../../../LICENSE for clarification regarding multiple authors
 #
@@ -14,15 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Note we use `rnnt_loss` from torchaudio, which exists only in
-torchaudio >= v0.10.0. It also means you have to use torch >= v1.10.0
-"""
+
 import k2
 import torch
 import torch.nn as nn
-import torchaudio
-import torchaudio.functional
 from encoder_interface import EncoderInterface
 
 from icefall.utils import add_sos
@@ -38,6 +33,7 @@ class Transducer(nn.Module):
         encoder: EncoderInterface,
         decoder: nn.Module,
         joiner: nn.Module,
+        prune_range: int = 3,
     ):
         """
         Args:
@@ -62,6 +58,7 @@ class Transducer(nn.Module):
         self.encoder = encoder
         self.decoder = decoder
         self.joiner = joiner
+        self.prune_range = prune_range
 
     def forward(
         self,
@@ -102,24 +99,32 @@ class Transducer(nn.Module):
 
         decoder_out = self.decoder(sos_y_padded)
 
-        logits = self.joiner(encoder_out, decoder_out)
-
-        # rnnt_loss requires 0 padded targets
         # Note: y does not start with SOS
         y_padded = y.pad(mode="constant", padding_value=0)
 
-        assert hasattr(torchaudio.functional, "rnnt_loss"), (
-            f"Current torchaudio version: {torchaudio.__version__}\n"
-            "Please install a version >= 0.10.0"
+        y_padded = y_padded.to(torch.int64)
+        boundary = torch.zeros(
+            (x.size(0), 4), dtype=torch.int64, device=x.device
+        )
+        boundary[:, 2] = y_lens
+        boundary[:, 3] = x_lens
+
+        simple_loss, (px_grad, py_grad) = k2.rnnt_loss_simple(
+            decoder_out, encoder_out, y_padded, blank_id, boundary, True
         )
 
-        loss = torchaudio.functional.rnnt_loss(
-            logits=logits,
-            targets=y_padded,
-            logit_lengths=x_lens,
-            target_lengths=y_lens,
-            blank=blank_id,
-            reduction="sum",
+        ranges = k2.get_rnnt_prune_ranges(
+            px_grad, py_grad, boundary, self.prune_range
         )
 
-        return loss
+        am_pruning, lm_pruning = k2.do_rnnt_pruning(
+            encoder_out, decoder_out, ranges
+        )
+
+        logits = self.joiner(am_pruning, lm_pruning)
+
+        pruning_loss = k2.rnnt_loss_pruned(
+            logits, y_padded, ranges, blank_id, boundary
+        )
+
+        return (-torch.sum(simple_loss), -torch.sum(pruning_loss))

--- a/icefall/utils.py
+++ b/icefall/utils.py
@@ -25,13 +25,15 @@ from collections import defaultdict
 from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, Iterable, List, TextIO, Tuple, Union
+from typing import Dict, Iterable, List, TextIO, Optional, Tuple, Union
 
 import k2
 import k2.version
 import kaldialign
 import torch
+import torch.nn as nn
 import torch.distributed as dist
+from torch.cuda.amp import GradScaler
 from torch.utils.tensorboard import SummaryWriter
 
 Pathlike = Union[str, Path]

--- a/icefall/utils.py
+++ b/icefall/utils.py
@@ -690,3 +690,94 @@ def make_pad_mask(lengths: torch.Tensor) -> torch.Tensor:
     expaned_lengths = torch.arange(max_len).expand(n, max_len).to(lengths)
 
     return expaned_lengths >= lengths.unsqueeze(1)
+
+
+def l1_norm(x):
+    return torch.sum(torch.abs(x))
+
+
+def l2_norm(x):
+    return torch.sum(torch.pow(x, 2))
+
+
+def linf_norm(x):
+    return torch.max(torch.abs(x))
+
+
+def measure_weight_norms(
+    model: nn.Module, norm: str = "l2"
+) -> Dict[str, float]:
+    """
+    Compute the norms of the model's parameters.
+
+    :param model: a torch.nn.Module instance
+    :param norm: how to compute the norm. Available values: 'l1', 'l2', 'linf'
+    :return: a dict mapping from parameter's name to its norm.
+    """
+    with torch.no_grad():
+        norms = {}
+        for name, param in model.named_parameters():
+            if norm == "l1":
+                val = l1_norm(param)
+            elif norm == "l2":
+                val = l2_norm(param)
+            elif norm == "linf":
+                val = linf_norm(param)
+            else:
+                raise ValueError(f"Unknown norm type: {norm}")
+            norms[name] = val.item()
+        return norms
+
+
+def measure_gradient_norms(
+    model: nn.Module, norm: str = "l1"
+) -> Dict[str, float]:
+    """
+    Compute the norms of the gradients for each of model's parameters.
+
+    :param model: a torch.nn.Module instance
+    :param norm: how to compute the norm. Available values: 'l1', 'l2', 'linf'
+    :return: a dict mapping from parameter's name to its gradient's norm.
+    """
+    with torch.no_grad():
+        norms = {}
+        for name, param in model.named_parameters():
+            if norm == "l1":
+                val = l1_norm(param.grad)
+            elif norm == "l2":
+                val = l2_norm(param.grad)
+            elif norm == "linf":
+                val = linf_norm(param.grad)
+            else:
+                raise ValueError(f"Unknown norm type: {norm}")
+            norms[name] = val.item()
+        return norms
+
+
+def optim_step_and_measure_param_change(
+    model: nn.Module,
+    optimizer: torch.optim.Optimizer,
+    scaler: Optional[GradScaler] = None,
+) -> Dict[str, float]:
+    """
+    Perform model weight update and measure the "relative change in parameters per minibatch."
+    It is understood as a ratio between the L2 norm of the difference between original and updates parameters,
+    and the L2 norm of the original parameter. It is given by the formula:
+
+        .. math::
+            \begin{aligned}
+                \delta = \frac{\Vert\theta - \theta_{new}\Vert^2}{\Vert\theta\Vert^2}
+            \end{aligned}
+    """
+    param_copy = {n: p.detach().clone() for n, p in model.named_parameters()}
+    if scaler:
+        scaler.step(optimizer)
+    else:
+        optimizer.step()
+    relative_change = {}
+    with torch.no_grad():
+        for n, p_new in model.named_parameters():
+            p_orig = param_copy[n]
+            delta = l2_norm(p_orig - p_new) / l2_norm(p_orig)
+            relative_change[n] = delta.item()
+    return relative_change


### PR DESCRIPTION
After a month of experiments，I finally manage to make the pruned rnnt loss work. Thank for Daniel's help! 

By using the pruned version loss, we can train with larger batch size (max-duration = 300), and it only costs 2 hours to finish one epoch on full librispeech dataset (using 4 GPUs). Below are some experiment results, the WER is little worse than the model trained with torch rnnt loss, we will continue tuning the model to make it better.

For more details of the pruned rnnt loss, please see https://github.com/k2-fsa/k2/pull/891.

best WER for (greedy search) | baseline (trained with torch rnnt loss) <br> max-duration = 200 <br> 4 GPUs <br> test-clean \|\| test-other | k2 pruned rnnt loss (range = 3)<br> max-duration = 300 <br> 3 GPUs <br> test-clean \|\| test-other   | k2 pruned rnnt loss (range = 5) <br> max-duration = 300 <br> 4 GPUs<br> test-clean \|\| test-other  | k2 pruned rnnt loss (range = 8) <br> max-duration = 300 <br> 4 GPUs<br> test-clean \|\| test-other 
-- | -- | -- | -- | --
epoch 4 |   | 5.86 \|\| 14.13 | 6.75 \|\| 15.91 | 6.72 \|\| 15.34
epoch 5 |   | 5.09 \|\| 12.57 | 5.6 \|\| 13.65 | 5.59 \|\| 13.52
epoch 6 | 4.24 \|\| 10.6 | 4.83 \|\| 11.87 | 4.99 \|\| 12.38 | 5.07 \|\| 12.23
epoch 7 | 3.95 \|\| 9.87 |   | 4.65 \|\| 11.3 | 4.46 \|\| 11.5
epoch 8 | 3.64 \|\| 9.29 | 4.11 \|\| 9.23 | 4.38 \|\| 10.58 | 4.34 \|\| 10.53
epoch 9 | 3.57 \|\| 8.99 |   | 4.12 \|\| 10.02 | 4.06 \|\| 10.14
epoch 10 | 3.49 \|\| 8.69 | 3.65 \|\| 9.23 | 3.9 \|\| 9.66 | 3.82 \|\| 9.66
epoch 11 |   |   |   |  
epoch 12 | 3.24 \|\| 8.17 | 3.38 \|\| 8.56 | 3.61 \|\| 9.01 | 3.53 \|\| 8.89
epoch 14 | 3.16 \|\| 8.05 | 3.31 \|\| 8.4 | 3.46 \|\| 8.59 | 3.34 \|\| 8.54
epoch 15 | 3.12 \|\| 7.95 |   | 3.43 \|\| 8.41 | 3.32 \|\| 8.35
epoch 16 | 3.06 \|\| 7.99 | 3.27 \|\| 8.05 | 3.4 \|\| 8.31 | 3.29 \|\| 8.23
epoch 17 | 3.07 \|\| 7.86 |   | 3.35 \|\| 8.12 | 3.22 \|\| 8.02
epoch 18 | 3.02 \|\| 7.76 | 3.24 \|\| 7.91 | 3.31 \|\| 8.01 | 3.19 \|\| 8.0
epoch 19 | 3.0 \|\| 7.69 |   | 3.26 \|\| 7.93 | 3.15 \|\| 7.82
epoch 20 | 2.99 \|\| 7.61 | 3.14 \|\| 7.76 | 3.21 \|\| 7.78 | 3.09 \|\| 7.82
epoch 21 | 2.98 \|\| 7.51 | 3.11 \|\| 7.75 |   |  
epoch 22 | 2.95 \|\| 7.5 |   | 3.17 \|\| 7.97 | 3.0 \|\| 7.67
epoch 23 | 2.93 \|\| 7.43 | 3.1 \|\| 7.64 |   | 3.0 \|\| 7.66
epoch 24 | 2.92 \|\| 7.38 |   | 3.11 \|\| 7.68 | 2.98 \|\| 7.59
epoch 25 | 2.91 \|\| 7.37 |   |   |  
epoch 26 | 2.9 \|\| 7.34 |   | 3.06 \|\| 7.61 | 2.98 \|\| 7.47
epoch 27 | 2.87 \|\| 7.29 |   | 3.05 \|\| 7.55 | 3.0 \|\| 7.55
epoch 28 | 2.87 \|\| 7.27 |   | 3.05 \|\| 7.69 | 2.97 \|\| 7.43
epoch 29 | 2.85 \|\| 7.28 |   | 3.0 \|\| 7.47 | 2.98 \|\| 7.39
epoch 30 | 2.85 \|\| 7.29 |   |   |  
epoch 31 | 2.85 \|\| 7.26 |   |   | 2.94 \|\| 7.33
epoch 32 | 2.85 \|\| 7.27 |   | 2.98 \|\| 7.29 | 2.94 \|\| 7.33
epoch 33 | 2.85 \|\| 7.3 |   |   |  
