### PR TITLE
fix wenet stateless5 jit export error

### DIFF
--- a/egs/wenetspeech/ASR/pruned_transducer_stateless5/export.py
+++ b/egs/wenetspeech/ASR/pruned_transducer_stateless5/export.py
@@ -74,6 +74,7 @@ import logging
 from pathlib import Path
 
 import torch
+from scaling_converter import convert_scaled_to_non_scaled
 from train import add_model_arguments, get_params, get_transducer_model
 
 from icefall.checkpoint import average_checkpoints, load_checkpoint
@@ -184,6 +185,7 @@ def main():
         # it here.
         # Otherwise, one of its arguments is a ragged tensor and is not
         # torch scriptabe.
+        convert_scaled_to_non_scaled(model, inplace=True)
         model.__class__.forward = torch.jit.ignore(model.__class__.forward)
         logging.info("Using torch.jit.script")
         model = torch.jit.script(model)

--- a/egs/wenetspeech/ASR/pruned_transducer_stateless5/lstmp.py
+++ b/egs/wenetspeech/ASR/pruned_transducer_stateless5/lstmp.py
@@ -1,0 +1,1 @@
+../../../librispeech/ASR/pruned_transducer_stateless5/lstmp.py

--- a/egs/wenetspeech/ASR/pruned_transducer_stateless5/scaling_converter.py
+++ b/egs/wenetspeech/ASR/pruned_transducer_stateless5/scaling_converter.py
@@ -1,0 +1,1 @@
+../../../librispeech/ASR/pruned_transducer_stateless5/scaling_converter.py


### PR DESCRIPTION
apply `convert_scaled_to_non_scaled` to wenet pruned_transducer_stateless5 model when using jit export as @csukuangfj   [suggested](https://github.com/k2-fsa/icefall/issues/733#issuecomment-1337014509), I've exported models from [here](https://huggingface.co/luomingshuang/icefall_asr_wenetspeech_pruned_transducer_stateless5_streaming) and successfully ran the cpu_jit model in sherpa.