### PR TITLE
Set overwrite=True when extracting features in batches.

### DIFF
--- a/egs/gigaspeech/ASR/local/compute_fbank_gigaspeech_dev_test.py
+++ b/egs/gigaspeech/ASR/local/compute_fbank_gigaspeech_dev_test.py
@@ -20,11 +20,7 @@ import logging
 from pathlib import Path
 
 import torch
-from lhotse import (
-    CutSet,
-    KaldifeatFbank,
-    KaldifeatFbankConfig,
-)
+from lhotse import CutSet, KaldifeatFbank, KaldifeatFbankConfig
 
 # Torch's multithreaded behavior needs to be disabled or
 # it wastes a lot of CPU and slow things down.
@@ -69,6 +65,7 @@ def compute_fbank_gigaspeech_dev_test():
             storage_path=f"{in_out_dir}/feats_{partition}",
             num_workers=num_workers,
             batch_duration=batch_duration,
+            overwrite=True,
         )
         cut_set = cut_set.trim_to_supervisions(
             keep_overlapping=False, min_duration=None

--- a/egs/gigaspeech/ASR/local/compute_fbank_gigaspeech_splits.py
+++ b/egs/gigaspeech/ASR/local/compute_fbank_gigaspeech_splits.py
@@ -22,11 +22,7 @@ from datetime import datetime
 from pathlib import Path
 
 import torch
-from lhotse import (
-    CutSet,
-    KaldifeatFbank,
-    KaldifeatFbankConfig,
-)
+from lhotse import CutSet, KaldifeatFbank, KaldifeatFbankConfig
 
 # Torch's multithreaded behavior needs to be disabled or
 # it wastes a lot of CPU and slow things down.
@@ -120,6 +116,7 @@ def compute_fbank_gigaspeech_splits(args):
             storage_path=f"{output_dir}/feats_XL_{idx}",
             num_workers=args.num_workers,
             batch_duration=args.batch_duration,
+            overwrite=True,
         )
 
         logging.info("About to split cuts into smaller chunks.")

--- a/egs/librispeech/ASR/local/compute_fbank_gigaspeech_dev_test.py
+++ b/egs/librispeech/ASR/local/compute_fbank_gigaspeech_dev_test.py
@@ -68,6 +68,7 @@ def compute_fbank_gigaspeech_dev_test():
             storage_path=f"{in_out_dir}/{prefix}_feats_{partition}",
             num_workers=num_workers,
             batch_duration=batch_duration,
+            overwrite=True,
         )
         cut_set = cut_set.trim_to_supervisions(
             keep_overlapping=False, min_duration=None

--- a/egs/librispeech/ASR/local/compute_fbank_gigaspeech_splits.py
+++ b/egs/librispeech/ASR/local/compute_fbank_gigaspeech_splits.py
@@ -126,6 +126,7 @@ def compute_fbank_gigaspeech_splits(args):
             storage_path=f"{output_dir}/{prefix}_feats_XL_{idx}",
             num_workers=args.num_workers,
             batch_duration=args.batch_duration,
+            overwrite=True,
         )
 
         logging.info("About to split cuts into smaller chunks.")

--- a/egs/spgispeech/ASR/local/compute_fbank_musan.py
+++ b/egs/spgispeech/ASR/local/compute_fbank_musan.py
@@ -92,6 +92,7 @@ def compute_fbank_musan():
             batch_duration=500,
             num_workers=4,
             storage_type=LilcomChunkyWriter,
+            overwrite=True,
         )
     )
 

--- a/egs/spgispeech/ASR/local/compute_fbank_spgispeech.py
+++ b/egs/spgispeech/ASR/local/compute_fbank_spgispeech.py
@@ -119,6 +119,7 @@ def compute_fbank_spgispeech(args):
                 batch_duration=500,
                 num_workers=4,
                 storage_type=LilcomChunkyWriter,
+                overwrite=True,
             )
             cs.to_file(cuts_train_idx_path)
 
@@ -138,6 +139,7 @@ def compute_fbank_spgispeech(args):
                 batch_duration=500,
                 num_workers=4,
                 storage_type=LilcomChunkyWriter,
+                overwrite=True,
             )
 
 

