### PR TITLE
Support exporting BS Zipformer models to ONNX, used in Triton Server

### DIFF
--- a/egs/librispeech/ASR/pruned_transducer_stateless7_ctc_bs/export_onnx.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless7_ctc_bs/export_onnx.py
@@ -300,6 +300,7 @@ def export_decoder_model_onnx(
     )
     logging.info(f"Saved to {decoder_filename}")
 
+
 def export_decoder_model_onnx_triton(
     decoder_model: nn.Module,
     decoder_filename: str,
@@ -336,6 +337,7 @@ def export_decoder_model_onnx_triton(
         },
     )
     logging.info(f"Saved to {decoder_filename}")
+
 
 def export_joiner_model_onnx(
     joiner_model: nn.Module,
@@ -432,6 +434,7 @@ def export_joiner_model_onnx(
     )
     logging.info(f"Saved to {decoder_proj_filename}")
 
+
 def export_joiner_model_onnx_triton(
     joiner_model: nn.Module,
     joiner_filename: str,
@@ -516,6 +519,7 @@ def export_joiner_model_onnx_triton(
     )
     logging.info(f"Saved to {decoder_proj_filename}")
 
+
 def export_lconv_onnx(
     lconv: nn.Module,
     lconv_filename: str,
@@ -559,6 +563,7 @@ def export_lconv_onnx(
     )
     logging.info(f"Saved to {lconv_filename}")
 
+
 def export_lconv_onnx_triton(
     lconv: nn.Module,
     lconv_filename: str,
@@ -584,7 +589,7 @@ def export_lconv_onnx_triton(
         The opset version to use.
     """
     lconv_input = torch.zeros(15, 498, 384, dtype=torch.float32)
-    lconv_input_lens = torch.tensor([498]*15, dtype=torch.int64)
+    lconv_input_lens = torch.tensor([498] * 15, dtype=torch.int64)
 
     lconv = TritonOnnxLconv(lconv)
 
@@ -827,7 +832,6 @@ def main():
             decoder_filename,
             opset_version=opset_version,
         )
-
 
     joiner_filename = params.exp_dir / "joiner.onnx"
     if params.onnx is True:

--- a/egs/librispeech/ASR/pruned_transducer_stateless7_ctc_bs/export_onnx.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless7_ctc_bs/export_onnx.py
@@ -2,6 +2,7 @@
 #
 # Copyright 2021 Xiaomi Corporation (Author: Fangjun Kuang,
 #                                            Yifan   Yang)
+#           2023 NVIDIA Corporation (Author: Wen Ding)
 #
 # See ../../../../LICENSE for clarification regarding multiple authors
 #

--- a/egs/librispeech/ASR/pruned_transducer_stateless7_ctc_bs/export_onnx.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless7_ctc_bs/export_onnx.py
@@ -196,7 +196,6 @@ def get_parser():
             - joiner_encoder_proj.onnx
             - joiner_decoder_proj.onnx
             - lconv.onnx
-            - frame_reducer.onnx
             - ctc_output.onnx
         """,
     )
@@ -875,12 +874,13 @@ def main():
             opset_version=opset_version,
         )
 
-    frame_reducer_filename = params.exp_dir / "frame_reducer.onnx"
-    export_frame_reducer_onnx(
-        model.frame_reducer,
-        frame_reducer_filename,
-        opset_version=opset_version,
-    )
+    if params.onnx is True:
+        frame_reducer_filename = params.exp_dir / "frame_reducer.onnx"
+        export_frame_reducer_onnx(
+            model.frame_reducer,
+            frame_reducer_filename,
+            opset_version=opset_version,
+        )
 
     ctc_output_filename = params.exp_dir / "ctc_output.onnx"
     export_ctc_output_onnx(

--- a/egs/librispeech/ASR/pruned_transducer_stateless7_ctc_bs/export_onnx.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless7_ctc_bs/export_onnx.py
@@ -2,7 +2,7 @@
 #
 # Copyright 2021 Xiaomi Corporation (Author: Fangjun Kuang,
 #                                            Yifan   Yang)
-#           2023 NVIDIA Corporation (Author: Wen Ding)
+#           2023 NVIDIA Corporation (Author: Wen     Ding)
 #
 # See ../../../../LICENSE for clarification regarding multiple authors
 #
@@ -43,6 +43,7 @@ Check `onnx_check.py` for how to use them.
     - joiner_decoder_proj.onnx
     - lconv.onnx
     - frame_reducer.onnx
+    - ctc_output.onnx
 
 (2) Export to ONNX format which can be used in Triton Server
 ./pruned_transducer_stateless7_ctc_bs/export_onnx.py \
@@ -52,6 +53,15 @@ Check `onnx_check.py` for how to use them.
   --avg 13 \
   --onnx-triton 1
 
+It will generate the following files in the given `exp_dir`.
+
+    - encoder.onnx
+    - decoder.onnx
+    - joiner.onnx
+    - joiner_encoder_proj.onnx
+    - joiner_decoder_proj.onnx
+    - lconv.onnx
+    - ctc_output.onnx
 
 Please see ./onnx_pretrained.py for usage of the generated files
 
@@ -157,7 +167,8 @@ def get_parser():
         type=str2bool,
         default=False,
         help="""If True, --jit is ignored and it exports the model
-        to onnx format. It will generate the following files:
+        to onnx format.
+        It will generate the following files:
 
             - encoder.onnx
             - decoder.onnx
@@ -166,6 +177,7 @@ def get_parser():
             - joiner_decoder_proj.onnx
             - lconv.onnx
             - frame_reducer.onnx
+            - ctc_output.onnx
 
         Refer to ./onnx_check.py and ./onnx_pretrained.py for how to use them.
         """,
@@ -177,13 +189,15 @@ def get_parser():
         help="""If True, and it exports the model
         to onnx format which can be used in NVIDIA triton server. 
         It will generate the following files:
+
             - encoder.onnx
             - decoder.onnx
             - joiner.onnx
             - joiner_encoder_proj.onnx
             - joiner_decoder_proj.onnx
             - lconv.onnx
-            - ctc_model.onnx
+            - frame_reducer.onnx
+            - ctc_output.onnx
         """,
     )
 

--- a/egs/librispeech/ASR/pruned_transducer_stateless7_ctc_bs/export_onnx.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless7_ctc_bs/export_onnx.py
@@ -183,7 +183,7 @@ def get_parser():
             - joiner_encoder_proj.onnx
             - joiner_decoder_proj.onnx
             - lconv.onnx
-            - frame_reducer.onnx
+            - ctc_model.onnx
         """,
     )
 
@@ -569,7 +569,7 @@ def export_lconv_onnx_triton(
     The exported lconv has two inputs:
 
         - lconv_input: a tensor of shape (N, T, C)
-        - src_key_padding_mask: a tensor of shape (N, T)
+        - lconv_input_lens: a tensor of shape (N, )
 
     and has one output:
 

--- a/egs/librispeech/ASR/pruned_transducer_stateless7_ctc_bs/onnx_wrapper.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless7_ctc_bs/onnx_wrapper.py
@@ -88,10 +88,8 @@ class TritonOnnxLconv(nn.Module):
     ) -> torch.Tensor:
         """
         Args:
-          encoder_out:
-            Output from the encoder. Its shape is (N, T, C).
-          decoder_out:
-            Output from the decoder. Its shape is (N, T, C).
+          lconv_input: Its shape is (N, T, C).
+          lconv_input_lens: Its shape is (N, ).
         Returns:
           Return a tensor of shape (N, T, C).
         """

--- a/egs/librispeech/ASR/pruned_transducer_stateless7_ctc_bs/onnx_wrapper.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless7_ctc_bs/onnx_wrapper.py
@@ -1,0 +1,101 @@
+# Copyright (c) 2023, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+from torch import nn
+from icefall.utils import make_pad_mask
+
+class TritonOnnxDecoder(nn.Module):
+    """
+    Triton wrapper for decoder model
+    """
+
+    def __init__(
+        self,
+        model
+    ):
+        """
+        Args:
+            model: decoder model
+        """
+        super().__init__()
+
+        self.model = model
+
+    def forward(self, y: torch.Tensor) -> torch.Tensor:
+        """
+        Args:
+          y:
+            A 2-D tensor of shape (N, U).
+        Returns:
+          Return a tensor of shape (N, U, decoder_dim).
+        """
+        need_pad = False
+        return self.model(y, need_pad)
+
+class TritonOnnxJoiner(nn.Module):
+    def __init__(
+        self,
+        model,
+    ):
+        super().__init__()
+
+        self.model = model
+        self.encoder_proj = model.encoder_proj
+        self.decoder_proj = model.decoder_proj
+
+    def forward(
+        self,
+        encoder_out: torch.Tensor,
+        decoder_out: torch.Tensor,
+    ) -> torch.Tensor:
+        """
+        Args:
+          encoder_out:
+            Output from the encoder. Its shape is (N, T, C).
+          decoder_out:
+            Output from the decoder. Its shape is (N, T, C).
+        Returns:
+          Return a tensor of shape (N, T, C).
+        """
+        project_input = False
+        return self.model(encoder_out, decoder_out, project_input)
+
+class TritonOnnxLconv(nn.Module):
+    def __init__(
+        self,
+        model,
+    ):
+        super().__init__()
+
+        self.model = model
+
+    def forward(
+        self,
+        lconv_input: torch.Tensor,
+        lconv_input_lens: torch.Tensor,
+    ) -> torch.Tensor:
+        """
+        Args:
+          encoder_out:
+            Output from the encoder. Its shape is (N, T, C).
+          decoder_out:
+            Output from the decoder. Its shape is (N, T, C).
+        Returns:
+          Return a tensor of shape (N, T, C).
+        """
+        mask = make_pad_mask(lconv_input_lens)
+
+        return self.model(x=lconv_input, src_key_padding_mask=mask)
+

--- a/egs/librispeech/ASR/pruned_transducer_stateless7_ctc_bs/onnx_wrapper.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless7_ctc_bs/onnx_wrapper.py
@@ -16,15 +16,13 @@ import torch
 from torch import nn
 from icefall.utils import make_pad_mask
 
+
 class TritonOnnxDecoder(nn.Module):
     """
     Triton wrapper for decoder model
     """
 
-    def __init__(
-        self,
-        model
-    ):
+    def __init__(self, model):
         """
         Args:
             model: decoder model
@@ -43,6 +41,7 @@ class TritonOnnxDecoder(nn.Module):
         """
         need_pad = False
         return self.model(y, need_pad)
+
 
 class TritonOnnxJoiner(nn.Module):
     def __init__(
@@ -72,6 +71,7 @@ class TritonOnnxJoiner(nn.Module):
         project_input = False
         return self.model(encoder_out, decoder_out, project_input)
 
+
 class TritonOnnxLconv(nn.Module):
     def __init__(
         self,
@@ -96,4 +96,3 @@ class TritonOnnxLconv(nn.Module):
         mask = make_pad_mask(lconv_input_lens)
 
         return self.model(x=lconv_input, src_key_padding_mask=mask)
-


### PR DESCRIPTION
Hi all,

This PR is to support exporting BS Zipformer models to ONNX, which can be used in Triton Server.
These exported ONNX models can be deployed using Triton in Sherpa. Sherpa link: https://github.com/k2-fsa/sherpa/pull/364

Thanks,
Wen
