### PR TITLE
Fix calling optimized_transducer after new release.

### DIFF
--- a/egs/librispeech/ASR/transducer_stateless/model.py
+++ b/egs/librispeech/ASR/transducer_stateless/model.py
@@ -120,6 +120,7 @@ class Transducer(nn.Module):
             target_lengths=y_lens,
             blank=blank_id,
             reduction="sum",
+            from_log_softmax=False,
         )
 
         return loss


### PR DESCRIPTION
We added a flag `from_log_softmax` to support label smoothing. This PR fixes the calling of `optimized_transducer.transducer_loss()`.