--- a/egs/wenetspeech/ASR/local/compute_fbank_wenetspeech_dev_test.py
+++ b/egs/wenetspeech/ASR/local/compute_fbank_wenetspeech_dev_test.py
@@ -75,6 +75,7 @@ def compute_fbank_wenetspeech_dev_test():
             num_workers=num_workers,
             batch_duration=batch_duration,
             storage_type=LilcomHdf5Writer,
+            overwrite=True,
         )
 
         logging.info(f"Saving to {cuts_path}")

--- a/egs/wenetspeech/ASR/local/compute_fbank_wenetspeech_splits.py
+++ b/egs/wenetspeech/ASR/local/compute_fbank_wenetspeech_splits.py
@@ -140,6 +140,7 @@ def compute_fbank_wenetspeech_splits(args):
             num_workers=args.num_workers,
             batch_duration=args.batch_duration,
             storage_type=LilcomChunkyWriter,
+            overwrite=True,
         )
 
         logging.info(f"Saving to {cuts_path}")


### PR DESCRIPTION
@pingfengluo reported the following error this morning, which I have seen before:
```
2022-07-22 04:00:03,436 INFO [train.py:859] Epoch 20, batch 33700, loss[loss=0.1769, simple_loss=0.2527, pruned_loss=0.05054, over 9882.00 frames.], tot_loss[loss=0.203, simple_loss=0.2838, pruned_loss=0.06109, over 1971049.83 frames.], batch size: 91, lr: 1.30e-04
2022-07-22 04:00:03,437 INFO [train.py:859] Epoch 20, batch 33700, loss[loss=0.2009, simple_loss=0.2789, pruned_loss=0.06148, over 9860.00 frames.], tot_loss[loss=0.2019, simple_loss=0.2821, pruned_loss=0.06092, over 1972654.00 frames.], batch size: 145, lr: 1.30e-04
Traceback (most recent call last):
  File "conv_emformer_transducer_stateless2/train.py", line 1144, in <module>
    main()
  File "conv_emformer_transducer_stateless2/train.py", line 1135, in main
    mp.spawn(run, args=(world_size, args), nprocs=world_size, join=True)
  File "/opt/conda/lib/python3.7/site-packages/torch/multiprocessing/spawn.py", line 240, in spawn
    return start_processes(fn, args, nprocs, join, daemon, start_method='spawn')
  File "/opt/conda/lib/python3.7/site-packages/torch/multiprocessing/spawn.py", line 198, in start_processes
    while not context.join():
  File "/opt/conda/lib/python3.7/site-packages/torch/multiprocessing/spawn.py", line 160, in join
    raise ProcessRaisedException(msg, error_index, failed_process.pid)
torch.multiprocessing.spawn.ProcessRaisedException: 

-- Process 4 terminated with the following error:
Traceback (most recent call last):
  File "/opt/conda/lib/python3.7/site-packages/torch/multiprocessing/spawn.py", line 69, in _wrap
    fn(i, *args)
  File "/data/juicefs_speech_asr/11152336/code/icefall/egs/norm/ASR/conv_emformer_transducer_stateless2/train.py", line 1058, in run
    rank=rank,
  File "/data/juicefs_speech_asr/11152336/code/icefall/egs/norm/ASR/conv_emformer_transducer_stateless2/train.py", line 790, in train_one_epoch
    for batch_idx, batch in enumerate(train_dl):
  File "/opt/conda/lib/python3.7/site-packages/torch/utils/data/dataloader.py", line 530, in __next__
    data = self._next_data()
  File "/opt/conda/lib/python3.7/site-packages/torch/utils/data/dataloader.py", line 1224, in _next_data
    return self._process_data(data)
  File "/opt/conda/lib/python3.7/site-packages/torch/utils/data/dataloader.py", line 1250, in _process_data
    data.reraise()
  File "/opt/conda/lib/python3.7/site-packages/torch/_utils.py", line 457, in reraise
    raise exception
ValueError: Caught ValueError in DataLoader worker process 0.
Original Traceback (most recent call last):
  File "/opt/conda/lib/python3.7/site-packages/lhotse/utils.py", line 668, in wrapper
    return fn(*args, **kwargs)
  File "/opt/conda/lib/python3.7/site-packages/lhotse/cut.py", line 1012, in load_features
    feats = self.features.load(start=self.start, duration=self.duration)
  File "/opt/conda/lib/python3.7/site-packages/lhotse/features/base.py", line 479, in load
    right_offset_frames=right_offset_frames,
  File "/opt/conda/lib/python3.7/site-packages/lhotse/caching.py", line 70, in wrapper
    return m(*args, **kwargs)
  File "/opt/conda/lib/python3.7/site-packages/lhotse/features/io.py", line 765, in read
    decompressed_chunks = [lilcom.decompress(data) for data in chunk_data]
  File "/opt/conda/lib/python3.7/site-packages/lhotse/features/io.py", line 765, in <listcomp>
    decompressed_chunks = [lilcom.decompress(data) for data in chunk_data]
  File "/opt/conda/lib/python3.7/site-packages/lilcom/lilcom_interface.py", line 111, in decompress
    "decompress_float returned {}".format(ret))
ValueError: Something went wrong in decompression (likely bad data): decompress_float returned 7

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/conda/lib/python3.7/site-packages/lhotse/utils.py", line 668, in wrapper
    return fn(*args, **kwargs)
  File "/opt/conda/lib/python3.7/site-packages/lhotse/cut.py", line 2905, in load_features
    feats[: first_cut.num_frames, :] = first_cut.load_features()
  File "/opt/conda/lib/python3.7/site-packages/lhotse/utils.py", line 671, in wrapper
    f"{e}\n[extra info] When calling: {fn.__qualname__}(args={args} kwargs={kwargs})"
ValueError: Something went wrong in decompression (likely bad data): decompress_float returned 7
[extra info] When calling: MonoCut.load_features(args=(MonoCut(id='1b6b1601-1d6c-479c-ac6c-beb9eee83d7f', start=549.52225, duration=1.4555625, 
channel=0, supervisions=[SupervisionSegment(id='X0000029781_273379719_S00143_sp0.9', recording_id='X0000029781_273379719_sp0.9', start=0.0, duration=1.4555625, 
channel=0, text='xxxxxxxx-private-xxxxx', language='Chinese', speaker=None, 
gender=None, custom=None, alignment=None)], features=Features(type='kaldifeat-fbank', 
num_frames=61693, num_features=80, frame_shift=0.01, sampling_rate=16000, start=0.0, duration=616.9333125, storage_type='lilcom_chunky', storage_path='data/fbank/XXL_split_1000/feats_XXL_0896.lca', 
storage_key='2224402390,49467,45101,46012,45257,45562,45975,46006,45724,46087,45893,
44745,45121,46208,45113,45664,45022,45699,45649,45785,45478,45840,44964,45503,45179,
45736,45698,45086,45480,45346,45013,45347,44743,44464,44949,44564,45481,45105,44441,
45152,45979,45975,45727,45167,45643,45831,45969,46819,45192,45832,44124,45465,45082,
45380,46036,44882,45831,45605,44851,44967,
45456,45420,44736,46164,45292,45039,44746,45636,46109,45247,45945,45262,44891,45687,
46291,45139,45141,45758,45717,46724,46443,44658,45087,45438,45891,46081,45845,45056,45830,
45502,45539,45159,45683,45628,44554,44949,45463,44799,45126,45568,45279,44866,45551,45734,
45939,45217,44982,45415,45755,45926,44931,44861,45675,45560,45073,45080,45104,45891,46038,
45276,45256,45993,45772,45980,18553', recording_id='X0000029781_273379719_sp0.9', channels=0), recording=Recording(id='X0000029781_273379719_sp0.9', sources=[AudioSource(type='file', channels=[0], source='/xxxxx.opus')], sampling_rate=16000, num_samples=9870933, 
duration=616.9333125, transforms=[{'name': 'Speed', 'kwargs': {'factor': 0.9}}]), custom=None),) kwargs={})
```

The default behavior uses `overwrite=False`, which corrupts the lilcom compressed file if we restart the feature extraction.

This PR sets `overwrite=True`. The common case is that we usually split a large dataset into smaller pieces and extract features for each piece separately/independently.  It is cheap to restart the feature extraction process for a piece from scratch.