### PR TITLE
Fix distillation with HuBERT

### DIFF
--- a/egs/librispeech/ASR/distillation_with_hubert.sh
+++ b/egs/librispeech/ASR/distillation_with_hubert.sh
@@ -23,8 +23,8 @@
 # To start from scratch, you can
 # set stage=0, stop_stage=4, use_extracted_codebook=False
 
-stage=0
-stop_stage=4
+stage=2
+stop_stage=2
 
 # Set the GPUs available.
 # This script requires at least one GPU.
@@ -49,7 +49,7 @@ full_libri=False
 #   "True" -> stage 0 and stage 1 would be skipped,
 #     and directly download the extracted codebook indexes for distillation
 #   "False" -> start from scratch
-use_extracted_codebook=False
+use_extracted_codebook=True
 
 # teacher_model_id can be one of
 #   "hubert_xtralarge_ll60k_finetune_ls960" -> fine-tuned model, it is the one we currently use.
@@ -155,8 +155,16 @@ if [ $stage -le 2 ] && [ $stop_stage -ge 2 ]; then
     fi
     log "Downloading extracted codebook indexes to $codebook_download_dir"
     # Make sure you have git-lfs installed (https://git-lfs.github.com)
+    # The codebook indexes are generated using lhotse 1.11.0, to avoid
+    # potential issues, we recommend you to use the same version of lhotse
+    # to run `prepare.sh`.
+    lhotse_version=$(python3 -c "import lhotse; print(lhotse.version.__version__)")
+    if [ "$lhotse_version" != "1.11.0" ]; then
+      log "Using the wrong lhotse version(Expected: 1.11.0, but using $lhotse_version). Please install lhotse 1.11.0 before proceeding. Try pip install lhotse==1.11.0"
+      exit 1
+    fi
     git lfs install
