### PR TITLE
Pruned transducer stateless5 for LibriSpeech

### DIFF
--- a/egs/librispeech/ASR/pruned_transducer_stateless5/export.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless5/export.py
@@ -50,6 +50,7 @@ from pathlib import Path
 
 import sentencepiece as spm
 import torch
+from scaling_converter import convert_scaled_to_non_scaled
 from train import add_model_arguments, get_params, get_transducer_model
 
 from icefall.checkpoint import (
@@ -263,6 +264,7 @@ def main():
         # it here.
         # Otherwise, one of its arguments is a ragged tensor and is not
         # torch scriptabe.
+        convert_scaled_to_non_scaled(model, inplace=True)
         model.__class__.forward = torch.jit.ignore(model.__class__.forward)
         logging.info("Using torch.jit.script")
         model = torch.jit.script(model)

--- a/egs/librispeech/ASR/pruned_transducer_stateless5/lstmp.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless5/lstmp.py
@@ -1,0 +1,1 @@
+../lstm_transducer_stateless2/lstmp.py

--- a/egs/librispeech/ASR/pruned_transducer_stateless5/scaling_converter.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless5/scaling_converter.py
@@ -1,0 +1,1 @@
+../pruned_transducer_stateless3/scaling_converter.py


### PR DESCRIPTION
Fix the failure of converting models to torch.jit.script
The conversion command is :
```
./pruned_transducer_stateless5/export.py \
  --exp-dir ./pruned_transducer_stateless5/exp \
  --bpe-model data/lang_bpe_500/bpe.model \
  --epoch 20 \
  --avg 10 \
  --jit 1
```