### PR TITLE
Add fast beam search decoding

### DIFF
--- a/egs/librispeech/ASR/pruned_transducer_stateless/beam_search.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless/beam_search.py
@@ -90,7 +90,7 @@ def fast_beam_search(
         logits = logits.squeeze(1).squeeze(1)
         log_probs = logits.log_softmax(dim=-1)
         decoding_streams.advance(log_probs)
-    decoding_streams.detach()
+    decoding_streams.terminate_and_flush_to_atreams()
     lattice = decoding_streams.format_output(encoder_out_lens.tolist())
 
     best_path = one_best_decoding(lattice)

--- a/egs/librispeech/ASR/pruned_transducer_stateless/beam_search.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless/beam_search.py
@@ -17,8 +17,85 @@
 from dataclasses import dataclass
 from typing import Dict, List, Optional
 
+import k2
 import torch
 from model import Transducer
+
+from icefall.decode import one_best_decoding
+from icefall.utils import get_texts
+
+
+def fast_beam_search(
+    decoding_graph: k2.Fsa,
+    model: Transducer,
+    encoder_out: torch.Tensor,
+    encoder_out_lens: torch.Tensor,
+    beam: float,
+    max_states: int,
+    max_contexts: int,
+) -> List[int]:
+    """It limits the maximum number of symbols per frame to 1.
+
+    Args:
+      model:
+        An instance of `Transducer`.
+      encoder_out:
+        A tensor of shape (N, T, C) from the encoder. Support only N==1 for now.
+      decoding_graph:
+        Decoding graph used for decoding, may be a TrivialGraph or a HLG.
+      beam:
+        Beam value, similar to the beam used in Kaldi..
+      max_states:
+        Max states per stream per frame.
+      max_contexts:
+        Max contexts pre stream per frame.
+    Returns:
+      Return the decoded result.
+    """
+    assert encoder_out.ndim == 3
+
+    context_size = model.decoder.context_size
+    vocab_size = model.decoder.vocab_size
+
+    B, T, C = encoder_out.shape
+
+    config = k2.RnntDecodingConfig(
+        vocab_size=vocab_size,
+        decoder_history_len=context_size,
+        beam=beam,
+        max_contexts=max_contexts,
+        max_states=max_states,
+    )
+    indivisual_streams = []
+    for i in range(B):
+        indivisual_streams.append(k2.RnntDecodingStream(decoding_graph))
+    decoding_streams = k2.RnntDecodingStreams(indivisual_streams, config)
+
+    for t in range(T):
+        # shape is a RaggedShape of shape (B, context)
+        # contexts is a Tensor of shape (shape.NumElements(), context_size)
+        shape, contexts = decoding_streams.get_contexts()
+        # decoder_out is of shape (shape.NumElements(), 1, decoder_out_dim)
+        decoder_out = model.decoder(contexts, need_pad=False)
+        # current_encoder_out is of shape
+        # (shape.NumElements(), 1, encoder_out_dim)
+        # fmt: off
+        current_encoder_out = torch.index_select(
+            encoder_out[:, t:t + 1, :], 0, shape.row_ids(1)
+        )
+        # fmt: on
+        logits = model.joiner(
+            current_encoder_out.unsqueeze(2), decoder_out.unsqueeze(1)
+        )
+        logits = logits.squeeze(1).squeeze(1)
+        log_probs = logits.log_softmax(dim=-1)
+        decoding_streams.advance(log_probs)
+    decoding_streams.detach()
+    lattice = decoding_streams.format_output(encoder_out_lens.tolist())
+
+    best_path = one_best_decoding(lattice)
+    hyps = get_texts(best_path)
+    return hyps
 
 
 def greedy_search(

--- a/egs/librispeech/ASR/pruned_transducer_stateless/decode.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless/decode.py
@@ -208,13 +208,13 @@ def decode_one_batch(
         The neural model.
       sp:
         The BPE model.
-      decoding_graph:
-        The decoding graph. Can be either a `k2.trivial_graph` or HLG, Used
-        only when --decoding_method is fast_beam_search.
       batch:
         It is the return value from iterating
         `lhotse.dataset.K2SpeechRecognitionDataset`. See its documentation
         for the format of the `batch`.
+      decoding_graph:
+        The decoding graph. Can be either a `k2.trivial_graph` or HLG, Used
+        only when --decoding_method is fast_beam_search.
     Returns:
       Return the decoding result. See above description for the format of
       the returned dict.

--- a/egs/librispeech/ASR/pruned_transducer_stateless/decode.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless/decode.py
@@ -50,9 +50,9 @@ Usage:
         --exp-dir ./pruned_transducer_stateless/exp \
         --max-duration 1500 \
         --decoding-method fast_beam_search \
-        --beam 8 \
-        --max-contexts 10 \
-        --max-states 20
+        --beam 4 \
+        --max-contexts 4 \
+        --max-states 8
 """
 
 
@@ -142,7 +142,7 @@ def get_parser():
     parser.add_argument(
         "--beam",
         type=float,
-        default=8,
+        default=4,
         help="""Used only when --decoding-method is
         fast_beam_search""",
     )
@@ -150,7 +150,7 @@ def get_parser():
     parser.add_argument(
         "--max-contexts",
         type=int,
-        default=5,
+        default=4,
         help="""Used only when --decoding-method is
         fast_beam_search""",
     )
@@ -158,7 +158,7 @@ def get_parser():
     parser.add_argument(
         "--max-states",
         type=int,
-        default=10,
+        default=8,
         help="""Used only when --decoding-method is
         fast_beam_search""",
     )

--- a/egs/librispeech/ASR/pruned_transducer_stateless/decode.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless/decode.py
@@ -206,7 +206,7 @@ def decode_one_batch(
       sp:
         The BPE model.
       decoding_graph:
-        The decoding graph. Can be either a `k2.TrivialGraph` or HLG, Used
+        The decoding graph. Can be either a `k2.trivial_graph` or HLG, Used
         only when --decoding_method is fast_beam_search.
       batch:
         It is the return value from iterating
@@ -307,7 +307,7 @@ def decode_dataset(
       sp:
         The BPE model.
       decoding_graph:
-        The decoding graph. Can be either a `k2.TrivialGraph` or HLG, Used
+        The decoding graph. Can be either a `k2.trivial_graph` or HLG, Used
         only when --decoding_method is fast_beam_search.
     Returns:
       Return a dict, whose key may be "greedy_search" if greedy search
@@ -471,7 +471,7 @@ def main():
     model.device = device
 
     if params.decoding_method == "fast_beam_search":
-        decoding_graph = k2.TrivialGraph(params.vocab_size - 1, device=device)
+        decoding_graph = k2.trivial_graph(params.vocab_size - 1, device=device)
     else:
         decoding_graph = None
 

--- a/egs/librispeech/ASR/pruned_transducer_stateless/decode.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless/decode.py
@@ -60,7 +60,7 @@ import argparse
 import logging
 from collections import defaultdict
 from pathlib import Path
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import k2
 import sentencepiece as spm
@@ -135,16 +135,19 @@ def get_parser():
         "--beam-size",
         type=int,
         default=4,
-        help="""Used only when --decoding-method is
-        beam_search or modified_beam_search""",
+        help="""An interger indicating how many candidates we will keep for each
+        frame. Used only when --decoding-method is beam_search or
+        modified_beam_search.""",
     )
 
     parser.add_argument(
         "--beam",
         type=float,
         default=4,
-        help="""Used only when --decoding-method is
-        fast_beam_search""",
+        help="""A floating point value to calculate the cutoff score during beam
+        search (i.e., `cutoff = max-score - beam`), which is the same as the
+        `beam` in Kaldi.
+        Used only when --decoding-method is fast_beam_search""",
     )
 
     parser.add_argument(
@@ -185,8 +188,8 @@ def decode_one_batch(
     params: AttributeDict,
     model: nn.Module,
     sp: spm.SentencePieceProcessor,
-    decoding_graph: k2.Fsa,
     batch: dict,
+    decoding_graph: Optional[k2.Fsa] = None,
 ) -> Dict[str, List[List[str]]]:
     """Decode one batch and return the result in a dict. The dict has the
     following format:
@@ -293,7 +296,7 @@ def decode_dataset(
     params: AttributeDict,
     model: nn.Module,
     sp: spm.SentencePieceProcessor,
-    decoding_graph: k2.Fsa,
+    decoding_graph: Optional[k2.Fsa] = None,
 ) -> Dict[str, List[Tuple[List[str], List[str]]]]:
     """Decode dataset.
 

--- a/egs/librispeech/ASR/pruned_transducer_stateless/decoder.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless/decoder.py
@@ -61,6 +61,7 @@ class Decoder(nn.Module):
 
         assert context_size >= 1, context_size
         self.context_size = context_size
+        self.vocab_size = vocab_size
         if context_size > 1:
             self.conv = nn.Conv1d(
                 in_channels=embedding_dim,


### PR DESCRIPTION
This PR uses the GPU parallel decoding method in https://github.com/k2-fsa/k2/pull/926.

The decoding results and time used are as follows:

I used the same model as https://github.com/k2-fsa/icefall/pull/248. The decoding process can run with the max value of **max-duration=2000**, which means **several hundred streams** for not very long utterances.  You can see in the table, the decoding time seems not affect very much by the `beam`, `max-contexts`,  `max-states` (I think it is because we use a small decoding graph, i.e. k2.trivial_graph). So I suggest to use beam=4, max-contexts=4, max-states=8 here.

As for the WERs, it is not as good as the results in https://github.com/k2-fsa/icefall/pull/248 that decoded with `modified_beam_search`(which is 2.56||6.27).  I think one of the reasons is we use much larger batch-size, when I used `max-duration=1` to decode, I can got  WERs of 2.58 || 6.28.


Will try HLG graph to see if it can reduce the WERs any further.



<div class="okr-block-clipboard" data-okr="%7B%22okrDelta%22%3A%5B%7B%22lineType%22%3A%22unsupport%22%2C%22lineOptions%22%3A%7B%7D%2C%22lineContent%22%3A%5B%5D%7D%5D%2C%22businessKey%22%3A%22lark-doc%22%7D"></div><div data-zone-id="0" data-line-index="0" style="white-space: pre;">

beam | max-contexts | max-states | WERs for test-clean | WERs for test-other | time for test-clean(seconds) | time for test-other(seconds)
-- | -- | -- | -- | -- | -- | --
1 | -1 | -1 | 2.62 | 6.34 | 50 | 47
3 | -1 | -1 | 2.61 | 6.29 |   |  
5 | -1 | -1 | 2.61 | 6.29 | 50 | 49
7 | -1 | -1 | 2.61 | 6.29 |   |  
9 | -1 | -1 | 2.61 | 6.29 |   |  
12 | -1 | -1 | 2.61 | 6.29 | 50 | 48
15 | -1 | -1 | 2.61 | 6.29 |   |  
15 | 1 | 1 | 2.62 | 6.37 | 50 | 49
15 | 2 | 2 | 2.62 | 6.31 |   |  
15 | 2 | 4 | 2.62 | 6.31 |   |  
15 | 2 | 6 | 2.62 | 6.31 |   |  
15 | 3 | 3 | 2.61 | 6.29 |   |  
15 | 3 | 6 | 2.61 | 6.29 |   |  
15 | 3 | 9 | 2.61 | 6.29 |   |  
15 | 4 | 4 | 2.61 | 6.29 |   |  
15 | 4 | 8 | 2.61 | 6.29 |   |  
15 | 4 | 12 | 2.61 | 6.29 |   |  
15 | 5 | 5 | 2.61 | 6.29 |   |  
15 | 5 | 10 | 2.61 | 6.29 |   |  
15 | 5 | 15 | 2.61 | 6.29 |   |  
15 | 6 | 6 | 2.61 | 6.29 |   |  
15 | 6 | 12 | 2.61 | 6.29 |   |  
15 | 6 | 18 | 2.61 | 6.29 |   |  
15 | 8 | 8 | 2.61 | 6.29 |   |  
15 | 8 | 16 | 2.61 | 6.29 |   |  
15 | 8 | 24 | 2.61 | 6.29 |   |  
15 | 10 | 10 | 2.61 | 6.29 |   |  
15 | 10 | 20 | 2.61 | 6.29 |   |  
15 | 10 | 30 | 2.61 | 6.29 | 52 | 48

</div>