### PR TITLE
Replace LilcomChunkyWriter with ChunkedLilcomHdf5Writer.

### DIFF
--- a/egs/aishell/ASR/local/compute_fbank_aidatatang_200zh.py
+++ b/egs/aishell/ASR/local/compute_fbank_aidatatang_200zh.py
@@ -29,7 +29,7 @@ import os
 from pathlib import Path
 
 import torch
-from lhotse import CutSet, Fbank, FbankConfig, LilcomChunkyWriter
+from lhotse import ChunkedLilcomHdf5Writer, CutSet, Fbank, FbankConfig
 from lhotse.recipes.utils import read_manifests_if_cached
 
 from icefall.utils import get_executor
@@ -90,7 +90,7 @@ def compute_fbank_aidatatang_200zh(num_mel_bins: int = 80):
                 # when an executor is specified, make more partitions
                 num_jobs=num_jobs if ex is None else 80,
                 executor=ex,
-                storage_type=LilcomChunkyWriter,
+                storage_type=ChunkedLilcomHdf5Writer,
             )
 
             cut_set.to_file(output_dir / f"{prefix}_cuts_{partition}.{suffix}")

--- a/egs/aishell/ASR/local/compute_fbank_aishell.py
+++ b/egs/aishell/ASR/local/compute_fbank_aishell.py
@@ -29,7 +29,7 @@ import os
 from pathlib import Path
 
 import torch
-from lhotse import CutSet, Fbank, FbankConfig, LilcomChunkyWriter
+from lhotse import ChunkedLilcomHdf5Writer, CutSet, Fbank, FbankConfig
 from lhotse.recipes.utils import read_manifests_if_cached
 
 from icefall.utils import get_executor
@@ -86,7 +86,7 @@ def compute_fbank_aishell(num_mel_bins: int = 80):
                 # when an executor is specified, make more partitions
                 num_jobs=num_jobs if ex is None else 80,
                 executor=ex,
-                storage_type=LilcomChunkyWriter,
+                storage_type=ChunkedLilcomHdf5Writer,
             )
             cut_set.to_file(output_dir / f"{prefix}_cuts_{partition}.{suffix}")
 

--- a/egs/librispeech/ASR/local/compute_fbank_librispeech.py
+++ b/egs/librispeech/ASR/local/compute_fbank_librispeech.py
@@ -28,7 +28,7 @@ import os
 from pathlib import Path
 
 import torch
-from lhotse import CutSet, Fbank, FbankConfig, LilcomChunkyWriter
+from lhotse import ChunkedLilcomHdf5Writer, CutSet, Fbank, FbankConfig
 from lhotse.recipes.utils import read_manifests_if_cached
 
 from icefall.utils import get_executor
@@ -91,7 +91,7 @@ def compute_fbank_librispeech():
                 # when an executor is specified, make more partitions
                 num_jobs=num_jobs if ex is None else 80,
                 executor=ex,
-                storage_type=LilcomChunkyWriter,
+                storage_type=ChunkedLilcomHdf5Writer,
             )
             cut_set.to_file(output_dir / cuts_filename)
 

--- a/egs/librispeech/ASR/local/compute_fbank_musan.py
+++ b/egs/librispeech/ASR/local/compute_fbank_musan.py
@@ -28,7 +28,7 @@ import os
 from pathlib import Path
 
 import torch
-from lhotse import CutSet, Fbank, FbankConfig, LilcomChunkyWriter, combine
+from lhotse import ChunkedLilcomHdf5Writer, CutSet, Fbank, FbankConfig, combine
 from lhotse.recipes.utils import read_manifests_if_cached
 
 from icefall.utils import get_executor
@@ -92,7 +92,7 @@ def compute_fbank_musan():
                 storage_path=f"{output_dir}/musan_feats",
                 num_jobs=num_jobs if ex is None else 80,
                 executor=ex,
-                storage_type=LilcomChunkyWriter,
+                storage_type=ChunkedLilcomHdf5Writer,
             )
         )
         musan_cuts.to_file(musan_cuts_path)

--- a/egs/spgispeech/ASR/local/compute_fbank_musan.py
+++ b/egs/spgispeech/ASR/local/compute_fbank_musan.py
@@ -27,7 +27,7 @@ import logging
 from pathlib import Path
 
 import torch
