### PR TITLE
fix for memory usage in pruned_transducer_stateless7/scaling.py

### DIFF
--- a/egs/librispeech/ASR/pruned_transducer_stateless7/scaling.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless7/scaling.py
@@ -562,7 +562,7 @@ class ActivationBalancer(torch.nn.Module):
                 sign_factor = None
 
             scale_factor = _compute_scale_factor(
-                x,
+                x.detach(),
                 self.channel_dim,
                 min_abs=self.min_abs,
                 max_abs=self.max_abs,


### PR DESCRIPTION
Fix for memory usage... in pruned_transducer_stateless7/scaling.py, when _compute_scale_factor is called, it should be called with x.detach(), not x. 