### PR TITLE
fix typo

### DIFF
--- a/egs/librispeech/ASR/pruned_transducer_stateless2/beam_search.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless2/beam_search.py
@@ -2377,6 +2377,6 @@ def modified_beam_search_lm_shallow_fusion(
         return ans
     else:
         return DecodingResults(
-            tokens=ans,
+            hyps=ans,
             timestamps=ans_timestamps,
         )


### PR DESCRIPTION
Fix a typo in `beam_search.py`