### PR TITLE
Don't use a lambda for dataloader's worker_init_fn.

### DIFF
--- a/egs/librispeech/ASR/tdnn_lstm_ctc/asr_datamodule.py
+++ b/egs/librispeech/ASR/tdnn_lstm_ctc/asr_datamodule.py
@@ -42,11 +42,11 @@ from icefall.utils import str2bool
 
 
 class _SeedWorkers:
+    def __init__(self, seed: int):
+        self.seed = seed
+
     def __call__(self, worker_id: int):
-        # 'seed' is derived from the current random state, which will have
-        # previously been set in the main process.
-        seed = torch.randint(0, 100000, ()).item()
-        fix_random_seed(seed + worker_id)
+        fix_random_seed(self.seed + worker_id)
 
 
 class LibriSpeechAsrDataModule:
@@ -311,13 +311,18 @@ class LibriSpeechAsrDataModule:
             logging.info("Loading sampler state dict")
             train_sampler.load_state_dict(sampler_state_dict)
 
+        # 'seed' is derived from the current random state, which will have
+        # previously been set in the main process.
+        seed = torch.randint(0, 100000, ()).item()
+        worker_init_fn = _SeedWorkers(seed)
+
         train_dl = DataLoader(
             train,
             sampler=train_sampler,
             batch_size=None,
             num_workers=self.args.num_workers,
             persistent_workers=False,
-            worker_init_fn=_SeedWorkers(),
+            worker_init_fn=worker_init_fn,
         )
 
         return train_dl

--- a/egs/librispeech/ASR/tdnn_lstm_ctc/asr_datamodule.py
+++ b/egs/librispeech/ASR/tdnn_lstm_ctc/asr_datamodule.py
@@ -41,6 +41,14 @@ from torch.utils.data import DataLoader
 from icefall.utils import str2bool
 
 
+class _SeedWorkers:
+    def __call__(self, worker_id: int):
+        # 'seed' is derived from the current random state, which will have
+        # previously been set in the main process.
+        seed = torch.randint(0, 100000, ()).item()
+        fix_random_seed(seed + worker_id)
+
+
 class LibriSpeechAsrDataModule:
     """
     DataModule for k2 ASR experiments.
@@ -303,20 +311,13 @@ class LibriSpeechAsrDataModule:
             logging.info("Loading sampler state dict")
             train_sampler.load_state_dict(sampler_state_dict)
 
-        # 'seed' is derived from the current random state, which will have
-        # previously been set in the main process.
-        seed = torch.randint(0, 100000, ()).item()
-
-        def worker_init_fn(worker_id: int):
-            fix_random_seed(seed + worker_id)
-
         train_dl = DataLoader(
             train,
             sampler=train_sampler,
             batch_size=None,
             num_workers=self.args.num_workers,
             persistent_workers=False,
-            worker_init_fn=worker_init_fn,
+            worker_init_fn=_SeedWorkers(),
         )
 
         return train_dl


### PR DESCRIPTION
From 
https://pytorch.org/docs/stable/data.html

<img width="758" alt="Screen Shot 2022-03-31 at 8 23 23 PM" src="https://user-images.githubusercontent.com/5284924/161053828-e0067f14-d866-4d97-a874-0b8fced76800.png">

This PR fixes the following error during DDP training:
```
  File "/usr/lib/python3.8/multiprocessing/context.py", line 283, in _Popen
    return Popen(process_obj)
  File "/usr/lib/python3.8/multiprocessing/popen_spawn_posix.py", line 32, in __init__
    super().__init__(process_obj)
  File "/usr/lib/python3.8/multiprocessing/popen_fork.py", line 19, in __init__
    self._launch(process_obj)
  File "/usr/lib/python3.8/multiprocessing/popen_spawn_posix.py", line 47, in _launch
    reduction.dump(process_obj, fp)
  File "/usr/lib/python3.8/multiprocessing/reduction.py", line 60, in dump
    ForkingPickler(file, protocol).dump(obj)
AttributeError: Can't pickle local object 'LibriSpeechAsrDataModule.train_dataloaders.<locals>.worker_init_fn'
```