### PR TITLE
WIP: Support exporting pretrained models to mace/ncnn and others via pnnx

### DIFF
--- a/egs/librispeech/ASR/pruned_transducer_stateless2/conformer.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless2/conformer.py
@@ -1611,9 +1611,8 @@ class Conv2dSubsampling(nn.Module):
         x = self.conv(x)
         # Now x is of shape (N, odim, ((T-1)//2 - 1)//2, ((idim-1)//2 - 1)//2)
         if torch.jit.is_tracing() and self.for_ncnn:
-            x = self.out(
-                x.transpose(1, 2).contiguous().view(1, -1, self.conv_out_dim)
-            )
+            x = x.permute(0, 2, 1, 3).reshape(1, -1, self.conv_out_dim)
+            x = self.out(x)
         else:
             b, c, t, f = x.size()
             x = self.out(x.transpose(1, 2).contiguous().view(b, t, c * f))

--- a/egs/librispeech/ASR/pruned_transducer_stateless2/conformer.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless2/conformer.py
@@ -798,7 +798,7 @@ class RelPositionalEncoding(torch.nn.Module):
 
         self.d_model = d_model
         self.dropout = torch.nn.Dropout(p=dropout_rate)
-        self.pe = None
+        self.register_buffer("pe", None)
         self.extend_pe(torch.tensor(0.0).expand(1, max_len))
 
     def extend_pe(self, x: Tensor, left_context: int = 0) -> None:
@@ -835,7 +835,7 @@ class RelPositionalEncoding(torch.nn.Module):
         pe_positive = torch.flip(pe_positive, [0]).unsqueeze(0)
         pe_negative = pe_negative[1:].unsqueeze(0)
         pe = torch.cat([pe_positive, pe_negative], dim=1)
