### PR TITLE
Test absolute position encoding in attention

### DIFF
--- a/egs/librispeech/ASR/pruned_transducer_stateless4/decode.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless4/decode.py
@@ -409,12 +409,14 @@ def decode_one_batch(
     feature_lens = supervisions["num_frames"].to(device)
 
     if params.simulate_streaming:
-        feature_lens += params.left_context
-        feature = torch.nn.functional.pad(
-            feature,
-            pad=(0, 0, 0, params.left_context),
-            value=LOG_EPS,
-        )
+        if params.decode_chunk_size > 0:
+            # except the case of using full attention
+            feature_lens += params.left_context
+            feature = torch.nn.functional.pad(
+                feature,
+                pad=(0, 0, 0, params.left_context),
+                value=LOG_EPS,
+            )
         encoder_out, encoder_out_lens, _ = model.encoder.streaming_forward(
             x=feature,
             x_lens=feature_lens,


### PR DESCRIPTION
This PR is not to be merged. We validate the effect of using relative position encoding (PE) in attention modules, compared to using absolute PE. Specifically, relative PE models the relative positions for each pair of query-position and key-position, while absolute PE only models the absolute key-position. 

Following table presents the results of the streaming conformer trained with dynamic attention chunk sizes, using relative PE and absolute PE respectively: 

| method | chunk=320ms | full attention | comment |
| - | - | - | - |
| relative PE | 3.74 & 9.63 | 3.16 & 7.93 | epoch-17-avg-5 | 
| absolute PE | 3.82 & 9.99 |  3.41 & 8.24 | epoch-17-avg-5 | 
| relative PE | 3.67 & 9.46 | 3.07 & 7.8 | epoch-20-avg-5 | 
| absolute PE | 3.68 & 9.62 |  3.29 & 7.87 | epoch-20-avg-5 | 