### PR TITLE
print num_frame as %.2f

### DIFF
--- a/icefall/utils.py
+++ b/icefall/utils.py
@@ -521,8 +521,8 @@ class MetricsTracker(collections.defaultdict):
         for k, v in self.norm_items():
             norm_value = "%.4g" % v
             ans += str(k) + "=" + str(norm_value) + ", "
-        frames = str(self["frames"])
-        ans += "over " + frames + " frames."
+        frames = "%.2f" % self["frames"]
+        ans += "over " + str(frames) + " frames."
         return ans
 
     def norm_items(self) -> List[Tuple[str, float]]:


### PR DESCRIPTION
Changed the logging INFO from
```
INFO [train.py:529] (0/2) Epoch 11, batch 1200, loss[ctc_loss=0.1767, att_loss=0.3112, loss=0.2843, over 2450 frames.], tot_loss[ctc_loss=0.1494, att_loss=0.2804, loss=0.2542, over 465668.9883888189 frames.], batch size: 7
```
to
```
INFO [train.py:529] (0/2) Epoch 11, batch 1200, loss[ctc_loss=0.1893, att_loss=0.3245, loss=0.2974, over 2450.00 frames.], tot_loss[ctc_loss=0.1494, att_loss=0.2807, loss=0.2544, over 465668.99 frames.], batch size: 7
```