### PR TITLE
Fix Emformer for torchscript using torch 1.6.0

### DIFF
--- a/egs/librispeech/ASR/pruned_stateless_emformer_rnnt2/emformer.py
+++ b/egs/librispeech/ASR/pruned_stateless_emformer_rnnt2/emformer.py
@@ -296,7 +296,7 @@ class Emformer(EncoderInterface):
           Return the initial state of each layer. NOTE: the returned
           tensors are on the given device. `len(ans) == num_emformer_layers`.
         """
-        if self._init_state:
+        if len(self._init_state) > 0:
             # Note(fangjun): It is OK to share the init state as it is
             # not going to be modified by the model
             return self._init_state


### PR DESCRIPTION
torchscript in torch 1.6.0 and 1.7.1 complains that it cannot convert list-of-list to bool.

This PR fixes that.