### PR TITLE
fix typo of torch.eig

### DIFF
--- a/icefall/diagnostics.py
+++ b/icefall/diagnostics.py
@@ -140,7 +140,7 @@ def get_diagnostics_for_dim(
             stats = eigs.abs().sqrt()
         except:  # noqa
             print("Error getting eigenvalues, trying another method.")
-            eigs, _ = torch.eigs(stats)
+            eigs = torch.linalg.eigvals(stats)
             stats = eigs.abs().sqrt()
         # sqrt so it reflects data magnitude, like stddev- not variance
     elif sizes_same:


### PR DESCRIPTION
Is "torch.eigs" a typo of "torch.eig"? 

BTW, according to https://pytorch.org/docs/1.11/generated/torch.eig.html?highlight=torch%20eig#torch.eig, it's better to use "torch.linalg.eigvals".