### PR TITLE
Add multi_quantization  to requirements.txt

### DIFF
--- a/.github/scripts/run-aishell-pruned-transducer-stateless3-2022-06-20.sh
+++ b/.github/scripts/run-aishell-pruned-transducer-stateless3-2022-06-20.sh
@@ -27,7 +27,7 @@ soxi $repo/test_wavs/*.wav
 ls -lh $repo/test_wavs/*.wav
 
 pushd $repo/exp
-ln -s pretrained-epoch-29-avg-5-torch-1.10.pt pretrained.pt
+ln -s pretrained-epoch-29-avg-5-torch-1.10.0.pt pretrained.pt
 popd
 
 for sym in 1 2 3; do

--- a/.github/scripts/run-librispeech-pruned-transducer-stateless5-2022-05-13.sh
+++ b/.github/scripts/run-librispeech-pruned-transducer-stateless5-2022-05-13.sh
@@ -82,6 +82,7 @@ if [[ x"${GITHUB_EVENT_NAME}" == x"schedule" || x"${GITHUB_EVENT_LABEL_NAME}" ==
 
     ./pruned_transducer_stateless5/decode.py \
       --decoding-method $method \
+      --use-averaged-model 0 \
       --epoch 999 \
       --avg 1 \
       --max-duration $max_duration \

--- a/.github/scripts/run-librispeech-pruned-transducer-stateless5-2022-05-13.sh
+++ b/.github/scripts/run-librispeech-pruned-transducer-stateless5-2022-05-13.sh
@@ -37,7 +37,7 @@ for sym in 1 2 3; do
     --nhead 8 \
     --encoder-dim 512 \
     --decoder-dim 512 \
-    --joiner-dim 512
+    --joiner-dim 512 \
     $repo/test_wavs/1089-134686-0001.wav \
     $repo/test_wavs/1221-135766-0001.wav \
     $repo/test_wavs/1221-135766-0002.wav

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -19,3 +19,4 @@ kaldialign==0.2
 sentencepiece==0.1.96
 tensorboard==2.8.0
 typeguard==2.13.3
+multi_quantization

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ kaldialign
 sentencepiece>=0.1.96
 tensorboard
 typeguard
+multi_quantization


### PR DESCRIPTION
Someone reports the following error
```
./pruned_transducer_stateless6/export.py --jit=1
Traceback (most recent call last):
  File "./pruned_transducer_stateless6/export.py", line 52, in <module>
    from train import get_params, get_transducer_model
  File "/xxx/k2-fsa/icefall/egs/librispeech/ASR/pruned_transducer_stateless6/train.py", line 80, in <module>
    from model import Transducer
  File "/xxx/k2-fsa/icefall/egs/librispeech/ASR/pruned_transducer_stateless6/model.py", line 26, in <module>
    from quantization.prediction import JointCodebookLoss
ModuleNotFoundError: No module named 'quantization'
```

and he tries to use
```
pip install quantization
```
but failed.

This PR fixes that.