### PR TITLE
Fix torch.jit.script() export for streaming zipformer.

### DIFF
--- a/egs/librispeech/ASR/pruned_transducer_stateless7_streaming/export.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless7_streaming/export.py
@@ -856,6 +856,7 @@ def main():
         # Otherwise, one of its arguments is a ragged tensor and is not
         # torch scriptabe.
         model.__class__.forward = torch.jit.ignore(model.__class__.forward)
+        model.encoder.__class__.forward = model.encoder.__class__.streaming_forward
         logging.info("Using torch.jit.script")
         model = torch.jit.script(model)
         filename = params.exp_dir / "cpu_jit.pt"

--- a/egs/librispeech/ASR/pruned_transducer_stateless7_streaming/zipformer.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless7_streaming/zipformer.py
@@ -570,7 +570,6 @@ class Zipformer(EncoderInterface):
 
         return x, lengths
 
-    @torch.jit.export
     def streaming_forward(
         self,
         x: torch.Tensor,


### PR DESCRIPTION
It was causing errors for `jit_trace_export.py`.

![image](https://user-images.githubusercontent.com/5284924/232425201-b0d7d320-4c23-4e16-9129-dd68e9e49275.png)
