### PR TITLE
[egs] Add prefix when reading manifests due to recent lhotse changes

### DIFF
--- a/egs/aishell/ASR/local/compute_fbank_aishell.py
+++ b/egs/aishell/ASR/local/compute_fbank_aishell.py
@@ -53,7 +53,7 @@ def compute_fbank_aishell(num_mel_bins: int = 80):
         "test",
     )
     manifests = read_manifests_if_cached(
-        dataset_parts=dataset_parts, output_dir=src_dir
+        prefix="aishell", dataset_parts=dataset_parts, output_dir=src_dir
     )
     assert manifests is not None
 

--- a/egs/aishell/ASR/local/process_aidatatang_200zh.py
+++ b/egs/aishell/ASR/local/process_aidatatang_200zh.py
@@ -37,6 +37,7 @@ def preprocess_aidatatang_200zh():
     manifests = read_manifests_if_cached(
         dataset_parts=dataset_parts,
         output_dir=src_dir,
+        prefix="aidatatang"
     )
     assert len(manifests) > 0
 

--- a/egs/aishell/ASR/local/process_aidatatang_200zh.py
+++ b/egs/aishell/ASR/local/process_aidatatang_200zh.py
@@ -35,9 +35,7 @@ def preprocess_aidatatang_200zh():
 
     logging.info("Loading manifest")
     manifests = read_manifests_if_cached(
-        dataset_parts=dataset_parts,
-        output_dir=src_dir,
-        prefix="aidatatang"
+        dataset_parts=dataset_parts, output_dir=src_dir, prefix="aidatatang"
     )
     assert len(manifests) > 0
 

--- a/egs/gigaspeech/ASR/local/compute_fbank_musan.py
+++ b/egs/gigaspeech/ASR/local/compute_fbank_musan.py
@@ -53,7 +53,7 @@ def compute_fbank_musan():
     )
 
     manifests = read_manifests_if_cached(
-        dataset_parts=dataset_parts, output_dir=src_dir
+        prefix="musan", dataset_parts=dataset_parts, output_dir=src_dir
     )
     assert manifests is not None
 

--- a/egs/librispeech/ASR/local/compute_fbank_librispeech.py
+++ b/egs/librispeech/ASR/local/compute_fbank_librispeech.py
@@ -57,7 +57,7 @@ def compute_fbank_librispeech():
         "train-other-500",
     )
     manifests = read_manifests_if_cached(
-        dataset_parts=dataset_parts, output_dir=src_dir
+        prefix="librispeech", dataset_parts=dataset_parts, output_dir=src_dir
     )
     assert manifests is not None
 

--- a/egs/librispeech/ASR/local/compute_fbank_musan.py
+++ b/egs/librispeech/ASR/local/compute_fbank_musan.py
@@ -53,7 +53,7 @@ def compute_fbank_musan():
         "noise",
     )
     manifests = read_manifests_if_cached(
-        dataset_parts=dataset_parts, output_dir=src_dir
+        prefix="musan", dataset_parts=dataset_parts, output_dir=src_dir
     )
     assert manifests is not None
 

--- a/egs/spgispeech/ASR/local/compute_fbank_musan.py
+++ b/egs/spgispeech/ASR/local/compute_fbank_musan.py
@@ -65,7 +65,7 @@ def compute_fbank_musan():
         "noise",
     )
     manifests = read_manifests_if_cached(
-        dataset_parts=dataset_parts, output_dir=src_dir
+        prefix="musan", dataset_parts=dataset_parts, output_dir=src_dir
     )
     assert manifests is not None
 

--- a/egs/tedlium3/ASR/local/compute_fbank_tedlium.py
+++ b/egs/tedlium3/ASR/local/compute_fbank_tedlium.py
@@ -53,7 +53,7 @@ def compute_fbank_tedlium():
     )
 
     manifests = read_manifests_if_cached(
-        dataset_parts=dataset_parts, output_dir=src_dir
+        prefix="tedlium", dataset_parts=dataset_parts, output_dir=src_dir
     )
     assert manifests is not None
 

--- a/egs/timit/ASR/local/compute_fbank_timit.py
+++ b/egs/timit/ASR/local/compute_fbank_timit.py
@@ -54,7 +54,7 @@ def compute_fbank_timit():
         "TEST",
     )
     manifests = read_manifests_if_cached(
-        dataset_parts=dataset_parts, output_dir=src_dir
+        prefix="timit", dataset_parts=dataset_parts, output_dir=src_dir
     )
     assert manifests is not None
 

--- a/egs/wenetspeech/ASR/local/preprocess_wenetspeech.py
+++ b/egs/wenetspeech/ASR/local/preprocess_wenetspeech.py
@@ -62,6 +62,7 @@ def preprocess_wenet_speech():
         dataset_parts=dataset_parts,
         output_dir=src_dir,
         suffix="jsonl.gz",
+        prefix="wenetspeech",
     )
     assert manifests is not None
 


### PR DESCRIPTION
This fixes an issue that appeared following a recent lhotse change normalizing output path names for recipes (https://github.com/lhotse-speech/lhotse/pull/712). I didn't test all of them (only librispeech incl. musan), but I think it affects all the scripts I changed.