### PR TITLE
Add modified beam search for pruned rnn-t.

### DIFF
--- a/.github/workflows/run-librispeech-2022-03-12.yml
+++ b/.github/workflows/run-librispeech-2022-03-12.yml
@@ -1,0 +1,157 @@
+# Copyright      2021  Fangjun Kuang (csukuangfj@gmail.com)
+
+# See ../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: run-librispeech-2022-03-12
+# stateless transducer + k2 pruned rnnt-loss
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [labeled]
+
+jobs:
+  run_librispeech_2022_03_12:
+    if: github.event.label.name == 'ready' || github.event_name == 'push'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-18.04]
+        python-version: [3.7, 3.8, 3.9]
+        torch: ["1.10.0"]
+        torchaudio: ["0.10.0"]
+        k2-version: ["1.9.dev20211101"]
+
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install Python dependencies
+        run: |
+          python3 -m pip install --upgrade pip pytest
+          # numpy 1.20.x does not support python 3.6
+          pip install numpy==1.19
+          pip install torch==${{ matrix.torch }}+cpu torchaudio==${{ matrix.torchaudio }}+cpu -f https://download.pytorch.org/whl/cpu/torch_stable.html
+          pip install k2==${{ matrix.k2-version }}+cpu.torch${{ matrix.torch }} -f https://k2-fsa.org/nightly/
+
+          python3 -m pip install git+https://github.com/lhotse-speech/lhotse
+          python3 -m pip install kaldifeat
+          # We are in ./icefall and there is a file: requirements.txt in it
+          pip install -r requirements.txt
+
+      - name: Install graphviz
+        shell: bash
+        run: |
+          python3 -m pip install -qq graphviz
+          sudo apt-get -qq install graphviz
+
+      - name: Download pre-trained model
+        shell: bash
+        run: |
+          sudo apt-get -qq install git-lfs tree sox
+          cd egs/librispeech/ASR
+          mkdir tmp
+          cd tmp
+          git lfs install
+          git clone https://huggingface.co/csukuangfj/icefall-asr-librispeech-pruned-transducer-stateless-2022-03-12
+          cd ..
+          tree tmp
+          soxi tmp/icefall-asr-librispeech-pruned-transducer-stateless-2022-03-12/test_wavs/*.wav
+          ls -lh tmp/icefall-asr-librispeech-pruned-transducer-stateless-2022-03-12/test_wavs/*.wav
+
+      - name: Run greedy search decoding (max-sym-per-frame 1)
+        shell: bash
+        run: |
+          export PYTHONPATH=$PWD:PYTHONPATH
+          dir=./tmp/icefall-asr-librispeech-pruned-transducer-stateless-2022-03-12
+          cd egs/librispeech/ASR
+          ./transducer_stateless/pretrained.py \
+            --method greedy_search \
+            --max-sym-per-frame 1 \
+            --checkpoint $dir/exp/pretrained.pt \
+            --bpe-model $dir/data/lang_bpe_500/bpe.model \
+            $dir/test_wavs/1089-134686-0001.wav \
+            $dir/test_wavs/1221-135766-0001.wav \
+            $dir/test_wavs/1221-135766-0002.wav
+
+      - name: Run greedy search decoding (max-sym-per-frame 2)
+        shell: bash
+        run: |
+          export PYTHONPATH=$PWD:PYTHONPATH
+          dir=./tmp/icefall-asr-librispeech-pruned-transducer-stateless-2022-03-12
+          cd egs/librispeech/ASR
+          ./transducer_stateless/pretrained.py \
+            --method greedy_search \
+            --max-sym-per-frame 2 \
+            --checkpoint $dir/exp/pretrained.pt \
+            --bpe-model $dir/data/lang_bpe_500/bpe.model \
+            $dir/test_wavs/1089-134686-0001.wav \
+            $dir/test_wavs/1221-135766-0001.wav \
+            $dir/test_wavs/1221-135766-0002.wav
+
+      - name: Run greedy search decoding (max-sym-per-frame 3)
+        shell: bash
+        run: |
+          export PYTHONPATH=$PWD:PYTHONPATH
+          dir=./tmp/icefall-asr-librispeech-pruned-transducer-stateless-2022-03-12
+          cd egs/librispeech/ASR
+          ./transducer_stateless/pretrained.py \
+            --method greedy_search \
+            --max-sym-per-frame 3 \
+            --checkpoint $dir/exp/pretrained.pt \
+            --bpe-model $dir/data/lang_bpe_500/bpe.model \
+            $dir/test_wavs/1089-134686-0001.wav \
+            $dir/test_wavs/1221-135766-0001.wav \
+            $dir/test_wavs/1221-135766-0002.wav
+
+      - name: Run beam search decoding
+        shell: bash
+        run: |
+          export PYTHONPATH=$PWD:$PYTHONPATH
+          dir=./tmp/icefall-asr-librispeech-pruned-transducer-stateless-2022-03-12
+          cd egs/librispeech/ASR
+          ./transducer_stateless/pretrained.py \
+            --method beam_search \
+            --beam-size 4 \
+            --checkpoint $dir/exp/pretrained.pt \
+            --bpe-model $dir/data/lang_bpe_500/bpe.model \
+            $dir/test_wavs/1089-134686-0001.wav \
+            $dir/test_wavs/1221-135766-0001.wav \
+            $dir/test_wavs/1221-135766-0002.wav
+
+      - name: Run modified beam search decoding
+        shell: bash
+        run: |
+          export PYTHONPATH=$PWD:$PYTHONPATH
+          dir=./tmp/icefall-asr-librispeech-pruned-transducer-stateless-2022-03-12
+          cd egs/librispeech/ASR
+          ./transducer_stateless/pretrained.py \
+            --method modified_beam_search \
+            --beam-size 4 \
+            --checkpoint $dir/exp/pretrained.pt \
+            --bpe-model $dir/data/lang_bpe_500/bpe.model \
+            $dir/test_wavs/1089-134686-0001.wav \
+            $dir/test_wavs/1221-135766-0001.wav \
+            $dir/test_wavs/1221-135766-0002.wav

--- a/.github/workflows/run-librispeech-2022-03-12.yml
+++ b/.github/workflows/run-librispeech-2022-03-12.yml
@@ -87,7 +87,7 @@ jobs:
           export PYTHONPATH=$PWD:PYTHONPATH
           dir=./tmp/icefall-asr-librispeech-pruned-transducer-stateless-2022-03-12
           cd egs/librispeech/ASR
-          ./transducer_stateless/pretrained.py \
+          ./pruned_transducer_stateless/pretrained.py \
             --method greedy_search \
             --max-sym-per-frame 1 \
             --checkpoint $dir/exp/pretrained.pt \
@@ -102,7 +102,7 @@ jobs:
           export PYTHONPATH=$PWD:PYTHONPATH
           dir=./tmp/icefall-asr-librispeech-pruned-transducer-stateless-2022-03-12
           cd egs/librispeech/ASR
-          ./transducer_stateless/pretrained.py \
+          ./pruned_transducer_stateless/pretrained.py \
             --method greedy_search \
             --max-sym-per-frame 2 \
             --checkpoint $dir/exp/pretrained.pt \
@@ -117,7 +117,7 @@ jobs:
           export PYTHONPATH=$PWD:PYTHONPATH
           dir=./tmp/icefall-asr-librispeech-pruned-transducer-stateless-2022-03-12
           cd egs/librispeech/ASR
-          ./transducer_stateless/pretrained.py \
+          ./pruned_transducer_stateless/pretrained.py \
             --method greedy_search \
             --max-sym-per-frame 3 \
             --checkpoint $dir/exp/pretrained.pt \
@@ -132,7 +132,7 @@ jobs:
           export PYTHONPATH=$PWD:$PYTHONPATH
           dir=./tmp/icefall-asr-librispeech-pruned-transducer-stateless-2022-03-12
           cd egs/librispeech/ASR
-          ./transducer_stateless/pretrained.py \
+          ./pruned_transducer_stateless/pretrained.py \
             --method beam_search \
             --beam-size 4 \
             --checkpoint $dir/exp/pretrained.pt \
@@ -147,7 +147,7 @@ jobs:
           export PYTHONPATH=$PWD:$PYTHONPATH
           dir=./tmp/icefall-asr-librispeech-pruned-transducer-stateless-2022-03-12
           cd egs/librispeech/ASR
-          ./transducer_stateless/pretrained.py \
+          ./pruned_transducer_stateless/pretrained.py \
             --method modified_beam_search \
             --beam-size 4 \
             --checkpoint $dir/exp/pretrained.pt \

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ The best WER using modified beam search with beam size 4 is:
 
 |     | test-clean | test-other |
 |-----|------------|------------|
-| WER | 2.61       | 6.46       |
+| WER | 2.56       | 6.27       |
 
 Note: No auxiliary losses are used in the training and no LMs are used
 in the decoding.

--- a/egs/librispeech/ASR/README.md
+++ b/egs/librispeech/ASR/README.md
@@ -15,6 +15,7 @@ The following table lists the differences among them.
 | `transducer_stateless`                | Conformer | Embedding + Conv1d |                                                   |
 | `transducer_lstm`                     | LSTM      | LSTM               |                                                   |
 | `transducer_stateless_multi_datasets` | Conformer | Embedding + Conv1d | Using data from GigaSpeech as extra training data |
+| `pruned_transducer_stateless`         | Conformer | Embedding + Conv1d | Using k2 pruned RNN-T loss                        |
 
 The decoder in `transducer_stateless` is modified from the paper
 [Rnn-Transducer with Stateless Prediction Network](https://ieeexplore.ieee.org/document/9054419/).

--- a/egs/librispeech/ASR/RESULTS.md
+++ b/egs/librispeech/ASR/RESULTS.md
@@ -20,8 +20,8 @@ The WERs are:
 | greedy search (max sym per frame 1) | 2.62       | 6.37       | --epoch 42, --avg 11, --max-duration 100 |
 | greedy search (max sym per frame 2) | 2.62       | 6.37       | --epoch 42, --avg 11, --max-duration 100 |
 | greedy search (max sym per frame 3) | 2.62       | 6.37       | --epoch 42, --avg 11, --max-duration 100 |
-| modified beam search (beam size 4)  | 2.56       | 6.27       | --epoch 39, --avg 15, --max-duration 100 |
-| beam search (beam size 4)           | 2.57       | 6.27       | --epoch 39, --avg 15, --max-duration 100 |
+| modified beam search (beam size 4)  | 2.56       | 6.27       | --epoch 42, --avg 11, --max-duration 100 |
+| beam search (beam size 4)           | 2.57       | 6.27       | --epoch 42, --avg 11, --max-duration 100 |
 
 The decoding time for `test-clean` and `test-other` is given below:
 (A V100 GPU with 32 GB RAM is used for decoding. Note: Not all GPU RAM is used during decoding.)

--- a/egs/librispeech/ASR/RESULTS.md
+++ b/egs/librispeech/ASR/RESULTS.md
@@ -2,11 +2,110 @@
 
 ### LibriSpeech BPE training results (Pruned Transducer)
 
-#### Conformer encoder + embedding decoder
-
 Conformer encoder + non-current decoder. The decoder
 contains only an embedding layer, a Conv1d (with kernel size 2) and a linear
 layer (to transform tensor dim).
+
+#### 2022-03-12
+
+[pruned_transducer_stateless](./pruned_transducer_stateless)
+
+Using commit `1603744469d167d848e074f2ea98c587153205fa`.
+See <https://github.com/k2-fsa/icefall/pull/248>
+
+The WERs are:
+
+|                                     | test-clean | test-other | comment                                  |
+|-------------------------------------|------------|------------|------------------------------------------|
+| greedy search (max sym per frame 1) | 2.62       | 6.37       | --epoch 42, --avg 11, --max-duration 100 |
+| greedy search (max sym per frame 2) | 2.62       | 6.37       | --epoch 42, --avg 11, --max-duration 100 |
+| greedy search (max sym per frame 3) | 2.62       | 6.37       | --epoch 42, --avg 11, --max-duration 100 |
+| modified beam search (beam size 4)  | 2.56       | 6.27       | --epoch 39, --avg 15, --max-duration 100 |
+| beam search (beam size 4)           | 2.57       | 6.27       | --epoch 39, --avg 15, --max-duration 100 |
+
+The decoding time for `test-clean` and `test-other` is given below:
+(A V100 GPU with 32 GB RAM is used for decoding. Note: Not all GPU RAM is used during decoding.)
+
+| decoding method | test-clean (seconds) | test-other (seconds)|
+|---|---:|---:|
+| greedy search (--max-sym-per-frame=1) | 160 | 159 |
+| greedy search (--max-sym-per-frame=2) | 184 | 177 |
+| greedy search (--max-sym-per-frame=3) | 210 | 213 |
+| modified beam search (--beam-size 4)| 273 | 269 |
+|beam search (--beam-size 4) | 2741 | 2221 |
+
+We recommend you to use `modified_beam_search`.
+
+Training command:
+
+```bash
+cd egs/librispeech/ASR/
+./prepare.sh
+
+export CUDA_VISIBLE_DEVICES="0,1,2,3,4,5,6,7"
+
+. path.sh
+
+./pruned_transducer_stateless/train.py \
+  --world-size 8 \
+  --num-epochs 60 \
+  --start-epoch 0 \
+  --exp-dir pruned_transducer_stateless/exp \
+  --full-libri 1 \
+  --max-duration 300 \
+  --prune-range 5 \
+  --lr-factor 5 \
+  --lm-scale 0.25
+```
+
+The tensorboard training log can be found at
+<https://tensorboard.dev/experiment/WKRFY5fYSzaVBHahenpNlA/>
+
+The command for decoding is:
+
+```bash
+epoch=42
+avg=11
+sym=1
+
+# greedy search
+
+./pruned_transducer_stateless/decode.py \
+  --epoch $epoch \
+  --avg $avg \
+  --exp-dir ./pruned_transducer_stateless/exp \
+  --max-duration 100 \
+  --decoding-method greedy_search \
+  --beam-size 4 \
+  --max-sym-per-frame $sym
+
+# modified beam search
+./pruned_transducer_stateless/decode.py \
+  --epoch $epoch \
+  --avg $avg \
+  --exp-dir ./pruned_transducer_stateless/exp \
+  --max-duration 100 \
+  --decoding-method modified_beam_search \
+  --beam-size 4
+
+# beam search
+# (not recommended)
+./pruned_transducer_stateless/decode.py \
+  --epoch $epoch \
+  --avg $avg \
+  --exp-dir ./pruned_transducer_stateless/exp \
+  --max-duration 100 \
+  --decoding-method beam_search \
+  --beam-size 4
+```
+
+You can find a pre-trained model, decoding logs, and decoding results at
+<https://huggingface.co/csukuangfj/icefall-asr-librispeech-pruned-transducer-stateless-2022-03-12>
+
+#### 2022-02-18
+
+[pruned_transducer_stateless](./pruned_transducer_stateless)
+
 
 The WERs are
 
@@ -62,7 +161,7 @@ See
 
 ##### 2022-03-01
 
-Using commit `fill in it after merging`.
+Using commit `2332ba312d7ce72f08c7bac1e3312f7e3dd722dc`.
 
 It uses [GigaSpeech](https://github.com/SpeechColab/GigaSpeech)
 as extra training data. 20% of the time it selects a batch from L subset of
@@ -128,6 +227,9 @@ sym=1
   --decoding-method modified_beam_search \
   --beam-size 4
 ```
+
+You can find a pretrained model by visiting
+<https://huggingface.co/csukuangfj/icefall-asr-librispeech-transducer-stateless-multi-datasets-bpe-500-2022-03-01>
 
 
 ##### 2022-02-07

--- a/egs/librispeech/ASR/pruned_transducer_stateless/beam_search.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless/beam_search.py
@@ -262,7 +262,7 @@ def modified_beam_search(
     for t in range(T):
         # fmt: off
         current_encoder_out = encoder_out[:, t:t+1, :].unsqueeze(2)
-        # current_encoder_out is of shape (1, 1, encoder_out_dim)
+        # current_encoder_out is of shape (1, 1, 1, encoder_out_dim)
         # fmt: on
         A = list(B)
         B = HypothesisList()
@@ -278,11 +278,11 @@ def modified_beam_search(
         # decoder_input is of shape (num_hyps, context_size)
 
         decoder_out = model.decoder(decoder_input, need_pad=False).unsqueeze(1)
-        # decoder_output is of shape (num_hyps, 1,1, decoder_output_dim)
+        # decoder_output is of shape (num_hyps, 1, 1, decoder_output_dim)
 
         current_encoder_out = current_encoder_out.expand(
             decoder_out.size(0), 1, 1, -1
-        )
+        )  # (num_hyps, 1, 1, encoder_out_dim)
 
         logits = model.joiner(
             current_encoder_out,

--- a/egs/librispeech/ASR/pruned_transducer_stateless/beam_search.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless/beam_search.py
@@ -17,7 +17,6 @@
 from dataclasses import dataclass
 from typing import Dict, List, Optional
 
-import numpy as np
 import torch
 from model import Transducer
 

--- a/egs/librispeech/ASR/pruned_transducer_stateless/decode.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless/decode.py
@@ -56,13 +56,9 @@ import torch
 import torch.nn as nn
 from asr_datamodule import LibriSpeechAsrDataModule
 from beam_search import beam_search, greedy_search, modified_beam_search
-from conformer import Conformer
-from decoder import Decoder
-from joiner import Joiner
-from model import Transducer
+from train import get_params, get_transducer_model
 
 from icefall.checkpoint import average_checkpoints, load_checkpoint
-from icefall.env import get_env_info
 from icefall.utils import (
     AttributeDict,
     setup_logger,
@@ -141,72 +137,6 @@ def get_parser():
     )
 
     return parser
-
-
-def get_params() -> AttributeDict:
-    params = AttributeDict(
-        {
-            # parameters for conformer
-            "feature_dim": 80,
-            "subsampling_factor": 4,
-            "attention_dim": 512,
-            "nhead": 8,
-            "dim_feedforward": 2048,
-            "num_encoder_layers": 12,
-            "vgg_frontend": False,
-            # parameters for decoder
-            "embedding_dim": 512,
-            "env_info": get_env_info(),
-        }
-    )
-    return params
-
-
-def get_encoder_model(params: AttributeDict) -> nn.Module:
-    # TODO: We can add an option to switch between Conformer and Transformer
-    encoder = Conformer(
-        num_features=params.feature_dim,
-        output_dim=params.vocab_size,
-        subsampling_factor=params.subsampling_factor,
-        d_model=params.attention_dim,
-        nhead=params.nhead,
-        dim_feedforward=params.dim_feedforward,
-        num_encoder_layers=params.num_encoder_layers,
-        vgg_frontend=params.vgg_frontend,
-    )
-    return encoder
-
-
-def get_decoder_model(params: AttributeDict) -> nn.Module:
-    decoder = Decoder(
-        vocab_size=params.vocab_size,
-        embedding_dim=params.embedding_dim,
-        blank_id=params.blank_id,
-        context_size=params.context_size,
-    )
-    return decoder
-
-
-def get_joiner_model(params: AttributeDict) -> nn.Module:
-    joiner = Joiner(
-        input_dim=params.vocab_size,
-        inner_dim=params.embedding_dim,
-        output_dim=params.vocab_size,
-    )
-    return joiner
-
-
-def get_transducer_model(params: AttributeDict) -> nn.Module:
-    encoder = get_encoder_model(params)
-    decoder = get_decoder_model(params)
-    joiner = get_joiner_model(params)
-
-    model = Transducer(
-        encoder=encoder,
-        decoder=decoder,
-        joiner=joiner,
-    )
-    return model
 
 
 def decode_one_batch(
@@ -488,9 +418,6 @@ def main():
 
     logging.info("Done!")
 
-
-torch.set_num_threads(1)
-torch.set_num_interop_threads(1)
 
 if __name__ == "__main__":
     main()

--- a/egs/librispeech/ASR/pruned_transducer_stateless/decode.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless/decode.py
@@ -33,6 +33,15 @@ Usage:
         --max-duration 100 \
         --decoding-method beam_search \
         --beam-size 4
+
+(3) modified beam search
+./pruned_transducer_stateless/decode.py \
+        --epoch 28 \
+        --avg 15 \
+        --exp-dir ./pruned_transducer_stateless/exp \
+        --max-duration 100 \
+        --decoding-method modified_beam_search \
+        --beam-size 4
 """
 
 
@@ -46,7 +55,7 @@ import sentencepiece as spm
 import torch
 import torch.nn as nn
 from asr_datamodule import LibriSpeechAsrDataModule
-from beam_search import beam_search, greedy_search
+from beam_search import beam_search, greedy_search, modified_beam_search
 from conformer import Conformer
 from decoder import Decoder
 from joiner import Joiner
@@ -104,6 +113,7 @@ def get_parser():
         help="""Possible values are:
           - greedy_search
           - beam_search
+          - modified_beam_search
         """,
     )
 
@@ -111,7 +121,8 @@ def get_parser():
         "--beam-size",
         type=int,
         default=4,
-        help="Used only when --decoding-method is beam_search",
+        help="""Used only when --decoding-method is
+        beam_search or modified_beam_search""",
     )
 
     parser.add_argument(
@@ -125,7 +136,8 @@ def get_parser():
         "--max-sym-per-frame",
         type=int,
         default=3,
-        help="Maximum number of symbols per frame",
+        help="""Maximum number of symbols per frame.
+        Used only when --decoding_method is greedy_search""",
     )
 
     return parser
@@ -256,6 +268,10 @@ def decode_one_batch(
             )
         elif params.decoding_method == "beam_search":
             hyp = beam_search(
+                model=model, encoder_out=encoder_out_i, beam=params.beam_size
+            )
+        elif params.decoding_method == "modified_beam_search":
+            hyp = modified_beam_search(
                 model=model, encoder_out=encoder_out_i, beam=params.beam_size
             )
         else:
@@ -391,11 +407,15 @@ def main():
     params = get_params()
     params.update(vars(args))
 
-    assert params.decoding_method in ("greedy_search", "beam_search")
+    assert params.decoding_method in (
+        "greedy_search",
+        "beam_search",
+        "modified_beam_search",
+    )
     params.res_dir = params.exp_dir / params.decoding_method
 
     params.suffix = f"epoch-{params.epoch}-avg-{params.avg}"
-    if params.decoding_method == "beam_search":
+    if "beam_search" in params.decoding_method:
         params.suffix += f"-beam-{params.beam_size}"
     else:
         params.suffix += f"-context-{params.context_size}"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ kaldialign
 sentencepiece>=0.1.96
 tensorboard
 typeguard
-optimized_transducer


### PR DESCRIPTION
Training command
```bash
./pruned_transducer_stateless/train.py \
  --world-size 8 \
  --num-epochs 60 \
  --start-epoch 0 \
  --exp-dir pruned_transducer_stateless/exp \
  --full-libri 1 \
  --max-duration 300 \
  --prune-range 5 \
  --lr-factor 5 \
  --lm-scale 0.25
```

Tensorboard log https://tensorboard.dev/experiment/WKRFY5fYSzaVBHahenpNlA/

Decoding command
```bash
for epoch in 42; do
  for avg in 11; do
    ./pruned_transducer_stateless/decode.py \
      --epoch $epoch \
      --avg $avg \
      --exp-dir ./pruned_transducer_stateless/exp \
      --max-duration 100 \
      --decoding-method greedy_search \
      --max-sym-per-frame 1
  done
done

for epoch in 42; do
  for avg in 11; do
    ./pruned_transducer_stateless/decode.py \
      --epoch $epoch \
      --avg $avg \
      --exp-dir ./pruned_transducer_stateless/exp \
      --max-duration 100 \
      --decoding-method modified_beam_search \
      --beam-size 4
  done
done

for epoch in 42; do
  for avg in 11; do
    ./pruned_transducer_stateless/decode.py \
      --epoch $epoch \
      --avg $avg \
      --exp-dir ./pruned_transducer_stateless/exp \
      --max-duration 100 \
      --decoding-method beam_search \
      --beam-size 4
  done
done
```

Decoding results:

|  decoding method                                           | test-clean | test-other | comment                                                     |
|--------------------------------------------|------------|-----------|-----------------------------------------|
| greedy search (--max-sym-per-frame 1)     | 2.62            |  6.37         |--epoch 42 --avg 11 --max-duration 100 |
| greedy search (--max-sym-per-frame 2)      |   2.62         |  6.37        |--epoch 42 --avg 11 --max-duration 100 |
| greedy search (--max-sym-per-frame 3)      |   2.62         |  6.37         |--epoch 42 --avg 11 --max-duration 100 |
| modified beam search (--beam-size 4)      |  2.56            |     6.27     |--epoch 42 --avg 11 --max-duration 100 
| beam search (--beam-size 4)      |    2.57        |  6.27        |--epoch 42 --avg 11 --max-duration 100 |

Note:
1. The model is **not** trained using **modified** transducer.
2. By **modified beam search**, it means it hardcodes `--max-sym-per-frame=1` during beam search.
3. The current implementation of beam search is super slow and we recommend using only modified beam search.
4. For the decoding time of `test-clean` and `test-other`:

| decoding method | test-clean (seconds) | test-other (seconds)|
|---|---:|---:|
| greedy search (--max-sym-per-frame=1) | 160 | 159 |
| greedy search (--max-sym-per-frame=2) | 184 | 177 |
| greedy search (--max-sym-per-frame=3) | 210 | 213 |
| modified beam search (--beam-size 4)| 273 | 269 |
|beam search (--beam-size 4) | 2741 | 2221 |

Will update RESULTS.md and upload the pre-trained model to hugging face later today.