### PR TITLE
Fix typo in librispeech OpenFST-based HLG preparation script

### DIFF
--- a/egs/librispeech/ASR/prepare.sh
+++ b/egs/librispeech/ASR/prepare.sh
@@ -184,7 +184,7 @@ if [ $stage -le 5 ] && [ $stop_stage -ge 5 ]; then
     ./shared/convert-k2-to-openfst.py \
       --olabels aux_labels \
       $lang_dir/L_disambig.pt \
-      $lang_dir/disambig_L.fst
+      $lang_dir/L_disambig.fst
   fi
 fi
 

--- a/egs/librispeech/ASR/prepare_multidataset.sh
+++ b/egs/librispeech/ASR/prepare_multidataset.sh
@@ -198,7 +198,7 @@ if [ $stage -le 5 ] && [ $stop_stage -ge 5 ]; then
     ./shared/convert-k2-to-openfst.py \
       --olabels aux_labels \
       $lang_dir/L_disambig.pt \
-      $lang_dir/disambig_L.fst
+      $lang_dir/L_disambig.fst
   fi
 fi
 


### PR DESCRIPTION
`compile_hlg_using_openfst.py` expects `L_disambig.fst` instead of `disambig_L.fst`.