### PR TITLE
Fix exporting emformer with torchscript using torch 1.6.0

### DIFF
--- a/egs/librispeech/ASR/pruned_stateless_emformer_rnnt2/emformer.py
+++ b/egs/librispeech/ASR/pruned_stateless_emformer_rnnt2/emformer.py
@@ -202,6 +202,7 @@ class Emformer(EncoderInterface):
         )
         self.log_eps = math.log(1e-10)
 
+        self._has_init_state = False
         self._init_state = torch.jit.Attribute([], List[List[torch.Tensor]])
 
     def forward(
@@ -296,7 +297,7 @@ class Emformer(EncoderInterface):
           Return the initial state of each layer. NOTE: the returned
           tensors are on the given device. `len(ans) == num_emformer_layers`.
         """
-        if len(self._init_state) > 0:
+        if self._has_init_state:
             # Note(fangjun): It is OK to share the init state as it is
             # not going to be modified by the model
             return self._init_state
@@ -308,6 +309,7 @@ class Emformer(EncoderInterface):
             s = layer._init_state(batch_size=batch_size, device=device)
             ans.append(s)
 
+        self._has_init_state = True
         self._init_state = ans
 
         return ans


### PR DESCRIPTION
See https://github.com/k2-fsa/icefall/pull/401#discussion_r890071489

Before #401, it threw the following error for torch 1.6.0 and 1.7.1

## Error for torch 1.6.0
```
  File "/ceph-fj/fangjun/py38-1.6.0/lib/python3.8/site-packages/torch/jit/__init__.py", line 1900, in _construct
    init_fn(script_module)
  File "/ceph-fj/fangjun/py38-1.6.0/lib/python3.8/site-packages/torch/jit/_recursive.py", line 353, in init_fn
    scripted = create_script_module_impl(orig_value, sub_concrete_type, infer_methods_to_compile)
  File "/ceph-fj/fangjun/py38-1.6.0/lib/python3.8/site-packages/torch/jit/_recursive.py", line 376, in create_script_module_impl
    create_methods_from_stubs(concrete_type, stubs)
  File "/ceph-fj/fangjun/py38-1.6.0/lib/python3.8/site-packages/torch/jit/_recursive.py", line 292, in create_methods_from_stubs
    concrete_type._create_methods(defs, rcbs, defaults)
RuntimeError:
Could not cast value of type List[List[Tensor]] to bool:
  File "/ceph-fj/fangjun/open-source-2/icefall-streaming-2/egs/librispeech/ASR/pruned_stateless_emformer_rnnt2/emformer.py", line 301
        """
        #  if self.has_init_state:
        if self._init_state:
           ~~~~~~~~~~~~~~~~ <--- HERE
            # Note(fangjun): It is OK to share the init state as it is
            # not going to be modified by the model
```

## Error for torch 1.7.1
```
  File "/ceph-fj/fangjun/py38-1.7.1/lib/python3.8/site-packages/torch/jit/_recursive.py", line 388, in init_fn
    scripted = create_script_module_impl(orig_value, sub_concrete_type, stubs_fn)
  File "/ceph-fj/fangjun/py38-1.7.1/lib/python3.8/site-packages/torch/jit/_recursive.py", line 410, in create_script_module_impl
    create_methods_and_properties_from_stubs(concrete_type, method_stubs, property_stubs)
  File "/ceph-fj/fangjun/py38-1.7.1/lib/python3.8/site-packages/torch/jit/_recursive.py", line 304, in create_methods_and_properties_from_stubs
    concrete_type._create_methods_and_properties(property_defs, property_rcbs, method_defs, method_rcbs, method_defaults)
RuntimeError:
Could not cast value of type List[List[Tensor]] to bool:
  File "/ceph-fj/fangjun/open-source-2/icefall-streaming-2/egs/librispeech/ASR/pruned_stateless_emformer_rnnt2/emformer.py", line 301
        """
        #  if self.has_init_state:
        if self._init_state:
           ~~~~~~~~~~~~~~~~ <--- HERE
            # Note(fangjun): It is OK to share the init state as it is
            # not going to be modified by the model
```