### PR TITLE
Modify icefall/__init__.py.

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -13,4 +13,5 @@ per-file-ignores =
 exclude =
   .git,
   **/data/**,
-  icefall/shared/make_kn_lm.py
+  icefall/shared/make_kn_lm.py,
+  icefall/__init__.py

--- a/icefall/__init__.py
+++ b/icefall/__init__.py
@@ -1,0 +1,7 @@
+from .utils import AttributeDict, MetricsTracker
+from .utils import add_eos, add_sos, concat, encode_supervisions, \
+    get_alignments, get_executor, get_texts, l1_norm, l2_norm, linf_norm, \
+    load_alignments, make_pad_mask, measure_gradient_norms, \
+    measure_weight_norms, optim_step_and_measure_param_change, \
+    save_alignments, setup_logger, store_transcripts, str2bool, \
+    write_error_stats

--- a/icefall/__init__.py
+++ b/icefall/__init__.py
@@ -1,7 +1,24 @@
-from .utils import AttributeDict, MetricsTracker
-from .utils import add_eos, add_sos, concat, encode_supervisions, \
-    get_alignments, get_executor, get_texts, l1_norm, l2_norm, linf_norm, \
-    load_alignments, make_pad_mask, measure_gradient_norms, \
-    measure_weight_norms, optim_step_and_measure_param_change, \
-    save_alignments, setup_logger, store_transcripts, str2bool, \
-    write_error_stats
+from .utils import (
+    AttributeDict,
+    MetricsTracker,
+    add_eos,
+    add_sos,
+    concat,
+    encode_supervisions,
+    get_alignments,
+    get_executor,
+    get_texts,
+    l1_norm,
+    l2_norm,
+    linf_norm,
+    load_alignments,
+    make_pad_mask,
+    measure_gradient_norms,
+    measure_weight_norms,
+    optim_step_and_measure_param_change,
+    save_alignments,
+    setup_logger,
+    store_transcripts,
+    str2bool,
+    write_error_stats,
+)


### PR DESCRIPTION
Modify icefall/__init__.py to import common functions and classes defined in icefall/utils.py. Hence we can directly import them from `icefall` instead of `icefall.utils`.