### PR TITLE
fix mask errors when padding audios

### DIFF
--- a/icefall/utils.py
+++ b/icefall/utils.py
@@ -1017,7 +1017,7 @@ def add_eos(ragged: k2.RaggedTensor, eos_id: int) -> k2.RaggedTensor:
     return concat(ragged, eos_id, direction="right")
 
 
-def make_pad_mask(lengths: torch.Tensor,  max_len: int = 0) -> torch.Tensor:
+def make_pad_mask(lengths: torch.Tensor, max_len: int = 0) -> torch.Tensor:
     """
     Args:
       lengths:

--- a/icefall/utils.py
+++ b/icefall/utils.py
@@ -1017,11 +1017,13 @@ def add_eos(ragged: k2.RaggedTensor, eos_id: int) -> k2.RaggedTensor:
     return concat(ragged, eos_id, direction="right")
 
 
-def make_pad_mask(lengths: torch.Tensor) -> torch.Tensor:
+def make_pad_mask(lengths: torch.Tensor,  max_len: int = 0) -> torch.Tensor:
     """
     Args:
       lengths:
         A 1-D tensor containing sentence lengths.
+      max_len:
+        The length of masks.
     Returns:
       Return a 2-D bool tensor, where masked positions
       are filled with `True` and non-masked positions are
@@ -1035,8 +1037,7 @@ def make_pad_mask(lengths: torch.Tensor) -> torch.Tensor:
             [False, False, False, False, False]])
     """
     assert lengths.ndim == 1, lengths.ndim
-
-    max_len = lengths.max()
+    max_len = max(max_len, lengths.max())
     n = lengths.size(0)
 
     expaned_lengths = torch.arange(max_len).expand(n, max_len).to(lengths)


### PR DESCRIPTION
Here https://github.com/k2-fsa/icefall/blob/master/egs/librispeech/ASR/pruned_transducer_stateless2/conformer.py#L159, we assert `x.size(0) == lengths.max().item() `. It's correct during training time. However, when I tried to send multiple audios from different clients, to dynamic batch the requests, I padded all audios to the nearest 5 before sending them. Then it would cause an error if x.size(0) > mask.size(-1) (for attention scores masking).

This PR fixed the error and we need to use mask = make_pad_mask(lengths, x.size(0)) when dynamic batch with onnx or jit.