-    git clone https://huggingface.co/Zengwei/pruned_transducer_stateless6_hubert_xtralarge_ll60k_finetune_ls960 $codebook_download_dir
+    git clone https://huggingface.co/marcoyang/pruned_transducer_stateless6_hubert_xtralarge_ll60k_finetune_ls960 $codebook_download_dir
 
     mkdir -p data/vq_fbank
     mv $codebook_download_dir/*.jsonl.gz data/vq_fbank/

--- a/egs/librispeech/ASR/distillation_with_hubert.sh
+++ b/egs/librispeech/ASR/distillation_with_hubert.sh
@@ -157,7 +157,7 @@ if [ $stage -le 2 ] && [ $stop_stage -ge 2 ]; then
     # Make sure you have git-lfs installed (https://git-lfs.github.com)
     # The codebook indexes are generated using lhotse 1.11.0, to avoid
     # potential issues, we recommend you to use lhotse version >= 1.11.0
-    lhotse_version=$(python3 -c "import lhotse; print(lhotse.version.__version__>='1.11.0)")
+    lhotse_version=$(python3 -c "import lhotse; from packaging import version; print(version.parse(lhotse.version.__version__)>=version.parse('1.11.0'))")
     if [ "$lhotse_version" == "False" ]; then
       log "Expecting lhotse >= 1.11.0. This may lead to potential ID mismatch."
     fi

--- a/egs/librispeech/ASR/distillation_with_hubert.sh
+++ b/egs/librispeech/ASR/distillation_with_hubert.sh
@@ -23,8 +23,8 @@
 # To start from scratch, you can
 # set stage=0, stop_stage=4, use_extracted_codebook=False
 
-stage=2
-stop_stage=2
+stage=0
+stop_stage=4
 
 # Set the GPUs available.
 # This script requires at least one GPU.
@@ -35,7 +35,7 @@ stop_stage=2
 # export CUDA_VISIBLE_DEVICES="0"
 #
 # Suppose GPU 2,3,4,5 are available.
-export CUDA_VISIBLE_DEVICES="0,1,2,3"
+# export CUDA_VISIBLE_DEVICES="0,1,2,3"
 
 exp_dir=./pruned_transducer_stateless6/exp
 mkdir -p $exp_dir

--- a/egs/librispeech/ASR/distillation_with_hubert.sh
+++ b/egs/librispeech/ASR/distillation_with_hubert.sh
@@ -156,12 +156,10 @@ if [ $stage -le 2 ] && [ $stop_stage -ge 2 ]; then
     log "Downloading extracted codebook indexes to $codebook_download_dir"
     # Make sure you have git-lfs installed (https://git-lfs.github.com)
     # The codebook indexes are generated using lhotse 1.11.0, to avoid
-    # potential issues, we recommend you to use the same version of lhotse
-    # to run `prepare.sh`.
-    lhotse_version=$(python3 -c "import lhotse; print(lhotse.version.__version__)")
-    if [ "$lhotse_version" != "1.11.0" ]; then
-      log "Using the wrong lhotse version(Expected: 1.11.0, but using $lhotse_version). Please install lhotse 1.11.0 before proceeding. Try pip install lhotse==1.11.0"
-      exit 1
+    # potential issues, we recommend you to use lhotse version >= 1.11.0
+    lhotse_version=$(python3 -c "import lhotse; print(lhotse.version.__version__>='1.11.0)")
+    if [ "$lhotse_version" == "False" ]; then
+      log "Expecting lhotse >= 1.11.0. This may lead to potential ID mismatch."
     fi
     git lfs install
     git clone https://huggingface.co/marcoyang/pruned_transducer_stateless6_hubert_xtralarge_ll60k_finetune_ls960 $codebook_download_dir

--- a/egs/librispeech/ASR/pruned_transducer_stateless6/vq_utils.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless6/vq_utils.py
@@ -245,7 +245,7 @@ class CodebookIndexExtractor:
             cuts_vq = load_manifest(vq_manifest_path)
             cuts_ori = load_manifest(ori_manifest_path)
             assert len(cuts_vq) == len(cuts_ori), "Cuts should have the same length!"
-            
+
             if set(cuts_vq.ids) == set(cuts_ori.ids):
                 # IDs match exactly
                 cuts_vq = cuts_vq.sort_like(cuts_ori)
@@ -259,19 +259,21 @@ class CodebookIndexExtractor:
                 ori_id_map = {}
                 for id in cuts_ori.ids:
                     # some text normalization
-                    if 'sp' in id:
-                        clean_id = '-'.join(id.split('-')[:3]) + '_' + id.split('_')[-1]
+                    if "sp" in id:
+                        clean_id = "-".join(id.split("-")[:3]) + "_" + id.split("_")[-1]
                     else:
-                        clean_id = '-'.join(id.split('-')[:3])
+                        clean_id = "-".join(id.split("-")[:3])
                     ori_id_map[clean_id] = id
 
                 for id in cuts_vq.ids:
-                    if 'sp' in id:
-                        clean_id = '-'.join(id.split('-')[:3]) + '_' + id.split('_')[-1]
+                    if "sp" in id:
+                        clean_id = "-".join(id.split("-")[:3]) + "_" + id.split("_")[-1]
                     else:
-                        clean_id = '-'.join(id.split('-')[:3])
+                        clean_id = "-".join(id.split("-")[:3])
                     assert clean_id in ori_id_map, clean_id
-                    cuts_ori[ori_id_map[clean_id]].codebook_indexes = cuts_vq[id].codebook_indexes
+                    cuts_ori[ori_id_map[clean_id]].codebook_indexes = cuts_vq[
+                        id
+                    ].codebook_indexes
 
             CutSet.from_cuts(cuts_ori).to_jsonl(dst_vq_manifest_path)
             logging.info(f"Processed {subset}.")

--- a/egs/librispeech/ASR/pruned_transducer_stateless6/vq_utils.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless6/vq_utils.py
@@ -244,10 +244,25 @@ class CodebookIndexExtractor:
             )
             cuts_vq = load_manifest(vq_manifest_path)
             cuts_ori = load_manifest(ori_manifest_path)
-            cuts_vq = cuts_vq.sort_like(cuts_ori)
-            for cut_idx, (cut_vq, cut_ori) in enumerate(zip(cuts_vq, cuts_ori)):
-                assert cut_vq.id == cut_ori.id
-                cut_ori.codebook_indexes = cut_vq.codebook_indexes
+            assert len(cuts_vq) == len(cuts_ori), "Cuts should have the same length!"
+            
+            # get the mapping between audio and cut ID
+            ori_id_map = {}
+            for id in cuts_ori.ids:
+                # some text normalization
+                if 'sp' in id:
+                    clean_id = '-'.join(id.split('-')[:3]) + '_' + id.split('_')[-1]
+                else:
+                    clean_id = '-'.join(id.split('-')[:3])
+                ori_id_map[clean_id] = id
+
+            for id in cuts_vq.ids:
+                if 'sp' in id:
+                    clean_id = '-'.join(id.split('-')[:3]) + '_' + id.split('_')[-1]
+                else:
+                    clean_id = '-'.join(id.split('-')[:3])
+                assert clean_id in ori_id_map, clean_id
+                cuts_ori[ori_id_map[clean_id]].codebook_indexes = cuts_vq[id].codebook_indexes
 
             CutSet.from_cuts(cuts_ori).to_jsonl(dst_vq_manifest_path)
             logging.info(f"Processed {subset}.")

--- a/egs/librispeech/ASR/pruned_transducer_stateless6/vq_utils.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless6/vq_utils.py
@@ -246,7 +246,8 @@ class CodebookIndexExtractor:
             cuts_ori = load_manifest(ori_manifest_path)
             assert len(cuts_vq) == len(cuts_ori), "Cuts should have the same length!"
             
-            if set(cut_vq.ids) == set(cuts_ori.ids):
+            if set(cuts_vq.ids) == set(cuts_ori.ids):
+                # IDs match exactly
                 cuts_vq = cuts_vq.sort_like(cuts_ori)
                 for cut_idx, (cut_vq, cut_ori) in enumerate(zip(cuts_vq, cuts_ori)):
                     assert cut_vq.id == cut_ori.id
@@ -254,6 +255,7 @@ class CodebookIndexExtractor:
             else:
                 # in case of ID mismatch, remap them
                 # get the mapping between audio and cut ID
+                logging
                 ori_id_map = {}
                 for id in cuts_ori.ids:
                     # some text normalization

--- a/egs/librispeech/ASR/transducer_lstm/train.py
+++ b/egs/librispeech/ASR/transducer_lstm/train.py
@@ -629,17 +629,7 @@ def run(rank, world_size, args):
         # Keep only utterances with duration between 1 second and 20 seconds
         return 1.0 <= c.duration <= 20.0
 
-    num_in_total = len(train_cuts)
-
     train_cuts = train_cuts.filter(remove_short_and_long_utt)
-
-    num_left = len(train_cuts)
-    num_removed = num_in_total - num_left
-    removed_percent = num_removed / num_in_total * 100
-
-    logging.info(f"Before removing short and long utterances: {num_in_total}")
-    logging.info(f"After removing short and long utterances: {num_left}")
-    logging.info(f"Removed {num_removed} utterances ({removed_percent:.5f}%)")
 
     train_dl = librispeech.train_dataloaders(train_cuts)
 


### PR DESCRIPTION
This PR solves https://github.com/k2-fsa/icefall/issues/779.

Due to the change of naming conventions in lhotse, the old codebook indexes can not be merged with the original training manifest. The newly generated codebook index uses lhotse version of 1.11.0. Please re-run your `prepare.sh` with the same version before proceeding with `distillation_with_hubert.sh` to avoid the potential ID mismatch problem.