### PR TITLE
Add compile_lg.py for aishell2 recipe

### DIFF
--- a/egs/aishell2/ASR/local/compile_lg.py
+++ b/egs/aishell2/ASR/local/compile_lg.py
@@ -1,0 +1,1 @@
+../../../librispeech/ASR/local/compile_lg.py


### PR DESCRIPTION
I find the `compile_lg.py` is missing from `egs/aishell2/ASR/local`. Maybe @yuekaizhang forgot to add compile_lg.py for aishell2 recipe.