### PR TITLE
Use CTC loss as auxiliary loss in transducer training

### DIFF
--- a/egs/librispeech/ASR/transducer_stateless/model.py
+++ b/egs/librispeech/ASR/transducer_stateless/model.py
@@ -74,7 +74,10 @@ class Transducer(nn.Module):
             A ragged tensor with 2 axes [utt][label]. It contains labels of each
             utterance.
         Returns:
-          Return the transducer loss.
+          Return a tuple containing:
+            - the transducer loss, a tensor containing only one entry
+            - encoder_out, a tensor of shape (N, num_frames, encoder_out_dim)
+            - encoder_out_lens, a tensor of shape (N,)
         """
         assert x.ndim == 3, x.shape
         assert x_lens.ndim == 1, x_lens.shape
@@ -123,4 +126,8 @@ class Transducer(nn.Module):
             from_log_softmax=False,
         )
 
-        return loss
+        return (
+            loss,
+            encoder_out,
+            x_lens,
+        )


### PR DESCRIPTION
The total loss is
```
tot_loss = (1 - ctc_weight) * transducer_loss + ctc_weight * ctc_loss
```

Training command:
```
export CUDA_VISIBLE_DEVICES="0,1,2"

./transducer_stateless/train.py \
  --world-size 3 \
  --num-epochs 30 \
  --start-epoch 0 \
  --exp-dir transducer_stateless/exp-960h-lr-2.5-with-ctc-0.25 \
  --full-libri 1 \
  --max-duration 300 \
  --lr-factor 3 \
  --bpe-model data/lang_bpe_500/bpe.model \
  --ctc-weight 0.25
```

Tensorboard log (still in training):
- https://tensorboard.dev/experiment/jtb8UjYlS62p1jxLD6kfNw/