### PR TITLE
Fix for older versions of k2

### DIFF
--- a/icefall/graph_compiler.py
+++ b/icefall/graph_compiler.py
@@ -81,7 +81,7 @@ class CtcTrainingGraphCompiler(object):
 
         self.ctc_topo._is_repeat_token_ = (
             self.ctc_topo.labels != self.ctc_topo.aux_labels
-        )
+        ).int()
 
         decoding_graph = k2.compose(
             self.ctc_topo, fsa_with_self_loops, treat_epsilons_specially=False


### PR DESCRIPTION
See #724
Older versions of k2 do not support using a bool tensor for indexing.

The change was introduced by https://github.com/k2-fsa/icefall/pull/669

I suggest that we always add test to cover new changes.

