### PR TITLE
Update results for stateless transducer without pruned RNN-T loss.

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ The best WER using modified beam search with beam size 4 is:
 
 |     | test-clean | test-other |
 |-----|------------|------------|
-| WER | 2.56       | 6.27       |
+| WER | 2.56       | 6.20       |
 
 Note: No auxiliary losses are used in the training and no LMs are used
 in the decoding.

--- a/egs/librispeech/ASR/RESULTS.md
+++ b/egs/librispeech/ASR/RESULTS.md
@@ -159,6 +159,75 @@ See
 - [./transducer_stateless](./transducer_stateless)
 - [./transducer_stateless_multi_datasets](./transducer_stateless_multi_datasets)
 
+#### 2022-03-27
+
+Using commit `395a3f952be1449cd7c92b896f4eb9a1c899e2c7`.
+(--modified-transducer-prob 0.25)
+
+|                                     | test-clean | test-other | comment                                  |
+|-------------------------------------|------------|------------|------------------------------------------|
+| greedy search (max sym per frame 1) | 2.60       | 6.33       | --epoch 59, --avg 19, --max-duration 1000|
+| greedy search (max sym per frame 2) | 2.60       | 6.32       | --epoch 59, --avg 19, --max-duration 1000|
+| greedy search (max sym per frame 3) | 2.60       | 6.32       | --epoch 59, --avg 19, --max-duration 1000|
+| modified beam search (beam size 4)  | 2.56       | 6.20       | --epoch 59, --avg 19, --max-duration 1000|
+
+The training command for reproducing is given below:
+```bash
+export CUDA_VISIBLE_DEVICES="1,2,3,4,5,6,7"
+
+. path.sh
+
+./transducer_stateless/train.py \
+  --world-size 7 \
+  --num-epochs 60 \
+  --start-epoch 0 \
+  --exp-dir transducer_stateless/exp-2 \
+  --full-libri 1 \
+  --max-duration 300 \
+  --lr-factor 5 \
+  --modified-transducer-prob 0.25
+```
+
+The tensorboard training log can be found at
+<https://tensorboard.dev/experiment/IBmTNy1CQ9Wia4ECrBh0fA/>
+
+The decoding command is:
+```bash
+epoch=59
+avg=19
+
+## greedy search
+for sym in 1 2 3; do
+  ./transducer_stateless/decode.py \
+    --epoch $epoch \
+    --avg $avg \
+    --exp-dir ./transducer_stateless/exp-2 \
+    --max-duration 1000 \
+    --decoding-method greedy_search \
+    --max-sym-per-frame $sym
+done
+
+## modified_beam_search
+./transducer_stateless/decode.py \
+  --epoch $epoch \
+  --avg $avg \
+  --exp-dir ./transducer_stateless/exp-2 \
+  --max-duration 1000 \
+  --decoding-method modified_beam_search \
+  --max-sym-per-frame $sym
+```
+
+You can find a pretrained model by visiting
+<https://huggingface.co/csukuangfj/icefall-asr-librispeech-stateless-transducer-2022-03-27/>
+
+#### 2022-03-27
+
+Using commit `395a3f952be1449cd7c92b896f4eb9a1c899e2c7`.
+(--modified-transducer-prob 0.0)
+
+**TODO**: Add results.
+
+
 ##### 2022-03-01
 
 Using commit `2332ba312d7ce72f08c7bac1e3312f7e3dd722dc`.

--- a/egs/librispeech/ASR/RESULTS.md
+++ b/egs/librispeech/ASR/RESULTS.md
@@ -44,8 +44,6 @@ cd egs/librispeech/ASR/
 
 export CUDA_VISIBLE_DEVICES="0,1,2,3,4,5,6,7"
 
-. path.sh
-
 ./pruned_transducer_stateless/train.py \
   --world-size 8 \
   --num-epochs 60 \
@@ -175,8 +173,6 @@ The training command for reproducing is given below:
 ```bash
 export CUDA_VISIBLE_DEVICES="1,2,3,4,5,6,7"
 
-. path.sh
-
 ./transducer_stateless/train.py \
   --world-size 7 \
   --num-epochs 60 \
@@ -236,8 +232,6 @@ Using commit `395a3f952be1449cd7c92b896f4eb9a1c899e2c7`.
 The training command for reproducing is given below:
 ```bash
 export CUDA_VISIBLE_DEVICES="1,2,3,4,5,6,7"
-
-. path.sh
 
 ./transducer_stateless/train.py \
   --world-size 7 \

--- a/egs/librispeech/ASR/RESULTS.md
+++ b/egs/librispeech/ASR/RESULTS.md
@@ -168,6 +168,7 @@ Using commit `395a3f952be1449cd7c92b896f4eb9a1c899e2c7`.
 | greedy search (max sym per frame 2) | 2.60       | 6.32       | --epoch 59, --avg 19, --max-duration 1000|
 | greedy search (max sym per frame 3) | 2.60       | 6.32       | --epoch 59, --avg 19, --max-duration 1000|
 | modified beam search (beam size 4)  | 2.56       | 6.20       | --epoch 59, --avg 19, --max-duration 1000|
