### PR TITLE
Add RNN-LM rescoring in fast beam search

### DIFF
--- a/egs/librispeech/ASR/pruned_transducer_stateless2/beam_search.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless2/beam_search.py
@@ -46,7 +46,7 @@ def fast_beam_search_one_best(
       model:
         An instance of `Transducer`.
       decoding_graph:
-        Decoding graph used for decoding, may be a TrivialGraph or a HLG.
+        Decoding graph used for decoding, may be a TrivialGraph or a LG.
       encoder_out:
         A tensor of shape (N, T, C) from the encoder.
       encoder_out_lens:
@@ -106,7 +106,7 @@ def fast_beam_search_nbest_LG(
       model:
         An instance of `Transducer`.
       decoding_graph:
-        Decoding graph used for decoding, may be a TrivialGraph or a HLG.
+        Decoding graph used for decoding, may be a TrivialGraph or a LG.
       encoder_out:
         A tensor of shape (N, T, C) from the encoder.
       encoder_out_lens:
@@ -226,7 +226,7 @@ def fast_beam_search_nbest(
       model:
         An instance of `Transducer`.
       decoding_graph:
-        Decoding graph used for decoding, may be a TrivialGraph or a HLG.
+        Decoding graph used for decoding, may be a TrivialGraph or a LG.
       encoder_out:
         A tensor of shape (N, T, C) from the encoder.
       encoder_out_lens:
@@ -311,7 +311,7 @@ def fast_beam_search_nbest_oracle(
       model:
         An instance of `Transducer`.
       decoding_graph:
-        Decoding graph used for decoding, may be a TrivialGraph or a HLG.
+        Decoding graph used for decoding, may be a TrivialGraph or a LG.
       encoder_out:
         A tensor of shape (N, T, C) from the encoder.
       encoder_out_lens:
@@ -397,7 +397,7 @@ def fast_beam_search(
       model:
         An instance of `Transducer`.
       decoding_graph:
-        Decoding graph used for decoding, may be a TrivialGraph or a HLG.
+        Decoding graph used for decoding, may be a TrivialGraph or a LG.
       encoder_out:
         A tensor of shape (N, T, C) from the encoder.
       encoder_out_lens:
@@ -1227,7 +1227,7 @@ def fast_beam_search_with_nbest_rescoring(
       model:
         An instance of `Transducer`.
       decoding_graph:
-        Decoding graph used for decoding, may be a TrivialGraph or a HLG.
+        Decoding graph used for decoding, may be a TrivialGraph or a LG.
       encoder_out:
         A tensor of shape (N, T, C) from the encoder.
       encoder_out_lens:
@@ -1383,7 +1383,7 @@ def fast_beam_search_with_nbest_rnn_rescoring(
       model:
         An instance of `Transducer`.
       decoding_graph:
-        Decoding graph used for decoding, may be a TrivialGraph or a HLG.
+        Decoding graph used for decoding, may be a TrivialGraph or a LG.
       encoder_out:
         A tensor of shape (N, T, C) from the encoder.
       encoder_out_lens:

--- a/egs/librispeech/ASR/pruned_transducer_stateless3/decode.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless3/decode.py
@@ -605,6 +605,7 @@ def decode_one_batch(
             sp=sp,
             word_table=word_table,
             rnn_lm_model=rnn_lm_model,
+            rnn_lm_scale_list=ngram_lm_scale_list,
             use_double_scores=True,
             nbest_scale=params.nbest_scale,
             temperature=params.temperature,

--- a/icefall/decode.py
+++ b/icefall/decode.py
@@ -1006,6 +1006,8 @@ def rescore_with_rnn_lm(
         An FsaVec with axes [utt][state][arc].
       num_paths:
         Number of paths to extract from the given lattice for rescoring.
+      rnn_lm_model:
+        A rnn-lm model used for LM rescoring
       model:
         A transformer model. See the class "Transformer" in
         conformer_ctc/transformer.py for its interface.


### PR DESCRIPTION
The PR adds one decoding methods:

- ```fast_beam_search_with_nbest_rnn_rescoring``` which do a 4-gram rescoring and RNN-LM rescoring

```
For test-clean, WER of different settings are:
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.05_rnn_lm_scale_-0.1	2.02	best for test-clean
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0_rnn_lm_scale_-0.1	2.04
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.01_rnn_lm_scale_-0.1	2.04
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.02_rnn_lm_scale_-0.1	2.04
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.05_rnn_lm_scale_-0.05	2.04
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.02_rnn_lm_scale_-0.1	2.05
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.01_rnn_lm_scale_0	2.05
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.02_rnn_lm_scale_-0.02	2.05
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.05_rnn_lm_scale_-0.02	2.05
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.1_rnn_lm_scale_-0.05	2.05
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0_rnn_lm_scale_-0.02	2.06
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.01_rnn_lm_scale_-0.05	2.06
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.01_rnn_lm_scale_-0.02	2.06
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.02_rnn_lm_scale_-0.05	2.06
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.02_rnn_lm_scale_0	2.06
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.05_rnn_lm_scale_0	2.06
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.05_rnn_lm_scale_0.01	2.06
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.1_rnn_lm_scale_-0.1	2.06
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.1_rnn_lm_scale_0	2.06
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.05_rnn_lm_scale_-0.1	2.07
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.02_rnn_lm_scale_-0.05	2.07
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0_rnn_lm_scale_-0.05	2.07
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0_rnn_lm_scale_0	2.07
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0_rnn_lm_scale_0.01	2.07
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.01_rnn_lm_scale_0.01	2.07
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.02_rnn_lm_scale_-0.2	2.07
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.02_rnn_lm_scale_0.01	2.07
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.02_rnn_lm_scale_0.02	2.07
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.05_rnn_lm_scale_0.02	2.07
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.1_rnn_lm_scale_-0.2	2.07
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.1_rnn_lm_scale_-0.02	2.07
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0_rnn_lm_scale_0.02	2.08
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.01_rnn_lm_scale_-0.2	2.08
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.01_rnn_lm_scale_0.02	2.08
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.05_rnn_lm_scale_-0.2	2.08
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.1_rnn_lm_scale_0.01	2.08
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.1_rnn_lm_scale_0.02	2.08
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.02_rnn_lm_scale_-0.02	2.09
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.02_rnn_lm_scale_0.01	2.09
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.02_rnn_lm_scale_0.02	2.09
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0_rnn_lm_scale_-0.2	2.09
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.05_rnn_lm_scale_-0.05	2.1
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.02_rnn_lm_scale_-0.2	2.1
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.02_rnn_lm_scale_0	2.1
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.05_rnn_lm_scale_0.05	2.1
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.05_rnn_lm_scale_-0.02	2.11
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.05_rnn_lm_scale_0	2.11
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0_rnn_lm_scale_0.05	2.11
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.01_rnn_lm_scale_0.05	2.11
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.1_rnn_lm_scale_0.05	2.11
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.05_rnn_lm_scale_0.01	2.12
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.05_rnn_lm_scale_0.02	2.12
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.02_rnn_lm_scale_0.05	2.12
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.02_rnn_lm_scale_0.05	2.12
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.05_rnn_lm_scale_0.05	2.15
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.05_rnn_lm_scale_-0.2	2.16
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.3_rnn_lm_scale_-0.1	2.16
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.1_rnn_lm_scale_-0.1	2.17
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.1_rnn_lm_scale_-0.05	2.17
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.1_rnn_lm_scale_0.1	2.17
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.1_rnn_lm_scale_-0.02	2.18
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.1_rnn_lm_scale_0	2.18
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.1_rnn_lm_scale_0.01	2.19
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0_rnn_lm_scale_0.1	2.19
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.01_rnn_lm_scale_0.1	2.19
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.02_rnn_lm_scale_0.1	2.19
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.05_rnn_lm_scale_0.1	2.19
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.1_rnn_lm_scale_0.02	2.2
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.02_rnn_lm_scale_0.1	2.2
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.3_rnn_lm_scale_-0.2	2.2
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.3_rnn_lm_scale_-0.05	2.2
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.1_rnn_lm_scale_0.05	2.21
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.05_rnn_lm_scale_0.1	2.21
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.1_rnn_lm_scale_-0.2	2.23
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.3_rnn_lm_scale_-0.02	2.23
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.3_rnn_lm_scale_0.01	2.23
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.3_rnn_lm_scale_0	2.24
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.3_rnn_lm_scale_0.02	2.26
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.1_rnn_lm_scale_0.1	2.27
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.3_rnn_lm_scale_0.05	2.27
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.3_rnn_lm_scale_0.1	2.33
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.5_rnn_lm_scale_-0.2	2.33
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.5_rnn_lm_scale_-0.1	2.33
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.5_rnn_lm_scale_-0.05	2.33
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.5_rnn_lm_scale_-0.02	2.34
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.5_rnn_lm_scale_0	2.35
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.2_rnn_lm_scale_0	2.36
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.5_rnn_lm_scale_0.01	2.36
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.2_rnn_lm_scale_-0.02	2.38
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.2_rnn_lm_scale_0.01	2.38
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.2_rnn_lm_scale_-0.05	2.39
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.5_rnn_lm_scale_0.02	2.39
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.2_rnn_lm_scale_-0.1	2.4
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.2_rnn_lm_scale_0.02	2.4
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.5_rnn_lm_scale_0.05	2.4
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.2_rnn_lm_scale_0.05	2.42
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.5_rnn_lm_scale_0.1	2.42
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.05_rnn_lm_scale_0.3	2.45
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.1_rnn_lm_scale_0.3	2.45
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.3_rnn_lm_scale_-0.5	2.45
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.5_rnn_lm_scale_-0.5	2.45
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.8_rnn_lm_scale_-0.02	2.45
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.8_rnn_lm_scale_-0.1	2.46
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.8_rnn_lm_scale_-0.05	2.46
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.8_rnn_lm_scale_0	2.46
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.8_rnn_lm_scale_0.01	2.46
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.8_rnn_lm_scale_-0.2	2.47
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.8_rnn_lm_scale_0.02	2.47
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.2_rnn_lm_scale_-0.2	2.48
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0_rnn_lm_scale_0.3	2.48
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.01_rnn_lm_scale_0.3	2.48
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.02_rnn_lm_scale_0.3	2.48
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.8_rnn_lm_scale_0.05	2.49
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.3_rnn_lm_scale_0.3	2.5
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.8_rnn_lm_scale_-0.5	2.5
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_1.0_rnn_lm_scale_-0.05	2.5
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_1.0_rnn_lm_scale_-0.02	2.5
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.2_rnn_lm_scale_0.1	2.51
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.02_rnn_lm_scale_0.3	2.51
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_1.0_rnn_lm_scale_-0.1	2.51
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.05_rnn_lm_scale_0.3	2.53
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_1.0_rnn_lm_scale_-0.5	2.53
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_1.0_rnn_lm_scale_-0.2	2.53
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_1.0_rnn_lm_scale_0	2.53
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_1.0_rnn_lm_scale_0.01	2.53
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.8_rnn_lm_scale_0.1	2.54
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_1.0_rnn_lm_scale_0.02	2.54
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_1.0_rnn_lm_scale_0.05	2.54
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_1.0_rnn_lm_scale_0.1	2.55
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.1_rnn_lm_scale_-0.5	2.56
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.05_rnn_lm_scale_-0.5	2.57
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.1_rnn_lm_scale_0.3	2.58
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.01_rnn_lm_scale_-0.5	2.58
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.02_rnn_lm_scale_-0.5	2.58
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.5_rnn_lm_scale_0.3	2.58
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0_rnn_lm_scale_-0.5	2.59
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_1.5_rnn_lm_scale_-0.2	2.59
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_1.5_rnn_lm_scale_-0.1	2.6
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_1.5_rnn_lm_scale_-0.5	2.61
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.02_rnn_lm_scale_-0.5	2.62
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_1.5_rnn_lm_scale_0	2.62
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_1.5_rnn_lm_scale_0.01	2.62
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_1.5_rnn_lm_scale_0.02	2.62
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_1.5_rnn_lm_scale_-0.05	2.63
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_1.5_rnn_lm_scale_0.05	2.63
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_1.5_rnn_lm_scale_0.1	2.63
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_1.5_rnn_lm_scale_-0.02	2.64
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.8_rnn_lm_scale_0.3	2.65
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.05_rnn_lm_scale_-0.5	2.66
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_1.0_rnn_lm_scale_0.3	2.66
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_2.5_rnn_lm_scale_-0.1	2.69
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_1.5_rnn_lm_scale_0.3	2.7
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_2.5_rnn_lm_scale_-0.5	2.7
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_2.5_rnn_lm_scale_-0.2	2.7
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_2.5_rnn_lm_scale_-0.05	2.7
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_2.5_rnn_lm_scale_0	2.7
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_2.5_rnn_lm_scale_0.1	2.7
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.1_rnn_lm_scale_-0.5	2.71
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_2.5_rnn_lm_scale_-0.02	2.71
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_2.5_rnn_lm_scale_0.01	2.71
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_2.5_rnn_lm_scale_0.02	2.71
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_2.5_rnn_lm_scale_0.05	2.71
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_3_rnn_lm_scale_-0.1	2.71
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_3_rnn_lm_scale_-0.2	2.72
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_3_rnn_lm_scale_-0.05	2.72
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_3_rnn_lm_scale_-0.5	2.73
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_3_rnn_lm_scale_-0.02	2.73
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_3_rnn_lm_scale_0	2.73
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_3_rnn_lm_scale_0.01	2.73
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_3_rnn_lm_scale_0.02	2.73
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.3_rnn_lm_scale_0.5	2.74
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_3_rnn_lm_scale_0.05	2.74
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_3_rnn_lm_scale_0.1	2.74
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_2.5_rnn_lm_scale_0.3	2.75
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.5_rnn_lm_scale_0.5	2.76
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.8_rnn_lm_scale_0.5	2.77
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_1.0_rnn_lm_scale_0.5	2.77
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_3_rnn_lm_scale_0.3	2.77
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.2_rnn_lm_scale_0.3	2.78
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.02_rnn_lm_scale_0.5	2.79
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.1_rnn_lm_scale_0.5	2.8
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_1.5_rnn_lm_scale_0.5	2.8
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.01_rnn_lm_scale_0.5	2.81
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.05_rnn_lm_scale_0.5	2.81
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0_rnn_lm_scale_0.5	2.82
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_2.5_rnn_lm_scale_0.5	2.82
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.02_rnn_lm_scale_0.5	2.83
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.2_rnn_lm_scale_-0.5	2.84
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_3_rnn_lm_scale_0.5	2.84
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.05_rnn_lm_scale_0.5	2.85
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.1_rnn_lm_scale_0.5	2.89
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_2.5_rnn_lm_scale_0.8	2.93
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_3_rnn_lm_scale_0.8	2.93
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_1.5_rnn_lm_scale_0.8	2.94
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_1.0_rnn_lm_scale_0.8	2.96
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_3_rnn_lm_scale_1.0	2.97
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.8_rnn_lm_scale_0.8	2.98
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_2.5_rnn_lm_scale_1.0	2.98
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_1.5_rnn_lm_scale_1.0	2.99
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.2_rnn_lm_scale_0.5	3.0
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.5_rnn_lm_scale_0.8	3.01
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_1.0_rnn_lm_scale_1.0	3.04
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.8_rnn_lm_scale_1.0	3.07
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_3_rnn_lm_scale_1.5	3.07
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.3_rnn_lm_scale_0.8	3.08
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_2.5_rnn_lm_scale_1.5	3.09
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.5_rnn_lm_scale_-0.2	3.12
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.5_rnn_lm_scale_1.0	3.12
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.5_rnn_lm_scale_-0.1	3.13
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.5_rnn_lm_scale_-0.05	3.14
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.5_rnn_lm_scale_0.02	3.14
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_1.5_rnn_lm_scale_1.5	3.14
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.5_rnn_lm_scale_0	3.15
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.5_rnn_lm_scale_0.01	3.15
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.5_rnn_lm_scale_-0.02	3.16
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.5_rnn_lm_scale_0.05	3.18
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.1_rnn_lm_scale_0.8	3.18
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.3_rnn_lm_scale_1.0	3.18
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.05_rnn_lm_scale_0.8	3.19
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.5_rnn_lm_scale_0.1	3.2
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_1.0_rnn_lm_scale_1.5	3.2
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.02_rnn_lm_scale_0.8	3.21
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.8_rnn_lm_scale_1.5	3.21
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_3_rnn_lm_scale_2.5	3.21
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.2_rnn_lm_scale_0.8	3.22
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.1_rnn_lm_scale_0.8	3.22
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.05_rnn_lm_scale_0.8	3.22
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.02_rnn_lm_scale_0.8	3.22
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0_rnn_lm_scale_0.8	3.22
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.01_rnn_lm_scale_0.8	3.22
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_2.5_rnn_lm_scale_2.5	3.22
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.1_rnn_lm_scale_1.0	3.23
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.05_rnn_lm_scale_1.0	3.24
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_3_rnn_lm_scale_3	3.24
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.5_rnn_lm_scale_-0.5	3.25
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.02_rnn_lm_scale_1.0	3.25
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_2.5_rnn_lm_scale_3	3.25
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.01_rnn_lm_scale_1.0	3.27
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.02_rnn_lm_scale_1.0	3.28
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0_rnn_lm_scale_1.0	3.28
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.5_rnn_lm_scale_1.5	3.28
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.2_rnn_lm_scale_1.0	3.29
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.05_rnn_lm_scale_1.0	3.29
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.1_rnn_lm_scale_1.5	3.29
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_1.5_rnn_lm_scale_2.5	3.29
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.5_rnn_lm_scale_0.3	3.3
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.05_rnn_lm_scale_1.5	3.3
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.3_rnn_lm_scale_1.5	3.3
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.1_rnn_lm_scale_1.0	3.31
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0_rnn_lm_scale_1.5	3.31
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.01_rnn_lm_scale_1.5	3.31
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.02_rnn_lm_scale_1.5	3.31
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.02_rnn_lm_scale_1.5	3.32
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_1.0_rnn_lm_scale_2.5	3.32
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.05_rnn_lm_scale_1.5	3.33
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_1.5_rnn_lm_scale_3	3.33
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.1_rnn_lm_scale_1.5	3.35
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.5_rnn_lm_scale_2.5	3.36
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.8_rnn_lm_scale_2.5	3.36
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.5_rnn_lm_scale_0.5	3.37
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.2_rnn_lm_scale_1.5	3.37
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.3_rnn_lm_scale_2.5	3.37
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_1.0_rnn_lm_scale_3	3.38
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.1_rnn_lm_scale_2.5	3.39
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.8_rnn_lm_scale_3	3.39
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.3_rnn_lm_scale_3	3.4
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.5_rnn_lm_scale_3	3.4
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.01_rnn_lm_scale_2.5	3.41
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.02_rnn_lm_scale_2.5	3.41
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.05_rnn_lm_scale_2.5	3.41
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.05_rnn_lm_scale_2.5	3.42
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.02_rnn_lm_scale_2.5	3.42
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0_rnn_lm_scale_2.5	3.42
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.1_rnn_lm_scale_3	3.43
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.5_rnn_lm_scale_0.8	3.44
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.5_rnn_lm_scale_1.0	3.44
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.1_rnn_lm_scale_2.5	3.44
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.05_rnn_lm_scale_3	3.45
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.05_rnn_lm_scale_3	3.46
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.02_rnn_lm_scale_3	3.46
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0_rnn_lm_scale_3	3.46
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.01_rnn_lm_scale_3	3.46
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_0.02_rnn_lm_scale_3	3.46
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.2_rnn_lm_scale_2.5	3.47
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.1_rnn_lm_scale_3	3.47
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.2_rnn_lm_scale_3	3.51
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.5_rnn_lm_scale_1.5	3.55
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.5_rnn_lm_scale_2.5	3.61
beam_4.0_max_contexts_8_max_states_32_num_paths_200_nbest_scale_0.5_temperature_1.0_ngram_lm_scale_-0.5_rnn_lm_scale_3	3.63
```

I will double check the implementation and redo an RNN-LM training