### PR TITLE
[WIP] Smaller models

### DIFF
--- a/egs/librispeech/ASR/RESULTS.md
+++ b/egs/librispeech/ASR/RESULTS.md
@@ -1,5 +1,7 @@
 ## Results
 
+Add results for smaller models here.
+
 ### pruned_transducer_stateless7_ctc (zipformer with transducer loss and ctc loss)
 
 See <https://github.com/k2-fsa/icefall/pull/683> for more details.


### PR DESCRIPTION
I create this PR to post my current results for smaller models (i.e. the models with less parameters).  I'd say the parameters used to construct the models were chosen arbitrarily. The aim is to tune a good model with around 15M parameters.  The following results were based on `pruned_transducer_stateless5`, will try zipformer and update the results once available.


Num of params | Greedy search | Modified beam search | Fast beam search | Fast beam search LG |   | Model desc
-- | -- | -- | -- | -- | -- | --
8.6 M | 4.24 & 10.2 | 4.09 & 10.03 | 4.13 & 9.89 | 4.11 & 9.59 | --epoch 25 --avg 3 | --num-encoder-layers 16 --encoder-dim 144 --decoder-dim 320 --dim-feedforward 512 --nhead 4 --joiner-dim 320
8.8 M | 4.13 & 10.22 | 4.01 & 9.84 | 4.05 & 9.83 | 4.09 & 9.55 | --epoch 25 --avg 2 | --num-encoder-layers 16 --encoder-dim 144 --decoder-dim 320 --dim-feedforward 512 --nhead 4 --joiner-dim 512
10.4M | 4.03 & 10.11 | 3.89 & 9.82 | 3.97 & 9.91 | 4.0 & 9.51 | --epoch 25 --avg 3 | --num-encoder-layers 12 --encoder-dim 144 --decoder-dim 320 --dim-feedforward 1024 --nhead 4 --joiner-dim 512
19 M | 3.29 & 8.24 | 3.17 & 8.02 | 3.25 & 8.01 | 3.33 & 7.93 | --epoch 25 --avg 6 | --num-encoder-layers 16 --encoder-dim 256 --decoder-dim 512 --dim-feedforward 512 --nhead 4 --joiner-dim 512
15 M | 3.7 & 8.94 | 3.56 & 8.71 | 3.62 & 8.68 | 3.7 & 8.53 | --epoch 25 --avg 3 | --num-encoder-layers 12 --encoder-dim 256 --decoder-dim 512 --dim-feedforward 512 --nhead 4 --joiner-dim 512

These models are all non-streaming models, if someone need them, I can upload them to huggingface.