### PR TITLE
Add clamping operation in Eve optimizer for all scalar weights

### DIFF
--- a/egs/librispeech/ASR/pruned_transducer_stateless2/optim.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless2/optim.py
@@ -164,6 +164,10 @@ class Eve(Optimizer):
                     p.mul_(1 - (weight_decay * is_above_target_rms))
                 p.addcdiv_(exp_avg, denom, value=-step_size)
 
+                # Constrain the range of scalar weights
+                if p.numel() == 1:
+                    p.clamp_(min=-10, max=2)
+
         return loss
 
 


### PR DESCRIPTION
Add clamping operation in Eve optimizer for all scalar weights to avoid INF loss during training in some scenarios #534 . The clamping range is set to (-10,2).
Note: This change may cause unexpected effect if you resume training from a model that is trained without clamping.