### PR TITLE
remove if-branch at downsample pad in zipformer for onnx-export compatibility

### DIFF
--- a/egs/librispeech/ASR/pruned_transducer_stateless7/zipformer.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless7/zipformer.py
@@ -781,13 +781,12 @@ class AttentionDownsample(torch.nn.Module):
         ds = self.downsample
         d_seq_len = (seq_len + ds - 1) // ds
 
-        # Pad to an exact multiple of self.downsample
-        if seq_len != d_seq_len * ds:
-            # right-pad src, repeating the last element.
-            pad = d_seq_len * ds - seq_len
-            src_extra = src[src.shape[0] - 1 :].expand(pad, src.shape[1], src.shape[2])
-            src = torch.cat((src, src_extra), dim=0)
-            assert src.shape[0] == d_seq_len * ds, (src.shape[0], d_seq_len, ds)
+        # Pad to an exact multiple of self.downsample, could be 0 for onnx-export-compatibility
+        # right-pad src, repeating the last element.
+        pad = d_seq_len * ds - seq_len
+        src_extra = src[src.shape[0] - 1 :].expand(pad, src.shape[1], src.shape[2])
+        src = torch.cat((src, src_extra), dim=0)
+        assert src.shape[0] == d_seq_len * ds, (src.shape[0], d_seq_len, ds)
 
         src = src.reshape(d_seq_len, ds, batch_size, in_channels)
         scores = (src * self.query).sum(dim=-1, keepdim=True)


### PR DESCRIPTION
this if-branch can't trace in onnx-exporting when we use tensor which T-dim is an even number , throw RuntimeError when we run the onnx model :
> The input tensor cannot be reshaped to the requested shape. Input shape:{219,1,384}, requested shape:{110,2,1,384}

even though it can export successfully without any error

we can allow he number of pads to be 0 to make this an unconditional execution.