### PR TITLE
Enable packing for ncnn decoding

### DIFF
--- a/.github/scripts/run-librispeech-lstm-transducer-stateless2-2022-09-03.yml
+++ b/.github/scripts/run-librispeech-lstm-transducer-stateless2-2022-09-03.yml
@@ -63,7 +63,7 @@ log "Test exporting to pnnx format"
 ./ncnn/tools/pnnx/build/src/pnnx $repo/exp/decoder_jit_trace-pnnx.pt
 ./ncnn/tools/pnnx/build/src/pnnx $repo/exp/joiner_jit_trace-pnnx.pt
 
-./lstm_transducer_stateless2/ncnn-decode.py \
+time ./lstm_transducer_stateless2/ncnn-decode.py \
  --bpe-model-filename $repo/data/lang_bpe_500/bpe.model \
  --encoder-param-filename $repo/exp/encoder_jit_trace-pnnx.ncnn.param \
  --encoder-bin-filename $repo/exp/encoder_jit_trace-pnnx.ncnn.bin \
@@ -73,7 +73,7 @@ log "Test exporting to pnnx format"
  --joiner-bin-filename $repo/exp/joiner_jit_trace-pnnx.ncnn.bin \
  $repo/test_wavs/1089-134686-0001.wav
 
-./lstm_transducer_stateless2/streaming-ncnn-decode.py \
+time ./lstm_transducer_stateless2/streaming-ncnn-decode.py \
  --bpe-model-filename $repo/data/lang_bpe_500/bpe.model \
  --encoder-param-filename $repo/exp/encoder_jit_trace-pnnx.ncnn.param \
  --encoder-bin-filename $repo/exp/encoder_jit_trace-pnnx.ncnn.bin \
@@ -82,7 +82,6 @@ log "Test exporting to pnnx format"
  --joiner-param-filename $repo/exp/joiner_jit_trace-pnnx.ncnn.param \
  --joiner-bin-filename $repo/exp/joiner_jit_trace-pnnx.ncnn.bin \
  $repo/test_wavs/1089-134686-0001.wav
-
 
 
 log "Test exporting with torch.jit.trace()"

--- a/egs/librispeech/ASR/lstm_transducer_stateless2/streaming-ncnn-decode.py
+++ b/egs/librispeech/ASR/lstm_transducer_stateless2/streaming-ncnn-decode.py
@@ -90,8 +90,6 @@ class Model:
 
     def init_encoder(self, args):
         encoder_net = ncnn.Net()
-        encoder_net.opt.use_packing_layout = False
-        encoder_net.opt.use_fp16_storage = False
         encoder_param = args.encoder_param_filename
         encoder_model = args.encoder_bin_filename
 
@@ -105,7 +103,6 @@ class Model:
         decoder_model = args.decoder_bin_filename
 
         decoder_net = ncnn.Net()
-        decoder_net.opt.use_packing_layout = False
 
         decoder_net.load_param(decoder_param)
         decoder_net.load_model(decoder_model)
@@ -116,7 +113,6 @@ class Model:
         joiner_param = args.joiner_param_filename
         joiner_model = args.joiner_bin_filename
         joiner_net = ncnn.Net()
-        joiner_net.opt.use_packing_layout = False
         joiner_net.load_param(joiner_param)
         joiner_net.load_model(joiner_model)
 


### PR DESCRIPTION
Enable packing from https://github.com/Tencent/ncnn/wiki/element-packing

It was disabled since ncnn did not support LSTM with projection.

I have updated http://github.com/csukuangfj/ncnn to use the LSTM with projection from ncnn.

For a test wave, it reduces the decoding time from 14.33 seconds to 1.76 seconds.