### PR TITLE
Implement greedy search in batch mode for transducer decoding.

### DIFF
--- a/egs/librispeech/ASR/pruned_transducer_stateless/decode.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless/decode.py
@@ -71,6 +71,7 @@ from beam_search import (
     beam_search,
     fast_beam_search,
     greedy_search,
+    greedy_search_batch,
     modified_beam_search,
 )
 from train import get_params, get_transducer_model
@@ -258,6 +259,16 @@ def decode_one_batch(
             beam=params.beam,
             max_contexts=params.max_contexts,
             max_states=params.max_states,
+        )
+        for hyp in sp.decode(hyp_tokens):
+            hyps.append(hyp.split())
+    elif (
+        params.decoding_method == "greedy_search"
+        and params.max_sym_per_frame == 1
+    ):
+        hyp_tokens = greedy_search_batch(
+            model=model,
+            encoder_out=encoder_out,
         )
         for hyp in sp.decode(hyp_tokens):
             hyps.append(hyp.split())


### PR DESCRIPTION
Now if you use
```bash
--decoding-method greedy_search
--max-sym-per-frame 1
```
in decoding, it will decode in batch mode.

For the following deocoding command
```
    ./pruned_transducer_stateless/decode.py \
      --epoch 99 \
      --avg 1 \
      --exp-dir ./pruned_transducer_stateless/exp \
      --max-duration 2000 \
      --decoding-method greedy_search \
      --max-sym-per-frame 1
```

The output is given below:
<img width="1352" alt="Screen Shot 2022-03-21 at 10 19 55 PM" src="https://user-images.githubusercontent.com/5284924/159280867-16c3b66c-548f-4b1d-9376-6eda256fc5ef.png">

**note**: Don't be confused by `epoch-99.pt`, it is just a symlink to the pretrained model from https://github.com/k2-fsa/icefall/pull/248

You can see that the total time in decoding test-clean and test-other is less than 1 minute. The RTF is roughly computed as below:
```
>>> 60 / ((5.3 + 5.4)*60*60)
0.001557632398753894
```
(test-clean has 5.4 hours of data and test-other has 5.3 hours)
