### PR TITLE
exporting projection layers of joiner separately for onnx

### DIFF
--- a/.github/scripts/run-librispeech-pruned-transducer-stateless3-2022-05-13.sh
+++ b/.github/scripts/run-librispeech-pruned-transducer-stateless3-2022-05-13.sh
@@ -59,8 +59,8 @@ log "Decode with ONNX models"
   --onnx-encoder-filename $repo/exp/encoder.onnx \
   --onnx-decoder-filename $repo/exp/decoder.onnx \
   --onnx-joiner-filename $repo/exp/joiner.onnx \
-  --onnx-joiner-filename $repo/exp/joiner_encoder_proj.onnx \
-  --onnx-joiner-filename $repo/exp/joiner_decoder_proj.onnx
+  --onnx-joiner-encoder-proj-filename $repo/exp/joiner_encoder_proj.onnx \
+  --onnx-joiner-decoder-proj-filename $repo/exp/joiner_decoder_proj.onnx
 
 ./pruned_transducer_stateless3/onnx_check_all_in_one.py \
   --jit-filename $repo/exp/cpu_jit.pt \

--- a/.github/scripts/run-librispeech-pruned-transducer-stateless3-2022-05-13.sh
+++ b/.github/scripts/run-librispeech-pruned-transducer-stateless3-2022-05-13.sh
@@ -58,7 +58,9 @@ log "Decode with ONNX models"
   --jit-filename $repo/exp/cpu_jit.pt \
   --onnx-encoder-filename $repo/exp/encoder.onnx \
   --onnx-decoder-filename $repo/exp/decoder.onnx \
-  --onnx-joiner-filename $repo/exp/joiner.onnx
+  --onnx-joiner-filename $repo/exp/joiner.onnx \
+  --onnx-joiner-filename $repo/exp/joiner_encoder_proj.onnx \
+  --onnx-joiner-filename $repo/exp/joiner_decoder_proj.onnx
 
 ./pruned_transducer_stateless3/onnx_check_all_in_one.py \
   --jit-filename $repo/exp/cpu_jit.pt \

--- a/egs/librispeech/ASR/pruned_transducer_stateless3/export.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless3/export.py
@@ -62,12 +62,14 @@ It will generates 3 files: `encoder_jit_trace.pt`,
   --avg 10 \
   --onnx 1
 
-It will generate the following three files in the given `exp_dir`.
+It will generate the following six files in the given `exp_dir`.
 Check `onnx_check.py` for how to use them.
 
     - encoder.onnx
     - decoder.onnx
     - joiner.onnx
+    - joiner_encoder_proj.onnx
+    - joiner_decoder_proj.onnx
     - all_in_one.onnx
 
 

--- a/egs/librispeech/ASR/pruned_transducer_stateless3/export.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless3/export.py
@@ -498,7 +498,7 @@ def export_joiner_model_onnx(
     encoder_out = torch.rand(1, 1, 1, encoder_out_dim, dtype=torch.float32)
     decoder_out = torch.rand(1, 1, 1, decoder_out_dim, dtype=torch.float32)
 
-    project_input = False
+    project_input = True
     # Note: It uses torch.jit.trace() internally
     torch.onnx.export(
         joiner_model,

--- a/egs/librispeech/ASR/pruned_transducer_stateless3/export.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless3/export.py
@@ -116,15 +116,19 @@ import argparse
 import logging
 from pathlib import Path
 
-import onnx
 import onnx_graphsurgeon as gs
+import onnx
 import sentencepiece as spm
 import torch
 import torch.nn as nn
 from scaling_converter import convert_scaled_to_non_scaled
 from train import add_model_arguments, get_params, get_transducer_model
 
-from icefall.checkpoint import average_checkpoints, find_checkpoints, load_checkpoint
+from icefall.checkpoint import (
+    average_checkpoints,
+    find_checkpoints,
+    load_checkpoint,
+)
 from icefall.utils import str2bool
 
 

--- a/egs/librispeech/ASR/pruned_transducer_stateless3/export.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless3/export.py
@@ -222,6 +222,9 @@ def get_parser():
             - encoder.onnx
             - decoder.onnx
             - joiner.onnx
+            - joiner_encoder_proj.onnx
+            - joiner_decoder_proj.onnx
+            - all_in_one.onnx
 
         Check ./onnx_check.py and ./onnx_pretrained.py for how to use them.
         """,


### PR DESCRIPTION
1. Sherpa-onnx requires projection layers separately. Corresponding issue is [here](https://github.com/k2-fsa/sherpa-onnx/issues/7). 
2. "blank_id/unk_id/context_size" parameters are stored in all_in_one.onnx internally anymore.