### PR TITLE
Add kaldifst to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ onnx
 onnxruntime
 --extra-index-url https://pypi.ngc.nvidia.com
 dill
+kaldifst


### PR DESCRIPTION
#630 adds shallow_fusion, which requires kaldifst. This PR adds kaldifst to requirements.txt