### PR TITLE
[WIP] Half precision training

### DIFF
--- a/egs/librispeech/ASR/pruned_transducer_stateless/model.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless/model.py
@@ -128,17 +128,18 @@ class Transducer(nn.Module):
         boundary[:, 2] = y_lens
         boundary[:, 3] = x_lens
 
-        simple_loss, (px_grad, py_grad) = k2.rnnt_loss_smoothed(
-            lm=decoder_out,
-            am=encoder_out,
-            symbols=y_padded,
-            termination_symbol=blank_id,
-            lm_only_scale=lm_scale,
-            am_only_scale=am_scale,
-            boundary=boundary,
-            reduction="sum",
-            return_grad=True,
-        )
+        with torch.autocast(device_type=x.device.type, enabled=False):
+            simple_loss, (px_grad, py_grad) = k2.rnnt_loss_smoothed(
+                lm=decoder_out.float(),
+                am=encoder_out.float(),
+                symbols=y_padded,
+                termination_symbol=blank_id,
+                lm_only_scale=lm_scale,
+                am_only_scale=am_scale,
+                boundary=boundary,
+                reduction="sum",
+                return_grad=True,
+            )
 
         # ranges : [B, T, prune_range]
         ranges = k2.get_rnnt_prune_ranges(
@@ -157,13 +158,14 @@ class Transducer(nn.Module):
         # logits : [B, T, prune_range, C]
         logits = self.joiner(am_pruned, lm_pruned)
 
-        pruned_loss = k2.rnnt_loss_pruned(
-            logits=logits,
-            symbols=y_padded,
-            ranges=ranges,
-            termination_symbol=blank_id,
-            boundary=boundary,
-            reduction="sum",
-        )
+        with torch.autocast(device_type=x.device.type, enabled=False):
+            pruned_loss = k2.rnnt_loss_pruned(
+                logits=logits.float(),
+                symbols=y_padded,
+                ranges=ranges,
+                termination_symbol=blank_id,
+                boundary=boundary,
+                reduction="sum",
+            )
 
         return (simple_loss, pruned_loss)

--- a/egs/librispeech/ASR/pruned_transducer_stateless/model.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless/model.py
@@ -128,7 +128,7 @@ class Transducer(nn.Module):
         boundary[:, 2] = y_lens
         boundary[:, 3] = x_lens
 
-        with torch.autocast(device_type=x.device.type, enabled=False):
+        with torch.cuda.amp.autocast(enabled=False):
             simple_loss, (px_grad, py_grad) = k2.rnnt_loss_smoothed(
                 lm=decoder_out.float(),
                 am=encoder_out.float(),
@@ -158,7 +158,7 @@ class Transducer(nn.Module):
         # logits : [B, T, prune_range, C]
         logits = self.joiner(am_pruned, lm_pruned)
 
-        with torch.autocast(device_type=x.device.type, enabled=False):
+        with torch.cuda.amp.autocast(enabled=False):
             pruned_loss = k2.rnnt_loss_pruned(
                 logits=logits.float(),
                 symbols=y_padded,

--- a/egs/librispeech/ASR/pruned_transducer_stateless/train.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless/train.py
@@ -647,9 +647,7 @@ def train_one_epoch(
         params.batch_idx_train += 1
         batch_size = len(batch["supervisions"]["text"])
 
-        with torch.autocast(
-            device_type=model.device.type, enabled=params.use_fp16
-        ):
+        with torch.cuda.amp.autocast(enabled=params.use_fp16):
             loss, loss_info = compute_loss(
                 params=params,
                 model=model,
@@ -920,9 +918,7 @@ def scan_pessimistic_batches_for_oom(
         batch = train_dl.dataset[cuts]
         try:
             optimizer.zero_grad()
-            with torch.autocast(
-                device_type=model.device.type, enabled=params.use_fp16
-            ):
+            with torch.cuda.amp.autocast(enabled=params.use_fp16):
                 loss, _ = compute_loss(
                     params=params,
                     model=model,


### PR DESCRIPTION
I am trying half precision training on our pruned rnnt recipe according to the documents here (https://pytorch.org/docs/stable/notes/amp_examples.html).

Now, the training runs normally,  I can run it with `max-duration = 550`, and it takes about 1 hour 10 minutes to finish one epoch with 4 GPUs (for full precision training with `max-duration = 300`, this takes around 2 hours). 

It seems that the loss values are a little larger than the full precision training (at the beginning of epoch 2, 0.13 vs. 0.18). Here is the tensorboard: https://tensorboard.dev/experiment/pZgHoziMSXaoZxM6zhaoWA/#scalars

Corresponding fixes in k2:  https://github.com/k2-fsa/k2/pull/943

**[edit]:** Oops, the training has been unstable at the middle of epoch 2 ...