### PR TITLE
[Not for Merge]: Visualize the gradient of each node in the lattice.

### DIFF
--- a/egs/librispeech/ASR/pruned_transducer_stateless/model.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless/model.py
@@ -166,4 +166,23 @@ class Transducer(nn.Module):
             reduction="sum",
         )
 
-        return (simple_loss, pruned_loss)
+        B = px_grad.size(0)
+        S = px_grad.size(1)
+        T = px_grad.size(2) - 1
+        # px_grad's shape (B, S, T+1)
+        # py_grad's shape (B, S+1, T)
+
+        px_grad_pad = torch.zeros(
+            (B, 1, T + 1), dtype=px_grad.dtype, device=px_grad.device
+        )
+        py_grad_pad = torch.zeros(
+            (B, S + 1, 1), dtype=px_grad.dtype, device=px_grad.device
+        )
+
+        px_grad_padded = torch.cat([px_grad, px_grad_pad], dim=1)
+        py_grad_padded = torch.cat([py_grad, py_grad_pad], dim=2)
+
+        # tot_grad's shape (B, S+1, T+1)
+        tot_grad = px_grad_padded + py_grad_padded
+
+        return (simple_loss, pruned_loss, tot_grad, x_lens, y_lens)


### PR DESCRIPTION
This PR visualizes the gradient of each node in the lattice, which is used to compute the transducer loss.

The following shows some plots for different utterances.

You can see that
- Most of the nodes have a very small gradient, i.e., most of the nodes have the background color.
- Positions of nodes with non-zero gradient change somewhat monotonically, from the lower left to the upper right
- At each time frame, only a small set of nodes have a non-zero gradient, **which justifies the pruned RNN-T loss, i.e., putting a limit on the number of symbols per frame.**

![4160-11550-0025-15342-0_sp0 9](https://user-images.githubusercontent.com/5284924/158114019-b6e951c9-7214-4811-9ddc-624fefdd6919.png)
![3440-171006-0000-22865-0_sp0 9](https://user-images.githubusercontent.com/5284924/158114023-d3ffb7d0-04a7-4a10-9d6e-63cf2dbdc732.png)

![4195-186238-0001-16076-0_sp0 9](https://user-images.githubusercontent.com/5284924/158114011-45e1fa71-78dc-4d0c-b8a3-6cefc9b22705.png)


![8425-246962-0023-25419-0_sp0 9](https://user-images.githubusercontent.com/5284924/158113996-6c9dcfb5-98bb-4e55-831a-d4a0a7ea405d.png)
![5652-39938-0025-14246-0](https://user-images.githubusercontent.com/5284924/158114004-189a067a-99f4-4b85-aa88-417a3db1130b.png)
