### PR TITLE
Fix filename ctc_guild_decode_bs.py -> ctc_guide_decode_bs.py

### DIFF
--- a/docs/source/recipes/Non-streaming-ASR/librispeech/zipformer_ctc_blankskip.rst
+++ b/docs/source/recipes/Non-streaming-ASR/librispeech/zipformer_ctc_blankskip.rst
@@ -299,11 +299,11 @@ to run the training part first.
 
     - (1) ``epoch-1.pt``, ``epoch-2.pt``, ..., which are saved at the end
       of each epoch. You can pass ``--epoch`` to
-      ``pruned_transducer_stateless7_ctc_bs/ctc_guild_decode_bs.py`` to use them.
+      ``pruned_transducer_stateless7_ctc_bs/ctc_guide_decode_bs.py`` to use them.
 
     - (2) ``checkpoints-436000.pt``, ``epoch-438000.pt``, ..., which are saved
       every ``--save-every-n`` batches. You can pass ``--iter`` to
-      ``pruned_transducer_stateless7_ctc_bs/ctc_guild_decode_bs.py`` to use them.
+      ``pruned_transducer_stateless7_ctc_bs/ctc_guide_decode_bs.py`` to use them.
 
     We suggest that you try both types of checkpoints and choose the one
     that produces the lowest WERs.
@@ -311,7 +311,7 @@ to run the training part first.
 .. code-block:: bash
 
   $ cd egs/librispeech/ASR
-  $ ./pruned_transducer_stateless7_ctc_bs/ctc_guild_decode_bs.py --help
+  $ ./pruned_transducer_stateless7_ctc_bs/ctc_guide_decode_bs.py --help
 
 shows the options for decoding.
 
@@ -320,7 +320,7 @@ The following shows the example using ``epoch-*.pt``:
 .. code-block:: bash
 
     for m in greedy_search fast_beam_search modified_beam_search; do
-        ./pruned_transducer_stateless7_ctc_bs/ctc_guild_decode_bs.py \
+        ./pruned_transducer_stateless7_ctc_bs/ctc_guide_decode_bs.py \
             --epoch 30 \
             --avg 13 \
             --exp-dir pruned_transducer_stateless7_ctc_bs/exp \
@@ -333,7 +333,7 @@ To test CTC branch, you can use the following command:
 .. code-block:: bash
 
     for m in ctc-decoding 1best; do
-        ./pruned_transducer_stateless7_ctc_bs/ctc_guild_decode_bs.py \
+        ./pruned_transducer_stateless7_ctc_bs/ctc_guide_decode_bs.py \
             --epoch 30 \
             --avg 13 \
             --exp-dir pruned_transducer_stateless7_ctc_bs/exp \
@@ -367,7 +367,7 @@ It will generate a file ``./pruned_transducer_stateless7_ctc_bs/exp/pretrained.p
 
 .. hint::
 
-   To use the generated ``pretrained.pt`` for ``pruned_transducer_stateless7_ctc_bs/ctc_guild_decode_bs.py``,
+   To use the generated ``pretrained.pt`` for ``pruned_transducer_stateless7_ctc_bs/ctc_guide_decode_bs.py``,
    you can run:
 
    .. code-block:: bash
@@ -376,7 +376,7 @@ It will generate a file ``./pruned_transducer_stateless7_ctc_bs/exp/pretrained.p
       ln -s pretrained epoch-9999.pt
 
    And then pass ``--epoch 9999 --avg 1 --use-averaged-model 0`` to
-   ``./pruned_transducer_stateless7_ctc_bs/ctc_guild_decode_bs.py``.
+   ``./pruned_transducer_stateless7_ctc_bs/ctc_guide_decode_bs.py``.
 
 To use the exported model with ``./pruned_transducer_stateless7_ctc_bs/pretrained.py``, you
 can run:

--- a/egs/librispeech/ASR/RESULTS.md
+++ b/egs/librispeech/ASR/RESULTS.md
@@ -194,7 +194,7 @@ The decoding commands for the transducer branch of the model using blank skip ([
 for m in greedy_search modified_beam_search fast_beam_search; do
   for epoch in 30; do
     for avg in 15; do
-      ./pruned_transducer_stateless7_ctc_bs/ctc_guild_decode_bs.py \
+      ./pruned_transducer_stateless7_ctc_bs/ctc_guide_decode_bs.py \
           --epoch $epoch \
           --avg $avg \
           --use-averaged-model 1 \

--- a/egs/librispeech/ASR/pruned_transducer_stateless7_ctc_bs/ctc_guide_decode_bs.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless7_ctc_bs/ctc_guide_decode_bs.py
@@ -21,7 +21,7 @@
 """
 Usage:
 (1) greedy search
-./pruned_transducer_stateless7_ctc_bs/ctc_guild_decode_bs.py \
+./pruned_transducer_stateless7_ctc_bs/ctc_guide_decode_bs.py \
     --epoch 28 \
     --avg 15 \
     --exp-dir ./pruned_transducer_stateless7_ctc_bs/exp \
@@ -29,7 +29,7 @@ Usage:
     --decoding-method greedy_search
 
 (2) beam search (not recommended)
-./pruned_transducer_stateless7_ctc_bs/ctc_guild_decode_bs.py \
+./pruned_transducer_stateless7_ctc_bs/ctc_guide_decode_bs.py \
     --epoch 28 \
     --avg 15 \
     --exp-dir ./pruned_transducer_stateless7_ctc_bs/exp \
@@ -38,7 +38,7 @@ Usage:
     --beam-size 4
 
 (3) modified beam search
-./pruned_transducer_stateless7_ctc_bs/ctc_guild_decode_bs.py \
+./pruned_transducer_stateless7_ctc_bs/ctc_guide_decode_bs.py \
     --epoch 28 \
     --avg 15 \
     --exp-dir ./pruned_transducer_stateless7_ctc_bs/exp \
@@ -47,7 +47,7 @@ Usage:
     --beam-size 4
 
 (4) fast beam search (one best)
-./pruned_transducer_stateless7_ctc_bs/ctc_guild_decode_bs.py \
+./pruned_transducer_stateless7_ctc_bs/ctc_guide_decode_bs.py \
     --epoch 28 \
     --avg 15 \
     --exp-dir ./pruned_transducer_stateless7_ctc_bs/exp \
@@ -58,7 +58,7 @@ Usage:
     --max-states 64
 
 (5) fast beam search (nbest)
-./pruned_transducer_stateless7_ctc/ctc_guild_decode_bs.py \
+./pruned_transducer_stateless7_ctc/ctc_guide_decode_bs.py \
     --epoch 28 \
     --avg 15 \
     --exp-dir ./pruned_transducer_stateless7_ctc/exp \
@@ -71,7 +71,7 @@ Usage:
     --nbest-scale 0.5
 
 (6) fast beam search (nbest oracle WER)
-./pruned_transducer_stateless7_ctc_bs/ctc_guild_decode_bs.py \
+./pruned_transducer_stateless7_ctc_bs/ctc_guide_decode_bs.py \
     --epoch 28 \
     --avg 15 \
     --exp-dir ./pruned_transducer_stateless7_ctc_bs/exp \
@@ -84,7 +84,7 @@ Usage:
     --nbest-scale 0.5
 
 (7) fast beam search (with LG)
-./pruned_transducer_stateless7_ctc_bs/ctc_guild_decode_bs.py \
+./pruned_transducer_stateless7_ctc_bs/ctc_guide_decode_bs.py \
     --epoch 28 \
     --avg 15 \
     --exp-dir ./pruned_transducer_stateless7_ctc_bs/exp \

--- a/egs/librispeech/ASR/pruned_transducer_stateless7_ctc_bs/lconv.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless7_ctc_bs/lconv.py
@@ -62,7 +62,7 @@ class LConv(nn.Module):
             kernel_size=kernel_size,
             stride=1,
             padding=(kernel_size - 1) // 2,
-            groups=channels,
+            groups=2 * channels,
             bias=bias,
         )
 

--- a/egs/librispeech/ASR/streaming_conformer_ctc/train.py
+++ b/egs/librispeech/ASR/streaming_conformer_ctc/train.py
@@ -53,7 +53,6 @@ from icefall.utils import (
 )
 
 
-
 def get_parser():
     parser = argparse.ArgumentParser(
         formatter_class=argparse.ArgumentDefaultsHelpFormatter

--- a/egs/librispeech/ASR/streaming_conformer_ctc/train.py
+++ b/egs/librispeech/ASR/streaming_conformer_ctc/train.py
@@ -52,6 +52,7 @@ from icefall.utils import (
 )
 from lhotse.cut import Cut
 
+
 def get_parser():
     parser = argparse.ArgumentParser(
         formatter_class=argparse.ArgumentDefaultsHelpFormatter


### PR DESCRIPTION
Include:
egs/librispeech/ASR/pruned_transducer_stateless7_ctc_bs/ctc_guide_decode_bs.py filename && content(comments)
egs/librispeech/ASR/result.md content
docs/source/recipes/Non-streaming-ASR/librispeech/zipformer_ctc_blankskip.rst content
[icefall-asr-librispeech-pruned_transducer_stateless7_ctc_bs-2023-01-29/tree/main/exp/decode.sh](https://huggingface.co/yfyeung/icefall-asr-librispeech-pruned_transducer_stateless7_ctc_bs-2023-01-29) content 