+| beam search (beam size 4)           | 2.57       | 6.21       | --epoch 59, --avg 19, --max-duration 1000|
 
 The training command for reproducing is given below:
 ```bash
@@ -203,13 +204,22 @@ for sym in 1 2 3; do
     --max-sym-per-frame $sym
 done
 
-## modified_beam_search
+## modified beam search
 ./transducer_stateless/decode.py \
   --epoch $epoch \
   --avg $avg \
   --exp-dir ./transducer_stateless/exp-2 \
   --max-duration 1000 \
   --decoding-method modified_beam_search \
+  --beam-size 4
+
+## beam search
+./transducer_stateless/decode.py \
+  --epoch $epoch \
+  --avg $avg \
+  --exp-dir ./transducer_stateless/exp-2 \
+  --max-duration 1000 \
+  --decoding-method beam_search \
   --beam-size 4
 ```
 
@@ -228,6 +238,7 @@ Using commit `395a3f952be1449cd7c92b896f4eb9a1c899e2c7`.
 | greedy search (max sym per frame 2) | 2.63       | 6.37       | --epoch 49, --avg 11, --max-duration 1000|
 | greedy search (max sym per frame 3) | 2.63       | 6.37       | --epoch 49, --avg 11, --max-duration 1000|
 | modified beam search (beam size 4)  | 2.62       | 6.32       | --epoch 49, --avg 11, --max-duration 1000|
+| beam search (beam size 4)           | 2.58       | 6.24       | --epoch 49, --avg 11, --max-duration 1000|
 
 The training command for reproducing is given below:
 ```bash
@@ -263,13 +274,22 @@ for sym in 1 2 3; do
     --max-sym-per-frame $sym
 done
 
-## modified_beam_search
+## modified beam search
 ./transducer_stateless/decode.py \
   --epoch $epoch \
   --avg $avg \
   --exp-dir ./transducer_stateless/exp \
   --max-duration 1000 \
   --decoding-method modified_beam_search \
+  --beam-size 4
+
+## beam search
+./transducer_stateless/decode.py \
+  --epoch $epoch \
+  --avg $avg \
+  --exp-dir ./transducer_stateless/exp \
+  --max-duration 1000 \
+  --decoding-method beam_search \
   --beam-size 4
 ```
 

--- a/egs/librispeech/ASR/RESULTS.md
+++ b/egs/librispeech/ASR/RESULTS.md
@@ -214,7 +214,7 @@ done
   --exp-dir ./transducer_stateless/exp-2 \
   --max-duration 1000 \
   --decoding-method modified_beam_search \
-  --max-sym-per-frame $sym
+  --beam-size 4
 ```
 
 You can find a pretrained model by visiting
@@ -225,7 +225,62 @@ You can find a pretrained model by visiting
 Using commit `395a3f952be1449cd7c92b896f4eb9a1c899e2c7`.
 (--modified-transducer-prob 0.0)
 
-**TODO**: Add results.
+
+|                                     | test-clean | test-other | comment                                  |
+|-------------------------------------|------------|------------|------------------------------------------|
+| greedy search (max sym per frame 1) | 2.67       | 6.44       | --epoch 49, --avg 11, --max-duration 1000|
+| greedy search (max sym per frame 2) | 2.63       | 6.37       | --epoch 49, --avg 11, --max-duration 1000|
+| greedy search (max sym per frame 3) | 2.63       | 6.37       | --epoch 49, --avg 11, --max-duration 1000|
+| modified beam search (beam size 4)  | 2.62       | 6.32       | --epoch 49, --avg 11, --max-duration 1000|
+
+The training command for reproducing is given below:
+```bash
+export CUDA_VISIBLE_DEVICES="1,2,3,4,5,6,7"
+
+. path.sh
+
+./transducer_stateless/train.py \
+  --world-size 7 \
+  --num-epochs 60 \
+  --start-epoch 0 \
+  --exp-dir transducer_stateless/exp \
+  --full-libri 1 \
+  --max-duration 300 \
+  --lr-factor 5 \
+  --modified-transducer-prob 0.0
+```
+
+The tensorboard training log can be found at
+<https://tensorboard.dev/experiment/02aPElV6S26OQkbBbJqUnw/>
+
+The decoding command is:
+```bash
+epoch=49
+avg=11
+
+## greedy search
+for sym in 1 2 3; do
+  ./transducer_stateless/decode.py \
+    --epoch $epoch \
+    --avg $avg \
+    --exp-dir ./transducer_stateless/exp \
+    --max-duration 1000 \
+    --decoding-method greedy_search \
+    --max-sym-per-frame $sym
+done
+
+## modified_beam_search
+./transducer_stateless/decode.py \
+  --epoch $epoch \
+  --avg $avg \
+  --exp-dir ./transducer_stateless/exp \
+  --max-duration 1000 \
+  --decoding-method modified_beam_search \
+  --beam-size 4
+```
+
+You can find a pretrained model by visiting
+<https://huggingface.co/csukuangfj/icefall-asr-librispeech-stateless-transducer-2022-03-27-2/>
 
 
 ##### 2022-03-01


### PR DESCRIPTION
The purpose of this PR is to verify that if we limit the `--max-sym-per-frame=1` during decoding, we have to use modified transducer in training if no pruned RNN-T is used; otherwise, there is a degradation in WER about using `--max-sym-per-frame=1` in decoding.