### PR TITLE
Save batch to disk on OOM.

### DIFF
--- a/egs/librispeech/ASR/pruned_transducer_stateless2/train.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless2/train.py
@@ -670,25 +670,30 @@ def train_one_epoch(
         params.batch_idx_train += 1
         batch_size = len(batch["supervisions"]["text"])
 
-        with torch.cuda.amp.autocast(enabled=params.use_fp16):
-            loss, loss_info = compute_loss(
-                params=params,
-                model=model,
-                sp=sp,
-                batch=batch,
-                is_training=True,
-                warmup=(params.batch_idx_train / params.model_warm_step),
-            )
-        # summary stats
-        tot_loss = (tot_loss * (1 - 1 / params.reset_interval)) + loss_info
+        try:
+            with torch.cuda.amp.autocast(enabled=params.use_fp16):
+                loss, loss_info = compute_loss(
+                    params=params,
+                    model=model,
+                    sp=sp,
+                    batch=batch,
+                    is_training=True,
+                    warmup=(params.batch_idx_train / params.model_warm_step),
+                )
+            # summary stats
+            tot_loss = (tot_loss * (1 - 1 / params.reset_interval)) + loss_info
 
-        # NOTE: We use reduction==sum and loss is computed over utterances
-        # in the batch and there is no normalization to it so far.
-        scaler.scale(loss).backward()
-        scheduler.step_batch(params.batch_idx_train)
-        scaler.step(optimizer)
-        scaler.update()
-        optimizer.zero_grad()
+            # NOTE: We use reduction==sum and loss is computed over utterances
+            # in the batch and there is no normalization to it so far.
+            scaler.scale(loss).backward()
+            scheduler.step_batch(params.batch_idx_train)
+            scaler.step(optimizer)
+            scaler.update()
+            optimizer.zero_grad()
+        except RuntimeError as e:
+            if "CUDA out of memory" in str(e):
+                display_and_save_batch(batch, params=params, sp=sp)
+            raise
 
         if params.print_diagnostics and batch_idx == 5:
             return
@@ -933,6 +938,39 @@ def run(rank, world_size, args):
         cleanup_dist()
 
 
+def display_and_save_batch(
+    batch: dict,
+    params: AttributeDict,
+    sp: spm.SentencePieceProcessor,
+) -> None:
+    """Display the batch statistics and save the batch into disk.
+
+    Args:
+      batch:
+        A batch of data. See `lhotse.dataset.K2SpeechRecognitionDataset()`
+        for the content in it.
+      params:
+        Parameters for training. See :func:`get_params`.
+      sp:
+        The BPE model.
+    """
+    from lhotse.utils import uuid4
+
+    filename = f"{params.exp_dir}/batch-{uuid4()}.pt"
+    logging.info(f"Saving batch to {filename}")
+    torch.save(batch, filename)
+
+    supervisions = batch["supervisions"]
+    features = batch["inputs"]
+    cuts = supervisions["cut"]
+
+    logging.info(f"features shape: {features.shape}")
+
+    y = sp.encode(supervisions["text"], out_type=int)
+    num_tokens = sum(len(i) for i in y)
+    logging.info(f"num tokens: {num_tokens}")
+
+
 def scan_pessimistic_batches_for_oom(
     model: nn.Module,
     train_dl: torch.utils.data.DataLoader,
@@ -973,6 +1011,7 @@ def scan_pessimistic_batches_for_oom(
                     f"Failing criterion: {criterion} "
                     f"(={crit_values[criterion]}) ..."
                 )
+                display_and_save_batch(batch, params=params, sp=sp)
             raise
 
 

--- a/egs/librispeech/ASR/pruned_transducer_stateless2/train.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless2/train.py
@@ -156,15 +156,16 @@ def get_parser():
         "--initial-lr",
         type=float,
         default=0.003,
-        help="The initial learning rate.  This value should not need to be changed.",
+        help="The initial learning rate.  This value should not need to "
+        "be changed.",
     )
 
     parser.add_argument(
         "--lr-batches",
         type=float,
         default=5000,
-        help="""Number of steps that affects how rapidly the learning rate decreases.
-        We suggest not to change this.""",
+        help="""Number of steps that affects how rapidly the learning rate
+        decreases. We suggest not to change this.""",
     )
 
     parser.add_argument(
@@ -962,7 +963,6 @@ def display_and_save_batch(
 
     supervisions = batch["supervisions"]
     features = batch["inputs"]
-    cuts = supervisions["cut"]
 
     logging.info(f"features shape: {features.shape}")
 

--- a/egs/librispeech/ASR/pruned_transducer_stateless2/train.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless2/train.py
@@ -691,9 +691,8 @@ def train_one_epoch(
             scaler.step(optimizer)
             scaler.update()
             optimizer.zero_grad()
-        except RuntimeError as e:
-            if "CUDA out of memory" in str(e):
-                display_and_save_batch(batch, params=params, sp=sp)
+        except:
+            display_and_save_batch(batch, params=params, sp=sp)
             raise
 
         if params.print_diagnostics and batch_idx == 5:

--- a/egs/librispeech/ASR/pruned_transducer_stateless2/train.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless2/train.py
@@ -691,7 +691,7 @@ def train_one_epoch(
             scaler.step(optimizer)
             scaler.update()
             optimizer.zero_grad()
-        except:
+        except:  # noqa
             display_and_save_batch(batch, params=params, sp=sp)
             raise
 


### PR DESCRIPTION
See https://github.com/k2-fsa/icefall/issues/247#issuecomment-1116929465

> @csukuangfj I am thinking we should just make it the default that it prints out some details of the batch (e.g. dimensions and sentence-lengths at least; or perhaps the entire object), when we get an OOM error. This will make things like this easier to debug.

This PR prints out the T and U of the batch on CUDA OOM and also saves the batch to disk that can be loaded later using `torch.load`.

---

## Example outpus

### Single GPU training (world size == 1)

```
2022-05-05 12:33:52,875 INFO [train.py:983] Sanity check -- see if any of the batches in epoch 0 would cause OOM.
2022-05-05 12:33:54,767 ERROR [train.py:1007] Your GPU ran out of memory with the current max_duration setting. We recommend decreasing max_duration
and trying again.
Failing criterion: single_longest_cut (=19.985) ...
2022-05-05 12:33:54,767 INFO [train.py:961] Saving batch to pruned_transducer_stateless2/exp/batch-0f1259e0-a18f-f6b6-b535-106e122c9a56.pt
2022-05-05 12:33:54,838 INFO [train.py:967] features shape: torch.Size([40, 1999, 80])
2022-05-05 12:33:54,841 INFO [train.py:971] num tokens: 3544
Traceback (most recent call last):
.......
RuntimeError: CUDA out of memory. Tried to allocate 304.00 MiB (GPU 0; 31.75 GiB total capacity; 18.20 GiB already allocated; 131.50 MiB free; 18.33
GiB reserved in total by PyTorch) If reserved memory is >> allocated memory try setting max_split_size_mb to avoid fragmentation.  See documentation
for Memory Management and PYTORCH_CUDA_ALLOC_CONF
```

### Multi-GPU training (world size == 2)
```
2022-05-05 12:30:41,800 INFO [train.py:983] (0/2) Sanity check -- see if any of the batches in epoch 0 would cause OOM.
2022-05-05 12:30:43,578 ERROR [train.py:1007] (0/2) Your GPU ran out of memory with the current max_duration setting. We recommend decreasing max_dur
ation and trying again.
Failing criterion: single_longest_cut (=19.985) ...
2022-05-05 12:30:43,579 INFO [train.py:961] (0/2) Saving batch to pruned_transducer_stateless2/exp/batch-0f1259e0-a18f-f6b6-b535-106e122c9a56.pt
2022-05-05 12:30:43,654 INFO [train.py:967] (0/2) features shape: torch.Size([40, 1999, 80])
2022-05-05 12:30:43,657 INFO [train.py:971] (0/2) num tokens: 3544
2022-05-05 12:30:43,703 ERROR [train.py:1007] (1/2) Your GPU ran out of memory with the current max_duration setting. We recommend decreasing max_dur
ation and trying again.
Failing criterion: single_longest_cut (=19.57225) ...
2022-05-05 12:30:43,704 INFO [train.py:961] (1/2) Saving batch to pruned_transducer_stateless2/exp/batch-405cacec-8774-09a9-77d2-1e02ff01cf99.pt
2022-05-05 12:30:43,765 INFO [train.py:967] (1/2) features shape: torch.Size([40, 1957, 80])
2022-05-05 12:30:43,768 INFO [train.py:971] (1/2) num tokens: 3536
Traceback (most recent call last):
...
...
RuntimeError: CUDA out of memory. Tried to allocate 608.00 MiB (GPU 0; 31.75 GiB total capacity; 17.90 GiB already allocated; 365.50 MiB free; 18.04 GiB reserved in total by PyTorch)
 If reserved memory is >> allocated memory try setting max_split_size_mb to avoid fragmentation.  See documentation for Memory Management and PYTORCH_CUDA_ALLOC_CONF
```
```