### PR TITLE
Remove tail padding for non-streaming models

### DIFF
--- a/egs/librispeech/ASR/pruned_transducer_stateless2/decode.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless2/decode.py
@@ -380,14 +380,13 @@ def decode_one_batch(
     supervisions = batch["supervisions"]
     feature_lens = supervisions["num_frames"].to(device)
 
-    feature_lens += params.left_context
-    feature = torch.nn.functional.pad(
-        feature,
-        pad=(0, 0, 0, params.left_context),
-        value=LOG_EPS,
-    )
-
     if params.simulate_streaming:
+        feature_lens += params.left_context
+        feature = torch.nn.functional.pad(
+            feature,
+            pad=(0, 0, 0, params.left_context),
+            value=LOG_EPS,
+        )
         encoder_out, encoder_out_lens, _ = model.encoder.streaming_forward(
             x=feature,
             x_lens=feature_lens,

--- a/egs/librispeech/ASR/pruned_transducer_stateless3/decode.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless3/decode.py
@@ -462,14 +462,13 @@ def decode_one_batch(
     supervisions = batch["supervisions"]
     feature_lens = supervisions["num_frames"].to(device)
 
-    feature_lens += params.left_context
-    feature = torch.nn.functional.pad(
-        feature,
-        pad=(0, 0, 0, params.left_context),
-        value=LOG_EPS,
-    )
-
     if params.simulate_streaming:
+        feature_lens += params.left_context
+        feature = torch.nn.functional.pad(
+            feature,
+            pad=(0, 0, 0, params.left_context),
+            value=LOG_EPS,
+        )
         encoder_out, encoder_out_lens, _ = model.encoder.streaming_forward(
             x=feature,
             x_lens=feature_lens,

--- a/egs/librispeech/ASR/pruned_transducer_stateless4/decode.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless4/decode.py
@@ -392,14 +392,13 @@ def decode_one_batch(
     supervisions = batch["supervisions"]
     feature_lens = supervisions["num_frames"].to(device)
 
-    feature_lens += params.left_context
-    feature = torch.nn.functional.pad(
-        feature,
-        pad=(0, 0, 0, params.left_context),
-        value=LOG_EPS,
-    )
-
     if params.simulate_streaming:
+        feature_lens += params.left_context
+        feature = torch.nn.functional.pad(
+            feature,
+            pad=(0, 0, 0, params.left_context),
+            value=LOG_EPS,
+        )
         encoder_out, encoder_out_lens, _ = model.encoder.streaming_forward(
             x=feature,
             x_lens=feature_lens,

--- a/egs/librispeech/ASR/pruned_transducer_stateless5/decode.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless5/decode.py
@@ -378,14 +378,13 @@ def decode_one_batch(
     supervisions = batch["supervisions"]
     feature_lens = supervisions["num_frames"].to(device)
 
-    feature_lens += params.left_context
-    feature = torch.nn.functional.pad(
-        feature,
-        pad=(0, 0, 0, params.left_context),
-        value=LOG_EPS,
-    )
-
     if params.simulate_streaming:
+        feature_lens += params.left_context
+        feature = torch.nn.functional.pad(
+            feature,
+            pad=(0, 0, 0, params.left_context),
+            value=LOG_EPS,
+        )
         encoder_out, encoder_out_lens, _ = model.encoder.streaming_forward(
             x=feature,
             x_lens=feature_lens,


### PR DESCRIPTION
I found that there are many insertion errors at the tail of our results when I was debuging why `modified_beam_search` has worse results than `greedy_search`. I think the issue is we padded too much zero frames to the end of acoustic, and this has larger impact on `modified_beam_search`, so I got worse results when decoding with `modified_beam_search`.

```
grep "*->.*)$" errs-test-clean-greedy_search-epoch-25-avg-7-context-2-max-sym-per-frame-1-use-averaged-model.txt
1221-135767-0008-2333-0:        COME THEREFORE AND LET US FLING MUD AT THEM (*->COME)
1284-1180-0022-617-0:   I'M AFRAID I DON'T KNOW MUCH ABOUT THE LAND OF OZ (*->NO)
1320-122612-0014-1500-0:        THE EXAMINATION HOWEVER RESULTED IN NO DISCOVERY (*->HOWEVER)
1580-141083-0018-2474-0:        NOW MISTER (SOAMES->SOLMES) AT YOUR DISPOSAL (*->NO)
1580-141084-0035-2440-0:        HE COULD EXAMINE THE PAPERS IN HIS OWN OFFICE (*->HE SAID)
260-123440-0014-2036-0: AND I DECLARE IT'S TOO BAD THAT IT IS (*->TOO)
3575-170457-0032-876-0: COME COME (I AM->I'M) GETTING REALLY TIRED OF YOUR ABSENCE (*->COME)
4446-2273-0022-726-0:   THEY WERE BOTH REMEMBERING WHAT THE WOMAN HAD SAID WHEN SHE TOOK THE MONEY GOD GIVE YOU A HAPPY LOVE (*->AND)
4446-2275-0004-662-0:   ALEXANDER DID NOT (SIT->SET) DOWN (*->BUT)
5142-33396-0039-233-0:  I NAMED NINE OTHERS AND SAID (*->HE)
5142-33396-0041-235-0:  SO I SET GUARDS OVER (EVERY ONE->EVERYONE) IN THAT HOUSE (*->AND)
5683-32879-0015-448-0:  YES SAID RACHEL (*->WELL)
61-70968-0010-51-0:     FORTHWITH ALL RAN TO THE OPENING OF THE TENT TO SEE WHAT MIGHT BE AMISS BUT MASTER WILL WHO PEEPED OUT FIRST NEEDED NO MORE THAN ONE GLANCE (*->YES)
61-70968-0043-84-0:     FRIENDS SAID MONTFICHET FAINTLY TO THE WRESTLERS BEAR US ESCORT SO FAR AS THE SHERIFF'S HOUSE (*->AND)
61-70970-0012-12-0:     YET HE WILL TEACH YOU A FEW TRICKS WHEN MORNING IS COME (*->AND)
672-122797-0036-1386-0: HUMPY (DUMPY->DON'T BE) FELL DOWNSTAIRS AND YET HE MARRIED THE PRINCESS (*->SHE SAID)
6829-68769-0023-1149-0: I DIDN'T STOP TO THINK WHETHER IT WAS FOOLISH OR NOT I DID IT AND I'M GLAD I DID (*->IT)
6829-68769-0027-1153-0: WHOSE NAME DID YOU SIGN TO THE CHECK ASKED KENNETH (*->NO)
6829-68769-0037-1163-0: I'VE SEEN LOTS OF THAT KIND (IN->OF) MY DAY (*->AND)
6829-68771-0012-1192-0: THIS WAS THE FIRST OCCASION WITHIN A GENERATION WHEN SUCH AN ENTERTAINMENT HAD BEEN GIVEN AT ELMHURST AND THE ONLY (ONE->WHEN) WITHIN THE MEMORY OF MAN WHERE THE NEIGHBORS AND COUNTRY PEOPLE HAD BEEN (*->THE) INVITED (GUESTS->GUEST)
6930-75918-0002-768-0:  CONGRATULATIONS WERE POURED IN UPON THE PRINCESS EVERYWHERE DURING HER JOURNEY (*->AND)
7176-92135-0032-995-0:  HOW YOU MAY BE WONDERING ARE YOU TO BEGIN YOUR MASTERPIECE (*->WHY)
8463-294828-0024-1569-0:        WE DON'T KNOW WHERE IT WILL TAKE US (*->NO)
```

Actually, I think we don't need tail paddings for non-streaming models, the following is my decoding results:

| decoding method | no tail padding | with tail padding (64 frames in current master) |
| --- | ---- | --- |
| greedy_search |  2.66 & 6.27 | 2.7 & 6.38  |
| fast_beam_search | 2.67 & 6.2 | 2.77 & 6.39  |
| modified_beam_search |  2.62 & 6.08  | 2.75 & 6.37 |

