### PR TITLE
Conv-emformer MVQ

### DIFF
--- a/egs/librispeech/ASR/conv_emformer_transducer_stateless2/decode.py
+++ b/egs/librispeech/ASR/conv_emformer_transducer_stateless2/decode.py
@@ -541,7 +541,6 @@ def main():
     args = parser.parse_args()
     args.exp_dir = Path(args.exp_dir)
 
-    import pdb; pdb.set_trace()
     params = get_params()
     params.update(vars(args))
 


### PR DESCRIPTION
This PR adds MVQ KD support to recipe `conv_emformer_transducer_stateless2`. 

With 16 codebooks, the following WERs are achieved:
`greedy_search`:
| Model | Num Codebooks | test-clean | test-other  | 
| ----- | --- | ----| ---- | 
| Baseline | - | 3.50 | 9.09 |
| +MVQ, loss_scale=0.005 | 16 | 3.13 | 8.35 |
 
`modified_beam_search`:
| Model | Num Codebooks | test-clean | test-other  | 
| ----- | --- | ----| ---- | 
| Baseline | - | 3.43 | 8.86|
| +MVQ, loss_scale=0.005 | 16 | 3.08 | 8.18 |

Will upload the pre-trained models soon.
 