-from lhotse import CutSet, LilcomChunkyWriter, combine
+from lhotse import ChunkedLilcomHdf5Writer, CutSet, combine
 from lhotse.features.kaldifeat import (
     KaldifeatFbank,
     KaldifeatFbankConfig,
@@ -91,7 +91,7 @@ def compute_fbank_musan():
             storage_path=output_dir / "feats_musan",
             batch_duration=500,
             num_workers=4,
-            storage_type=LilcomChunkyWriter,
+            storage_type=ChunkedLilcomHdf5Writer,
         )
     )
 

--- a/egs/spgispeech/ASR/local/compute_fbank_spgispeech.py
+++ b/egs/spgispeech/ASR/local/compute_fbank_spgispeech.py
@@ -27,7 +27,7 @@ import logging
 from pathlib import Path
 
 import torch
-from lhotse import LilcomChunkyWriter, load_manifest_lazy
+from lhotse import ChunkedLilcomHdf5Writer, load_manifest_lazy
 from lhotse.features.kaldifeat import (
     KaldifeatFbank,
     KaldifeatFbankConfig,
@@ -118,7 +118,7 @@ def compute_fbank_spgispeech(args):
                 storage_path=output_dir / f"feats_train_{idx}",
                 batch_duration=500,
                 num_workers=4,
-                storage_type=LilcomChunkyWriter,
+                storage_type=ChunkedLilcomHdf5Writer,
             )
             cs.to_file(cuts_train_idx_path)
 
@@ -137,7 +137,7 @@ def compute_fbank_spgispeech(args):
                 manifest_path=src_dir / f"cuts_{partition}.jsonl.gz",
                 batch_duration=500,
                 num_workers=4,
-                storage_type=LilcomChunkyWriter,
+                storage_type=ChunkedLilcomHdf5Writer,
             )
 
 

--- a/egs/timit/ASR/local/compute_fbank_timit.py
+++ b/egs/timit/ASR/local/compute_fbank_timit.py
@@ -29,7 +29,7 @@ import os
 from pathlib import Path
 
 import torch
-from lhotse import CutSet, Fbank, FbankConfig, LilcomChunkyWriter
+from lhotse import ChunkedLilcomHdf5Writer, CutSet, Fbank, FbankConfig
 from lhotse.recipes.utils import read_manifests_if_cached
 
 from icefall.utils import get_executor
@@ -88,7 +88,7 @@ def compute_fbank_timit():
                 # when an executor is specified, make more partitions
                 num_jobs=num_jobs if ex is None else 80,
                 executor=ex,
-                storage_type=LilcomChunkyWriter,
+                storage_type=ChunkedLilcomHdf5Writer,
             )
             cut_set.to_file(cuts_file)
 

--- a/egs/yesno/ASR/local/compute_fbank_yesno.py
+++ b/egs/yesno/ASR/local/compute_fbank_yesno.py
@@ -12,7 +12,7 @@ import os
 from pathlib import Path
 
 import torch
-from lhotse import CutSet, Fbank, FbankConfig, LilcomChunkyWriter
+from lhotse import ChunkedLilcomHdf5Writer, CutSet, Fbank, FbankConfig
 from lhotse.recipes.utils import read_manifests_if_cached
 
 from icefall.utils import get_executor
@@ -74,7 +74,7 @@ def compute_fbank_yesno():
                 # when an executor is specified, make more partitions
                 num_jobs=num_jobs if ex is None else 1,  # use one job
                 executor=ex,
-                storage_type=LilcomChunkyWriter,
+                storage_type=ChunkedLilcomHdf5Writer,
             )
             cut_set.to_file(cuts_file)
 


### PR DESCRIPTION
It seems that there are issues with LilcomChunkyWriter in the multi-threaded scenario.

See
- https://github.com/k2-fsa/icefall/discussions/391#discussioncomment-2870627
- https://github.com/k2-fsa/icefall/discussions/391#discussioncomment-2885434
- https://github.com/lhotse-speech/lhotse/issues/607#issue-1157450209
- https://github.com/lhotse-speech/lhotse/issues/607#issuecomment-1148373507

One advantage of using ChunkedLilcomHdf5Writer is that it does not need to compete for locks in
the case of multiple threads.