-        self.pe = pe.to(device=x.device, dtype=x.dtype)
+        self.register_buffer("pe", pe.to(device=x.device, dtype=x.dtype))
 
     def forward(
         self,

--- a/egs/librispeech/ASR/pruned_transducer_stateless2/scaling.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless2/scaling.py
@@ -123,16 +123,16 @@ class BasicNorm(torch.nn.Module):
     doesn't have to do this trick.  We make the "eps" learnable.
 
     Args:
-       num_channels: the number of channels, e.g. 512.
+      num_channels: the number of channels, e.g. 512.
       channel_dim: the axis/dimension corresponding to the channel,
-        interprted as an offset from the input's ndim if negative.
-        shis is NOT the num_channels; it should typically be one of
+        interpreted as an offset from the input's ndim if negative.
+        This is NOT the num_channels; it should typically be one of
         {-2, -1, 0, 1, 2, 3}.
-       eps: the initial "epsilon" that we add as ballast in:
+      eps: the initial "epsilon" that we add as ballast in:
              scale = ((input_vec**2).mean() + epsilon)**-0.5
           Note: our epsilon is actually large, but we keep the name
           to indicate the connection with conventional LayerNorm.
-       learn_eps: if true, we learn epsilon; if false, we keep it
+      learn_eps: if true, we learn epsilon; if false, we keep it
          at the initial value.
     """
 

--- a/egs/librispeech/ASR/pruned_transducer_stateless3/scaling_converter.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless3/scaling_converter.py
@@ -28,7 +28,37 @@ import re
 
 import torch
 import torch.nn as nn
-from scaling import ScaledConv1d, ScaledConv2d, ScaledEmbedding, ScaledLinear
+from scaling import (
+    BasicNorm,
+    ScaledConv1d,
+    ScaledConv2d,
+    ScaledEmbedding,
+    ScaledLinear,
+)
+
+
+class NonScaledNorm(nn.Module):
+    """See BasicNorm for doc"""
+
+    def __init__(
+        self,
+        num_channels: int,
+        eps_exp: float,
+        channel_dim: int = -1,  # CAUTION: see documentation.
+    ):
+        super().__init__()
+        self.num_channels = num_channels
+        self.channel_dim = channel_dim
+        self.eps_exp = eps_exp
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        if not torch.jit.is_tracing():
+            assert x.shape[self.channel_dim] == self.num_channels
+        scales = (
+            torch.mean(x.pow(2), dim=self.channel_dim, keepdim=True)
+            + self.eps_exp
+        ).pow(-0.5)
+        return x * scales
 
 
 def scaled_linear_to_linear(scaled_linear: ScaledLinear) -> nn.Linear:
@@ -164,6 +194,16 @@ def scaled_embedding_to_embedding(
     return embedding
 
 
+def convert_basic_norm(basic_norm: BasicNorm) -> NonScaledNorm:
+    assert isinstance(basic_norm, BasicNorm), type(BasicNorm)
+    norm = NonScaledNorm(
+        num_channels=basic_norm.num_channels,
+        eps_exp=basic_norm.eps.data.exp().item(),
+        channel_dim=basic_norm.channel_dim,
+    )
+    return norm
+
+
 def convert_scaled_to_non_scaled(model: nn.Module, inplace: bool = False):
     """Convert `ScaledLinear`, `ScaledConv1d`, and `ScaledConv2d`
     in the given modle to their unscaled version `nn.Linear`, `nn.Conv1d`,
@@ -196,6 +236,8 @@ def convert_scaled_to_non_scaled(model: nn.Module, inplace: bool = False):
             d[name] = scaled_conv2d_to_conv2d(m)
         elif isinstance(m, ScaledEmbedding):
             d[name] = scaled_embedding_to_embedding(m)
+        elif isinstance(m, BasicNorm):
+            d[name] = convert_basic_norm(m)
 
     for k, v in d.items():
         if "." in k:

--- a/egs/librispeech/ASR/pruned_transducer_stateless3/scaling_converter.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless3/scaling_converter.py
@@ -55,8 +55,7 @@ class NonScaledNorm(nn.Module):
         if not torch.jit.is_tracing():
             assert x.shape[self.channel_dim] == self.num_channels
         scales = (
-            torch.mean(x.pow(2), dim=self.channel_dim, keepdim=True)
-            + self.eps_exp
+            torch.mean(x * x, dim=self.channel_dim, keepdim=True) + self.eps_exp
         ).pow(-0.5)
         return x * scales
 

--- a/egs/librispeech/ASR/pruned_transducer_stateless3/t2.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless3/t2.py
@@ -11,26 +11,38 @@ LOG_EPS = math.log(1e-10)
 
 @torch.no_grad()
 def main():
-    x = torch.rand(1, 200, 80)
-    f = torch.jit.load("foo/encoder_embed.pt")
+    x = torch.rand(10, 3)
+    f = torch.jit.load("foo/encoder_pos.pt")
 
-    param = "foo/encoder_embed.ncnn.param"
-    model = "foo/encoder_embed.ncnn.bin"
+    param = "foo/encoder_pos.ncnn.param"
+    model = "foo/encoder_pos.ncnn.bin"
 
     with ncnn.Net() as net:
         net.load_param(param)
         net.load_model(model)
         with net.create_extractor() as ex:
             ex.input("in0", ncnn.Mat(x.numpy()).clone())
-            ret, out0 = ex.extract("out0")
-            assert ret == 0
-            out0 = np.array(out0)
-            print("ncnn", out0.shape)
-            t = f(x)
-            out0 = torch.from_numpy(out0)
-            t = t.squeeze(0)
-            print("torch", t.shape)
-            torch.allclose(out0, t), (t - out0).abs().max()
+            ret, ncnn_out0 = ex.extract("out0")
+            assert ret == 0, ret
+            ncnn_out0 = np.array(ncnn_out0)
+
+            ret, ncnn_out1 = ex.extract("out1")
+            assert ret == 0, ret
+            ncnn_out1 = np.array(ncnn_out1)
+
+            torch_out0, torch_out1 = f(x.unsqueeze(0))
+            torch_out0 = torch_out0.squeeze(0)
+            torch_out1 = torch_out1.squeeze(1)
+
+            ncnn_out0 = torch.from_numpy(ncnn_out0)
+            ncnn_out1 = torch.from_numpy(ncnn_out1)
+
+            torch.allclose(torch_out0, ncnn_out0), (
+                torch_out0 - ncnn_out0
+            ).abs().max()
+            torch.allclose(torch_out1, ncnn_out1), (
+                torch_out1 - ncnn_out1
+            ).abs().max()
 
 
 if __name__ == "__main__":

--- a/egs/librispeech/ASR/pruned_transducer_stateless3/t2.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless3/t2.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+
+import math
+
+import ncnn
+import numpy as np
+import torch
+import torch.nn as nn
+from scaling import (
+    ActivationBalancer,
+    BasicNorm,
+    DoubleSwish,
+    ScaledConv2d,
+    ScaledLinear,
+)
+
+LOG_EPS = math.log(1e-10)
+
+
+class Foo(nn.Module):
+    def __init__(self):
+        super().__init__()
+        layer1_channels = 8
+        layer2_channels = 32
+        layer3_channels = 128
+        in_channels = 80
+        out_channels = 512
+        self.out_channels = out_channels
+        self.conv = nn.Sequential(
+            ScaledConv2d(
+                in_channels=1,
+                out_channels=layer1_channels,
+                kernel_size=3,
+                padding=1,
+            ),
+            ActivationBalancer(channel_dim=1),
+            DoubleSwish(),
+            ScaledConv2d(
+                in_channels=layer1_channels,
+                out_channels=layer2_channels,
+                kernel_size=3,
+                stride=2,
+            ),
+            ActivationBalancer(channel_dim=1),
+            DoubleSwish(),
+            ScaledConv2d(
+                in_channels=layer2_channels,
+                out_channels=layer3_channels,
+                kernel_size=3,
+                stride=2,
+            ),
+            ActivationBalancer(channel_dim=1),
+            DoubleSwish(),
+        )
+        self.out = ScaledLinear(
+            layer3_channels * (((in_channels - 1) // 2 - 1) // 2), out_channels
+        )
+        print(self.out.weight.shape)
+        self.out_norm = BasicNorm(out_channels, eps=1, learn_eps=False)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # On entry, x is (N, T, idim)
+        x = x.unsqueeze(1)  # (N, T, idim) -> (N, 1, T, idim) i.e., (N, C, H, W)
+        x = self.conv(x)
+        x = x.permute(0, 2, 1, 3)
+
+        # Now x is of shape (N, odim, ((T-1)//2 - 1)//2, ((idim-1)//2 - 1)//2)
+        #  b, c, t, f = x.shape
+        x = self.out(x.contiguous().view(1, -1, 128 * 19))
+
+        x = self.out_norm(x)
+        return x
+
+
+@torch.no_grad()
+def main():
+    x = torch.rand(1, 200, 80)
+    f = torch.jit.load("foo/scaled_conv2d.pt")
+
+    param = "foo/scaled_conv2d.ncnn.param"
+    model = "foo/scaled_conv2d.ncnn.bin"
+
+    with ncnn.Net() as net:
+        net.load_param(param)
+        net.load_model(model)
+        with net.create_extractor() as ex:
+            ex.input("in0", ncnn.Mat(x.numpy()).clone())
+            ret, out0 = ex.extract("out0")
+            assert ret == 0
+            out0 = np.array(out0)
+            print("ncnn", out0.shape)
+            t = f(x)
+            out0 = torch.from_numpy(out0)
+            t = t.squeeze(0)
+            print("torch", t.shape)
+            torch.allclose(out0, t), (t - out0).abs().max()
+
+
+if __name__ == "__main__":
+    main()

--- a/egs/librispeech/ASR/pruned_transducer_stateless3/t2.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless3/t2.py
@@ -5,80 +5,17 @@ import math
 import ncnn
 import numpy as np
 import torch
-import torch.nn as nn
-from scaling import (
-    ActivationBalancer,
-    BasicNorm,
-    DoubleSwish,
-    ScaledConv2d,
-    ScaledLinear,
-)
 
 LOG_EPS = math.log(1e-10)
-
-
-class Foo(nn.Module):
-    def __init__(self):
-        super().__init__()
-        layer1_channels = 8
-        layer2_channels = 32
-        layer3_channels = 128
-        in_channels = 80
-        out_channels = 512
-        self.out_channels = out_channels
-        self.conv = nn.Sequential(
-            ScaledConv2d(
-                in_channels=1,
-                out_channels=layer1_channels,
-                kernel_size=3,
-                padding=1,
-            ),
-            ActivationBalancer(channel_dim=1),
-            DoubleSwish(),
-            ScaledConv2d(
-                in_channels=layer1_channels,
-                out_channels=layer2_channels,
-                kernel_size=3,
-                stride=2,
-            ),
-            ActivationBalancer(channel_dim=1),
-            DoubleSwish(),
-            ScaledConv2d(
-                in_channels=layer2_channels,
-                out_channels=layer3_channels,
-                kernel_size=3,
-                stride=2,
-            ),
-            ActivationBalancer(channel_dim=1),
-            DoubleSwish(),
-        )
-        self.out = ScaledLinear(
-            layer3_channels * (((in_channels - 1) // 2 - 1) // 2), out_channels
-        )
-        print(self.out.weight.shape)
-        self.out_norm = BasicNorm(out_channels, eps=1, learn_eps=False)
-
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        # On entry, x is (N, T, idim)
-        x = x.unsqueeze(1)  # (N, T, idim) -> (N, 1, T, idim) i.e., (N, C, H, W)
-        x = self.conv(x)
-        x = x.permute(0, 2, 1, 3)
-
-        # Now x is of shape (N, odim, ((T-1)//2 - 1)//2, ((idim-1)//2 - 1)//2)
-        #  b, c, t, f = x.shape
-        x = self.out(x.contiguous().view(1, -1, 128 * 19))
-
-        x = self.out_norm(x)
-        return x
 
 
 @torch.no_grad()
 def main():
     x = torch.rand(1, 200, 80)
-    f = torch.jit.load("foo/scaled_conv2d.pt")
+    f = torch.jit.load("foo/encoder_embed.pt")
 
-    param = "foo/scaled_conv2d.ncnn.param"
-    model = "foo/scaled_conv2d.ncnn.bin"
+    param = "foo/encoder_embed.ncnn.param"
+    model = "foo/encoder_embed.ncnn.bin"
 
     with ncnn.Net() as net:
         net.load_param(param)

--- a/egs/librispeech/ASR/pruned_transducer_stateless3/test_generate_conformer.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless3/test_generate_conformer.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+
+
+import torch
+import torch.nn as nn
+from conformer import Conv2dSubsampling, MakePadMask, RelPositionalEncoding
+from scaling_converter import convert_scaled_to_non_scaled
+
+
+class Foo(nn.Module):
+    def __init__(self):
+        super().__init__()
+        num_features = 80
+        d_model = 512
+        dropout = 0.1
+
+        self.num_features = num_features
+        self.encoder_embed = Conv2dSubsampling(num_features, d_model)
+        self.encoder_pos = RelPositionalEncoding(d_model, dropout)
+        self.make_pad_mask = MakePadMask()
+
+    def forward(self, x: torch.Tensor, x_lens: torch.Tensor):
+        """
+        Args:
+          x:
+            (N,T,C)
+          x_lens:
+            (N,)
+        """
+        x = self.encoder_embed(x)
+        x, pos_emb = self.encoder_pos(x)
+        x = x.permute(1, 0, 2)  # (N, T, C) -> (T, N, C)
+        lengths1 = torch.floor((x_lens - 1) / 2)
+        lengths = torch.floor((lengths1 - 1) / 2)
+        lengths = lengths.to(x_lens)
+
+        return x, lengths, pos_emb
+
+
+def generate_pt():
+    f = Foo()
+    f.eval()
+    f = convert_scaled_to_non_scaled(f)
+    f.encoder_embed.for_pnnx = True
+
+    x = torch.rand(1, 30, 80, dtype=torch.float32)  # (T, C)
+    x_lens = torch.tensor([30])
+    y, lengths, pos_emb = f(x, x_lens)
+    print("y.shape", y.shape)
+    print("lengths", lengths)
+    print("pos_emb.shape", pos_emb.shape)
+    m = torch.jit.trace(f, (x, x_lens))
+    m.save("foo/conformer.pt")
+    #  print(m.graph)
+
+
+def main():
+    generate_pt()
+
+
+if __name__ == "__main__":
+    torch.manual_seed(20220809)
+    main()

--- a/egs/librispeech/ASR/pruned_transducer_stateless3/test_generate_encoder_embed.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless3/test_generate_encoder_embed.py
@@ -17,7 +17,11 @@ class Foo(nn.Module):
         self.num_features = num_features
         self.subsampling_factor = subsampling_factor
 
-        self.encoder_embed = Conv2dSubsampling(num_features, d_model)
+        self.encoder_embed = Conv2dSubsampling(
+            num_features,
+            d_model,
+            for_pnnx=True,
+        )
 
     def forward(self, x: torch.Tensor):
         """
@@ -33,7 +37,6 @@ def generate_pt():
     f = Foo()
     f.eval()
     f = convert_scaled_to_non_scaled(f)
-    f.encoder_embed.for_ncnn = True
     x = torch.rand(1, 30, 80)
     y = f(x)
     print("y.shape", y.shape)

--- a/egs/librispeech/ASR/pruned_transducer_stateless3/test_generate_encoder_embed.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless3/test_generate_encoder_embed.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+
+
+import torch
+import torch.nn as nn
+from conformer import Conv2dSubsampling
+from scaling_converter import convert_scaled_to_non_scaled
+
+
+class Foo(nn.Module):
+    def __init__(self):
+        super().__init__()
+
+        num_features = 80
+        subsampling_factor = 4
+        d_model = 512
+        self.num_features = num_features
+        self.subsampling_factor = subsampling_factor
+
+        self.encoder_embed = Conv2dSubsampling(num_features, d_model)
+
+    def forward(self, x: torch.Tensor):
+        """
+        Args:
+          x:
+            (N, T, C)
+        """
+        x = self.encoder_embed(x)
+        return x
+
+
+def generate_pt():
+    f = Foo()
+    f.eval()
+    f = convert_scaled_to_non_scaled(f)
+    f.encoder_embed.for_ncnn = True
+    x = torch.rand(1, 30, 80)
+    y = f(x)
+    print("y.shape", y.shape)
+    m = torch.jit.trace(f, x)
+    m.save("foo/encoder_embed.pt")
+
+
+def main():
+    generate_pt()
+
+
+if __name__ == "__main__":
+    torch.manual_seed(20220809)
+    main()

--- a/egs/librispeech/ASR/pruned_transducer_stateless3/test_generate_make_pad_mask.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless3/test_generate_make_pad_mask.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+
+
+import torch
+import torch.nn as nn
+from conformer import MakePadMask
+
+
+class Foo(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.make_pad_mask = MakePadMask()
+
+    def forward(self, x: torch.Tensor):
+        """
+        Args:
+          x:
+            (N,)
+        """
+        src_key_padding_mask = self.make_pad_mask(x)
+        return src_key_padding_mask
+
+
+def generate_pt():
+    f = Foo()
+    f.eval()
+    x = torch.tensor([1, 3, 5])
+    y = f(x)
+    print("y.shape", y.shape)
+    print(y)
+    m = torch.jit.trace(f, x)
+    m.save("foo/make_pad_mask.pt")
+    print(m.graph)
+
+
+def main():
+    generate_pt()
+
+
+if __name__ == "__main__":
+    torch.manual_seed(20220809)
+    main()

--- a/egs/librispeech/ASR/pruned_transducer_stateless3/test_generate_relpositional_encoding.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless3/test_generate_relpositional_encoding.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+
+
+import torch
+import torch.nn as nn
+from conformer import RelPositionalEncoding
+from scaling_converter import convert_scaled_to_non_scaled
+
+
+class Foo(nn.Module):
+    def __init__(self):
+        super().__init__()
+        d_model = 512
+        dropout = 0.1
+
+        self.encoder_pos = RelPositionalEncoding(d_model, dropout)
+
+    def forward(self, x: torch.Tensor):
+        """
+        Args:
+          x:
+            (N, T, C)
+        """
+        y, pos_emb = self.encoder_pos(x)
+        return y, pos_emb
+
+
+def generate_pt():
+    f = Foo()
+    f.eval()
+    f = convert_scaled_to_non_scaled(f)
+    x = torch.rand(1, 6, 4)
+    y, pos_emb = f(x)
+    print("y.shape", y.shape)
+    print("pos_emb.shape", pos_emb.shape)
+    m = torch.jit.trace(f, x)
+    m.save("foo/encoder_pos.pt")
+    print(m.encoder_pos.pe[0].shape)
+    print(type(m.encoder_pos.pe[0]))
+    print(m.graph)
+
+
+def main():
+    generate_pt()
+
+
+if __name__ == "__main__":
+    torch.manual_seed(20220809)
+    main()

--- a/egs/librispeech/ASR/pruned_transducer_stateless3/test_ncnn.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless3/test_ncnn.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+
+from pathlib import Path
+
+import ncnn
+import numpy as np
+import torch
+from scaling import ScaledConv2d
+from scaling_converter import scaled_conv2d_to_conv2d
+
+
+def generate_scaled_conv2d():
+    f = ScaledConv2d(in_channels=1, out_channels=2, kernel_size=3, padding=1)
+    f = scaled_conv2d_to_conv2d(f)
+    print(f)
+    x = torch.rand(1, 1, 6, 8)  # NCHW
+    m = torch.jit.trace(f, x)
+    m.save("foo/scaled_conv2d.pt")
+    print(m.graph)
+
+
+def compare_scaled_conv2d():
+    param = "foo/scaled_conv2d.ncnn.param"
+    model = "foo/scaled_conv2d.ncnn.bin"
+
+    with ncnn.Net() as net:
+        with net.create_extractor() as ex:
+            net = ncnn.Net()
+            net.load_param(param)
+            net.load_model(model)
+
+            ex = net.create_extractor()
+            x = torch.rand(1, 6, 5)  # CHW
+            ex.input("in0", ncnn.Mat(x.numpy()).clone())
+            ret, out0 = ex.extract("out0")
+            assert ret == 0
+            out0 = np.array(out0)
+            out0 = torch.from_numpy(out0)
+
+            m = torch.jit.load("foo/scaled_conv2d.pt")
+            y = m(x.unsqueeze(0)).squeeze(0)
+
+            assert torch.allclose(out0, y, atol=1e-3), (out0 - y).abs().max()
+
+
+@torch.no_grad()
+def main():
+    if not Path("foo/scaled_conv2d.ncnn.param").is_file():
+        generate_scaled_conv2d()
+    else:
+        compare_scaled_conv2d()
+
+
+if __name__ == "__main__":
+    torch.manual_seed(20220803)
+    main()

--- a/egs/librispeech/ASR/pruned_transducer_stateless3/test_ncnn.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless3/test_ncnn.py
@@ -2,88 +2,42 @@
 
 
 import torch
-import torch.nn as nn
-from scaling import (
-    ActivationBalancer,
-    BasicNorm,
-    DoubleSwish,
-    ScaledConv2d,
-    ScaledLinear,
-)
 from scaling_converter import convert_scaled_to_non_scaled
+from train import get_params, get_transducer_model
 
 
-class Foo(nn.Module):
-    def __init__(self):
-        super().__init__()
-        layer1_channels = 8
-        layer2_channels = 32
-        layer3_channels = 128
-        in_channels = 80
-        out_channels = 512
-        self.out_channels = out_channels
-        self.conv = nn.Sequential(
-            ScaledConv2d(
-                in_channels=1,
-                out_channels=layer1_channels,
-                kernel_size=3,
-                padding=1,
-            ),
-            ActivationBalancer(channel_dim=1),
-            DoubleSwish(),
-            ScaledConv2d(
-                in_channels=layer1_channels,
-                out_channels=layer2_channels,
-                kernel_size=3,
-                stride=2,
-            ),
-            ActivationBalancer(channel_dim=1),
-            DoubleSwish(),
-            ScaledConv2d(
-                in_channels=layer2_channels,
-                out_channels=layer3_channels,
-                kernel_size=3,
-                stride=2,
-            ),
-            ActivationBalancer(channel_dim=1),
-            DoubleSwish(),
-        )
-        self.out = ScaledLinear(
-            layer3_channels * (((in_channels - 1) // 2 - 1) // 2), out_channels
-        )
-        print(self.out.weight.shape)
-        self.out_norm = BasicNorm(out_channels, learn_eps=False)
+def get_model():
+    params = get_params()
+    params.vocab_size = 500
+    params.blank_id = 0
+    params.context_size = 2
+    params.unk_id = 2
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        # On entry, x is (N, T, idim)
-        x = x.unsqueeze(1)  # (N, T, idim) -> (N, 1, T, idim) i.e., (N, C, H, W)
-        x = self.conv(x)
-        x = x.permute(0, 2, 1, 3)
+    params.dynamic_chunk_training = False
+    params.short_chunk_size = 25
+    params.num_left_chunks = 4
+    params.causal_convolution = False
 
-        # Now x is of shape (N, odim, ((T-1)//2 - 1)//2, ((idim-1)//2 - 1)//2)
-        #  b, c, t, f = x.shape
-        x = self.out(x.contiguous().view(1, -1, 128 * 19))
-
-        x = self.out_norm(x)
-        return x
+    model = get_transducer_model(params, enable_giga=False)
+    return model
 
 
-def generate_scaled_conv2d():
-    print("generating")
-    f = Foo()
-    f.eval()
-    f = convert_scaled_to_non_scaled(f)
+def test_encoder_embedding():
+    model = get_model()
+    model = convert_scaled_to_non_scaled(model)
+
+    f = model.encoder.encoder_embed
+    f.for_ncnn = True
     print(f)
-    torch.save(f.state_dict(), "f.pt")
     x = torch.rand(1, 100, 80)  # NTC
     m = torch.jit.trace(f, x)
-    m.save("foo/scaled_conv2d.pt")
+    m.save("foo/encoder_embed.pt")
     print(m.graph)
 
 
 @torch.no_grad()
 def main():
-    generate_scaled_conv2d()
+    test_encoder_embedding()
 
 
 if __name__ == "__main__":

--- a/egs/librispeech/ASR/pruned_transducer_stateless3/test_ncnn.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless3/test_ncnn.py
@@ -2,8 +2,38 @@
 
 
 import torch
+import torch.nn as nn
+from conformer import RelPositionalEncoding
 from scaling_converter import convert_scaled_to_non_scaled
 from train import get_params, get_transducer_model
+
+
+class Foo(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.linear = nn.Linear(3, 100)
+        self.encoder_pos = RelPositionalEncoding(100, 0.1)
+        self.linear2 = nn.Linear(100, 2)
+
+    def forward(self, x):
+        y = self.linear(x)
+        z, embed = self.encoder_pos(y)
+        return z, embed
+
+
+def test():
+    f = Foo()
+    f.eval()
+    #  f.encoder_pos.for_ncnn = True
+    x = torch.rand(1, 10, 3)
+    y, _ = f(x)
+    print(y.shape)
+    #  print(embed.shape)
+
+    m = torch.jit.trace(f, x)
+    m.save("foo/encoder_pos.pt")
+    print(m.graph)
+    #  print(m.encoder_pos.graph)
 
 
 def get_model():
@@ -24,20 +54,24 @@ def get_model():
 
 def test_encoder_embedding():
     model = get_model()
+    model.eval()
     model = convert_scaled_to_non_scaled(model)
-
-    f = model.encoder.encoder_embed
+    f = model.encoder
     f.for_ncnn = True
-    print(f)
+    f.encoder_pos.for_ncnn = True
+
+    f.for_ncnn = True
     x = torch.rand(1, 100, 80)  # NTC
-    m = torch.jit.trace(f, x)
-    m.save("foo/encoder_embed.pt")
+    x_lens = torch.tensor([100])
+    m = torch.jit.trace(f, (x, x_lens))
+    m.save("foo/encoder_pos.pt")
     print(m.graph)
 
 
 @torch.no_grad()
 def main():
-    test_encoder_embedding()
+    #  test_encoder_embedding()
+    test()
 
 
 if __name__ == "__main__":

--- a/egs/librispeech/ASR/pruned_transducer_stateless3/test_ncnn.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless3/test_ncnn.py
@@ -1,54 +1,89 @@
 #!/usr/bin/env python3
 
-from pathlib import Path
 
-import ncnn
-import numpy as np
 import torch
-from scaling import ScaledConv2d
-from scaling_converter import scaled_conv2d_to_conv2d
+import torch.nn as nn
+from scaling import (
+    ActivationBalancer,
+    BasicNorm,
+    DoubleSwish,
+    ScaledConv2d,
+    ScaledLinear,
+)
+from scaling_converter import convert_scaled_to_non_scaled
+
+
+class Foo(nn.Module):
+    def __init__(self):
+        super().__init__()
+        layer1_channels = 8
+        layer2_channels = 32
+        layer3_channels = 128
+        in_channels = 80
+        out_channels = 512
+        self.out_channels = out_channels
+        self.conv = nn.Sequential(
+            ScaledConv2d(
+                in_channels=1,
+                out_channels=layer1_channels,
+                kernel_size=3,
+                padding=1,
+            ),
+            ActivationBalancer(channel_dim=1),
+            DoubleSwish(),
+            ScaledConv2d(
+                in_channels=layer1_channels,
+                out_channels=layer2_channels,
+                kernel_size=3,
+                stride=2,
+            ),
+            ActivationBalancer(channel_dim=1),
+            DoubleSwish(),
+            ScaledConv2d(
+                in_channels=layer2_channels,
+                out_channels=layer3_channels,
+                kernel_size=3,
+                stride=2,
+            ),
+            ActivationBalancer(channel_dim=1),
+            DoubleSwish(),
+        )
+        self.out = ScaledLinear(
+            layer3_channels * (((in_channels - 1) // 2 - 1) // 2), out_channels
+        )
+        print(self.out.weight.shape)
+        self.out_norm = BasicNorm(out_channels, learn_eps=False)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # On entry, x is (N, T, idim)
+        x = x.unsqueeze(1)  # (N, T, idim) -> (N, 1, T, idim) i.e., (N, C, H, W)
+        x = self.conv(x)
+        x = x.permute(0, 2, 1, 3)
+
+        # Now x is of shape (N, odim, ((T-1)//2 - 1)//2, ((idim-1)//2 - 1)//2)
+        #  b, c, t, f = x.shape
+        x = self.out(x.contiguous().view(1, -1, 128 * 19))
+
+        x = self.out_norm(x)
+        return x
 
 
 def generate_scaled_conv2d():
-    f = ScaledConv2d(in_channels=1, out_channels=2, kernel_size=3, padding=1)
-    f = scaled_conv2d_to_conv2d(f)
+    print("generating")
+    f = Foo()
+    f.eval()
+    f = convert_scaled_to_non_scaled(f)
     print(f)
-    x = torch.rand(1, 1, 6, 8)  # NCHW
+    torch.save(f.state_dict(), "f.pt")
+    x = torch.rand(1, 100, 80)  # NTC
     m = torch.jit.trace(f, x)
     m.save("foo/scaled_conv2d.pt")
     print(m.graph)
 
 
-def compare_scaled_conv2d():
-    param = "foo/scaled_conv2d.ncnn.param"
-    model = "foo/scaled_conv2d.ncnn.bin"
-
-    with ncnn.Net() as net:
-        with net.create_extractor() as ex:
-            net = ncnn.Net()
-            net.load_param(param)
-            net.load_model(model)
-
-            ex = net.create_extractor()
-            x = torch.rand(1, 6, 5)  # CHW
-            ex.input("in0", ncnn.Mat(x.numpy()).clone())
-            ret, out0 = ex.extract("out0")
-            assert ret == 0
-            out0 = np.array(out0)
-            out0 = torch.from_numpy(out0)
-
-            m = torch.jit.load("foo/scaled_conv2d.pt")
-            y = m(x.unsqueeze(0)).squeeze(0)
-
-            assert torch.allclose(out0, y, atol=1e-3), (out0 - y).abs().max()
-
-
 @torch.no_grad()
 def main():
-    if not Path("foo/scaled_conv2d.ncnn.param").is_file():
-        generate_scaled_conv2d()
-    else:
-        compare_scaled_conv2d()
+    generate_scaled_conv2d()
 
 
 if __name__ == "__main__":

--- a/egs/librispeech/ASR/pruned_transducer_stateless3/test_ncnn_conformer.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless3/test_ncnn_conformer.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+
+import ncnn
+import numpy as np
+import torch
+
+
+@torch.no_grad()
+def main():
+    x = torch.rand(30, 80, dtype=torch.float32)  # (T, C)
+    x_lens = torch.tensor([30])
+    m = torch.jit.load("foo/conformer.pt")
+    t, t_lens, t_embed = m(x.unsqueeze(0), x_lens)
+    t = t.squeeze(1)
+    t_embed = t_embed.squeeze(0)
+
+    print(t.shape)
+    print(t_lens)
+    print(t_embed.shape)
+
+    param = "foo/conformer.ncnn.param"
+    model = "foo/conformer.ncnn.bin"
+    with ncnn.Net() as net:
+        net.load_param(param)
+        net.load_model(model)
+        with net.create_extractor() as ex:
+            x = x.to(torch.float32)
+
+            # ncnn only support float binary ops
+            x_lens = x_lens.to(torch.float32)
+
+            ex.input("in0", ncnn.Mat(x.numpy()).clone())
+            ex.input("in1", ncnn.Mat(x_lens.numpy()).clone())
+
+            ret, ncnn_out0 = ex.extract("out0")
+            assert ret == 0, ret
+            n = np.array(ncnn_out0)
+            print(n.shape)
+            n = torch.from_numpy(n)
+            print(n.reshape(-1)[:10])
+            print(t.reshape(-1)[:10])
+            assert torch.allclose(t, n, atol=1e-3), (t - n).abs().max()
+
+            # test length
+            ret, ncnn_out1 = ex.extract("out1")
+            assert ret == 0, ret
+            n_lens = np.array(ncnn_out1)
+            assert t_lens.item() == n_lens.item()
+
+            # test pos_emb
+            ret, ncnn_out2 = ex.extract("out2")
+            assert ret == 0, ret
+            n_embed = np.array(ncnn_out2)
+            n_embed = torch.from_numpy(n_embed)
+            print(n_embed.reshape(-1)[:10])
+            print(t_embed.reshape(-1)[:10])
+            assert torch.allclose(t_embed, n_embed, atol=1e-3), (
+                (t - n).abs().max()
+            )
+            assert torch.allclose(t, n, atol=1e-3), (t - n).abs().max()
+
+
+torch.set_num_threads(1)
+torch.set_num_interop_threads(1)
+if __name__ == "__main__":
+    torch.manual_seed(202208010)
+    main()

--- a/egs/librispeech/ASR/pruned_transducer_stateless3/test_ncnn_encoder_embed.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless3/test_ncnn_encoder_embed.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+
+import math
+
+import ncnn
+import numpy as np
+import torch
+
+LOG_EPS = math.log(1e-10)
+
+
+@torch.no_grad()
+def main():
+    x = torch.rand(30, 80)  # (T, C)
+    m = torch.jit.load("foo/encoder_embed.pt")
+    t = m(x.unsqueeze(0))  # bach size is 1
+    t = t.squeeze(0)  # (T, C)
+    print(t.shape)
+
+    param = "foo/encoder_embed.ncnn.param"
+    model = "foo/encoder_embed.ncnn.bin"
+    with ncnn.Net() as net:
+        net.load_param(param)
+        net.load_model(model)
+        with net.create_extractor() as ex:
+            ex.input("in0", ncnn.Mat(x.numpy()).clone())
+
+            ret, ncnn_out0 = ex.extract("out0")
+            assert ret == 0, ret
+            n = np.array(ncnn_out0)
+            print(n.shape)  # (6, 512), (T, C)
+            n = torch.from_numpy(n)
+
+            print(t.reshape(-1)[:10])
+            print(n.reshape(-1)[:10])
+            assert torch.allclose(t, n, atol=1e-2), (t - n).abs().max()
+
+
+torch.set_num_threads(1)
+torch.set_num_interop_threads(1)
+if __name__ == "__main__":
+    torch.manual_seed(20220808)
+    main()

--- a/egs/librispeech/ASR/pruned_transducer_stateless3/test_ncnn_make_pad_mask.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless3/test_ncnn_make_pad_mask.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+
+import ncnn
+import torch
+
+
+@torch.no_grad()
+def main():
+    x = torch.tensor([1, 3, 5, 8])
+    m = torch.jit.load("foo/make_pad_mask.pt")
+    t = m(x)
+    print(t.shape)
+    print(t)
+
+    param = "foo/make_pad_mask.ncnn.param"
+    model = "foo/make_pad_mask.ncnn.bin"
+    with ncnn.Net() as net:
+        net.load_param(param)
+        net.load_model(model)
+        with net.create_extractor() as ex:
+            x = x.to(torch.int32)
+            ex.input("in0", ncnn.Mat(x.numpy()).clone())
+
+            ret, ncnn_out0 = ex.extract("out0")
+            assert ret == 0, ret
+            n = ncnn_out0.numpy("i")
+            print(n.shape)
+            n = torch.from_numpy(n).to(torch.bool)
+            print(n)
+            assert torch.equal(t, n), (t, n)
+
+
+torch.set_num_threads(1)
+torch.set_num_interop_threads(1)
+if __name__ == "__main__":
+    torch.manual_seed(202208010)
+    main()

--- a/egs/librispeech/ASR/pruned_transducer_stateless3/test_ncnn_relpositional_encoding.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless3/test_ncnn_relpositional_encoding.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+
+
+import ncnn
+import numpy as np
+import torch
+
+
+@torch.no_grad()
+def main():
+    x = torch.rand(100, 512)  # (T, C)
+    m = torch.jit.load("foo/encoder_pos.pt")
+    _, t = m(x.unsqueeze(0))  # bach size is 1
+    t = t.squeeze(0)  # (T, C)
+
+    param = "foo/encoder_pos.ncnn.param"
+    model = "foo/encoder_pos.ncnn.bin"
+    with ncnn.Net() as net:
+        net.load_param(param)
+        net.load_model(model)
+        with net.create_extractor() as ex:
+            ex.input("in0", ncnn.Mat(x.numpy()).clone())
+
+            ret, ncnn_out0 = ex.extract("out1")
+            assert ret == 0, ret
+            n = np.array(ncnn_out0)
+            print(n.shape)  # (6, 512), (T, C)
+            n = torch.from_numpy(n)
+
+            print(t.reshape(-1)[:10])
+            print(n.reshape(-1)[:10])
+            assert torch.allclose(t, n), (t - n).abs().max()
+
+
+torch.set_num_threads(1)
+torch.set_num_interop_threads(1)
+if __name__ == "__main__":
+    torch.manual_seed(20220808)
+    main()


### PR DESCRIPTION
The aim of this PR is to support exporting pretrained models in a way such that they can be used by other inference frameworks such as
- [ ] [mace](https://github.com/xiaomi/mace)
- [ ] [ncnn](https://github.com/tencent/ncnn)

and possibly others like: [tnn](https://github.com/tencent/tnn), [mnn](https://github.com/alibaba/MNN), etc.

We can also use the quantization support from the above frameworks, e.g., using full int8 support from [ncnn](https://github.com/tencent/ncnn)

As the first step, I am using [pnnx](https://github.com/Tencent/ncnn/tree/master/tools/pnnx) as the intermediate format.

---

It requires
https://github.com/csukuangfj/ncnn/pull/1