### PR TITLE
Update generate_model_from_checkpoint.py

### DIFF
--- a/egs/librispeech/ASR/pruned_transducer_stateless7/generate_model_from_checkpoint.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless7/generate_model_from_checkpoint.py
@@ -243,7 +243,10 @@ def main():
                     device=device,
                 )
             )
-            filename = params.exp_dir / f"iter-{params.iter}-avg-{params.avg}-use-averaged-model.pt"
+            filename = (
+                params.exp_dir
+                / f"iter-{params.iter}-avg-{params.avg}-use-averaged-model.pt"
+            )
             torch.save({"model": model.state_dict()}, filename)
         else:
             assert params.avg > 0, params.avg
@@ -263,7 +266,10 @@ def main():
                     device=device,
                 )
             )
-            filename = params.exp_dir / f"epoch-{params.epoch}-avg-{params.avg}-use-averaged-model.pt"
+            filename = (
+                params.exp_dir
+                / f"epoch-{params.epoch}-avg-{params.avg}-use-averaged-model.pt"
+            )
             torch.save({"model": model.state_dict()}, filename)
 
     num_param = sum([p.numel() for p in model.parameters()])

--- a/egs/librispeech/ASR/pruned_transducer_stateless7/generate_model_from_checkpoint.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless7/generate_model_from_checkpoint.py
@@ -65,13 +65,15 @@ from typing import Dict, List
 
 import sentencepiece as spm
 import torch
-from asr_datamodule import LibriSpeechAsrDataModule
 
 from train import add_model_arguments, get_params, get_transducer_model
 
+from icefall.utils import str2bool
 from icefall.checkpoint import (
+    average_checkpoints,
     average_checkpoints_with_averaged_model,
     find_checkpoints,
+    load_checkpoint,
 )
 
 
@@ -148,7 +150,6 @@ def get_parser():
 @torch.no_grad()
 def main():
     parser = get_parser()
-    LibriSpeechAsrDataModule.add_arguments(parser)
     args = parser.parse_args()
     args.exp_dir = Path(args.exp_dir)
 
@@ -194,7 +195,7 @@ def main():
                     f"Not enough checkpoints ({len(filenames)}) found for"
                     f" --iter {params.iter}, --avg {params.avg}"
                 )
-            logging.info(f"averaging {filenames}")
+            print(f"averaging {filenames}")
             model.to(device)
             model.load_state_dict(average_checkpoints(filenames, device=device))
             filename = params.exp_dir / f"iter-{params.iter}-avg-{params.avg}.pt"
@@ -209,7 +210,7 @@ def main():
             for i in range(start, params.epoch + 1):
                 if i >= 1:
                     filenames.append(f"{params.exp_dir}/epoch-{i}.pt")
-            logging.info(f"averaging {filenames}")
+            print(f"averaging {filenames}")
             model.to(device)
             model.load_state_dict(average_checkpoints(filenames, device=device))
             filename = params.exp_dir / f"epoch-{params.epoch}-avg-{params.avg}.pt"

--- a/egs/librispeech/ASR/pruned_transducer_stateless7/generate_model_from_checkpoint.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless7/generate_model_from_checkpoint.py
@@ -18,7 +18,7 @@
 """
 Usage:
 (1) use the averaged model with checkpoint exp_dir/epoch-xxx.pt
-./pruned_transducer_stateless7/generate_averaged_model.py \
+./pruned_transducer_stateless7/generate_model_from_checkpoint.py \
     --epoch 28 \
     --avg 15 \
     --use-averaged-model True \
@@ -28,7 +28,7 @@ It will generate a file `epoch-28-avg-15-use-averaged-model.pt` in the given `ex
 You can later load it by `torch.load("epoch-28-avg-15-use-averaged-model.pt")`.
 
 (2) use the averaged model with checkpoint exp_dir/checkpoint-iter.pt
-./pruned_transducer_stateless7/generate_averaged_model.py \
+./pruned_transducer_stateless7/generate_model_from_checkpoint.py \
     --iter 22000 \
     --avg 5 \
     --use-averaged-model True \
@@ -38,7 +38,7 @@ It will generate a file `iter-22000-avg-5-use-averaged-model.pt` in the given `e
 You can later load it by `torch.load("iter-22000-avg-5-use-averaged-model.pt")`.
 
 (3) use the original model with checkpoint exp_dir/epoch-xxx.pt
-./pruned_transducer_stateless7/generate_averaged_model.py \
+./pruned_transducer_stateless7/generate_model_from_checkpoint.py \
     --epoch 28 \
     --avg 15 \
     --use-averaged-model False \
@@ -48,7 +48,7 @@ It will generate a file `epoch-28-avg-15.pt` in the given `exp_dir`.
 You can later load it by `torch.load("epoch-28-avg-15.pt")`.
 
 (4) use the original model with checkpoint exp_dir/checkpoint-iter.pt
-./pruned_transducer_stateless7/generate_averaged_model.py \
+./pruned_transducer_stateless7/generate_model_from_checkpoint.py \
     --iter 22000 \
     --avg 5 \
     --use-averaged-model False \


### PR DESCRIPTION
Now it supports the parameters `use-averaged-model`.

Usage:
```shell
(1) use the averaged model with checkpoint exp_dir/epoch-xxx.pt
./pruned_transducer_stateless7/generate_model_from_checkpoint.py \
    --epoch 28 \
    --avg 15 \
    --use-averaged-model True \
    --exp-dir ./pruned_transducer_stateless7/exp
It will generate a file `epoch-28-avg-15-use-averaged-model.pt` in the given `exp_dir`.
You can later load it by `torch.load("epoch-28-avg-15-use-averaged-model.pt")`.
(2) use the averaged model with checkpoint exp_dir/checkpoint-iter.pt
./pruned_transducer_stateless7/generate_model_from_checkpoint.py \
    --iter 22000 \
    --avg 5 \
    --use-averaged-model True \
    --exp-dir ./pruned_transducer_stateless7/exp
It will generate a file `iter-22000-avg-5-use-averaged-model.pt` in the given `exp_dir`.
You can later load it by `torch.load("iter-22000-avg-5-use-averaged-model.pt")`.
(3) use the original model with checkpoint exp_dir/epoch-xxx.pt
./pruned_transducer_stateless7/generate_model_from_checkpoint.py \
    --epoch 28 \
    --avg 15 \
    --use-averaged-model False \
    --exp-dir ./pruned_transducer_stateless7/exp
It will generate a file `epoch-28-avg-15.pt` in the given `exp_dir`.
You can later load it by `torch.load("epoch-28-avg-15.pt")`.
(4) use the original model with checkpoint exp_dir/checkpoint-iter.pt
./pruned_transducer_stateless7/generate_model_from_checkpoint.py \
    --iter 22000 \
    --avg 5 \
    --use-averaged-model False \
    --exp-dir ./pruned_transducer_stateless7/exp
It will generate a file `iter-22000-avg-5.pt` in the given `exp_dir`.
You can later load it by `torch.load("iter-22000-avg-5.pt")`.
```