### PR TITLE
Use standard apache 2.0 license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,13 +1,4 @@
 
-                                 Legal Notices
-
-   NOTE (this is not from the Apache License): The copyright model is that
-   authors (or their employers, if noted in individual files) own their
-   individual contributions. The authors' contributions can be discerned
-   from the git history.
-
- -------------------------------------------------------------------------
-
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/


### PR DESCRIPTION
The license is from
https://www.apache.org/licenses/LICENSE-2.0

We use
```
https://www.apache.org/licenses/LICENSE-2.0.txt
```