### PR TITLE
Add adaption recipe for pruned_transducer_stateless7

### DIFF
--- a/egs/librispeech/ASR/finetune.sh
+++ b/egs/librispeech/ASR/finetune.sh
@@ -79,6 +79,7 @@ if [ $stage -le 1 ] && [ $stop_stage -ge 1 ]; then
     --use-averaged-model True \
     --beam-size 4 \
     --exp-dir pruned_transducer_stateless7/exp_giga_finetune \
+    --bpe-model icefall-asr-librispeech-pruned-transducer-stateless7-2022-11-11/data/lang_bpe_500/bpe.model \
     --max-duration 400 \
     --decoding-method $m
   done

--- a/egs/librispeech/ASR/pruned_transducer_stateless7/decode_gigaspeech.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless7/decode_gigaspeech.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 #
-# Copyright 2021-2022 Xiaomi Corporation (Author: Fangjun Kuang,
+# Copyright 2021-2023 Xiaomi Corporation (Author: Fangjun Kuang,
 #                                                 Zengwei Yao,
-#                                                 Xiaoyu Yang)
+#                                                 Xiaoyu Yang,
+#                                                 Yifan Yang,)
 #
 # See ../../../../LICENSE for clarification regarding multiple authors
 #
@@ -23,7 +24,7 @@ Usage:
 ./pruned_transducer_stateless7/decode.py \
     --epoch 28 \
     --avg 15 \
-    --exp-dir ./pruned_transducer_stateless7/exp \
+    --exp-dir ./pruned_transducer_stateless7/exp_giga_finetune \
     --max-duration 600 \
     --decoding-method greedy_search
 
@@ -31,7 +32,7 @@ Usage:
 ./pruned_transducer_stateless7/decode.py \
     --epoch 28 \
     --avg 15 \
-    --exp-dir ./pruned_transducer_stateless7/exp \
+    --exp-dir ./pruned_transducer_stateless7/exp_giga_finetune \
     --max-duration 600 \
     --decoding-method beam_search \
     --beam-size 4
@@ -40,7 +41,7 @@ Usage:
 ./pruned_transducer_stateless7/decode.py \
     --epoch 28 \
     --avg 15 \
-    --exp-dir ./pruned_transducer_stateless7/exp \
+    --exp-dir ./pruned_transducer_stateless7/exp_giga_finetune \
     --max-duration 600 \
     --decoding-method modified_beam_search \
     --beam-size 4
@@ -49,7 +50,7 @@ Usage:
 ./pruned_transducer_stateless7/decode.py \
     --epoch 28 \
     --avg 15 \
-    --exp-dir ./pruned_transducer_stateless7/exp \
+    --exp-dir ./pruned_transducer_stateless7/exp_giga_finetune \
     --max-duration 600 \
     --decoding-method fast_beam_search \
     --beam 20.0 \
@@ -60,7 +61,7 @@ Usage:
 ./pruned_transducer_stateless7/decode.py \
     --epoch 28 \
     --avg 15 \
-    --exp-dir ./pruned_transducer_stateless7/exp \
+    --exp-dir ./pruned_transducer_stateless7/exp_giga_finetune \
     --max-duration 600 \
     --decoding-method fast_beam_search_nbest \
     --beam 20.0 \
@@ -73,7 +74,7 @@ Usage:
 ./pruned_transducer_stateless7/decode.py \
     --epoch 28 \
     --avg 15 \
-    --exp-dir ./pruned_transducer_stateless7/exp \
+    --exp-dir ./pruned_transducer_stateless7/exp_giga_finetune \
     --max-duration 600 \
     --decoding-method fast_beam_search_nbest_oracle \
     --beam 20.0 \
@@ -86,7 +87,7 @@ Usage:
 ./pruned_transducer_stateless7/decode.py \
     --epoch 28 \
     --avg 15 \
-    --exp-dir ./pruned_transducer_stateless7/exp \
+    --exp-dir ./pruned_transducer_stateless7/exp_giga_finetune \
     --max-duration 600 \
     --decoding-method fast_beam_search_nbest_LG \
     --beam 20.0 \
@@ -187,7 +188,7 @@ def get_parser():
     parser.add_argument(
         "--exp-dir",
         type=str,
-        default="pruned_transducer_stateless7/exp",
+        default="pruned_transducer_stateless7/exp_giga_finetune",
         help="The experiment dir",
     )
 

--- a/egs/librispeech/ASR/pruned_transducer_stateless7/decode_gigaspeech.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless7/decode_gigaspeech.py
@@ -21,7 +21,7 @@
 """
 Usage:
 (1) greedy search
-./pruned_transducer_stateless7/decode.py \
+./pruned_transducer_stateless7/decode_gigaspeech.py \
     --epoch 28 \
     --avg 15 \
     --exp-dir ./pruned_transducer_stateless7/exp_giga_finetune \
@@ -29,7 +29,7 @@ Usage:
     --decoding-method greedy_search
 
 (2) beam search (not recommended)
-./pruned_transducer_stateless7/decode.py \
+./pruned_transducer_stateless7/decode_gigaspeech.py \
     --epoch 28 \
     --avg 15 \
     --exp-dir ./pruned_transducer_stateless7/exp_giga_finetune \
@@ -38,7 +38,7 @@ Usage:
     --beam-size 4
 
 (3) modified beam search
-./pruned_transducer_stateless7/decode.py \
+./pruned_transducer_stateless7/decode_gigaspeech.py \
     --epoch 28 \
     --avg 15 \
     --exp-dir ./pruned_transducer_stateless7/exp_giga_finetune \
@@ -47,7 +47,7 @@ Usage:
     --beam-size 4
 
 (4) fast beam search (one best)
-./pruned_transducer_stateless7/decode.py \
+./pruned_transducer_stateless7/decode_gigaspeech.py \
     --epoch 28 \
     --avg 15 \
     --exp-dir ./pruned_transducer_stateless7/exp_giga_finetune \
@@ -58,7 +58,7 @@ Usage:
     --max-states 64
 
 (5) fast beam search (nbest)
-./pruned_transducer_stateless7/decode.py \
+./pruned_transducer_stateless7/decode_gigaspeech.py \
     --epoch 28 \
     --avg 15 \
     --exp-dir ./pruned_transducer_stateless7/exp_giga_finetune \
@@ -71,7 +71,7 @@ Usage:
     --nbest-scale 0.5
 
 (6) fast beam search (nbest oracle WER)
-./pruned_transducer_stateless7/decode.py \
+./pruned_transducer_stateless7/decode_gigaspeech.py \
     --epoch 28 \
     --avg 15 \
     --exp-dir ./pruned_transducer_stateless7/exp_giga_finetune \
@@ -84,7 +84,7 @@ Usage:
     --nbest-scale 0.5
 
 (7) fast beam search (with LG)
-./pruned_transducer_stateless7/decode.py \
+./pruned_transducer_stateless7/decode_gigaspeech.py \
     --epoch 28 \
     --avg 15 \
     --exp-dir ./pruned_transducer_stateless7/exp_giga_finetune \

--- a/egs/librispeech/ASR/pruned_transducer_stateless7/finetune.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless7/finetune.py
@@ -1188,7 +1188,7 @@ def run(rank, world_size, args):
     valid_cuts = gigaspeech.dev_cuts()
     valid_dl = gigaspeech.valid_dataloaders(valid_cuts)
 
-    if 0 and not params.print_diagnostics:
+    if not params.print_diagnostics:
         scan_pessimistic_batches_for_oom(
             model=model,
             train_dl=train_dl,

--- a/egs/librispeech/ASR/pruned_transducer_stateless7/finetune.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless7/finetune.py
@@ -1131,7 +1131,11 @@ def run(rank, world_size, args):
 
     if params.use_mux:
         librispeech = LibriSpeechAsrDataModule(args)
-        train_cuts = CutSet.mux(librispeech.train_all_shuf_cuts(), gigaspeech.train_cuts(), weights=[0.95, 0.05])
+        train_cuts = CutSet.mux(
+            librispeech.train_all_shuf_cuts(),
+            gigaspeech.train_cuts(),
+            weights=[0.95, 0.05],
+        )
     else:
         train_cuts = gigaspeech.train_cuts()
 

--- a/egs/librispeech/ASR/pruned_transducer_stateless7/finetune.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless7/finetune.py
@@ -102,7 +102,8 @@ def set_batch_count(model: Union[nn.Module, DDP], batch_count: float) -> None:
 
 
 def add_finetune_arguments(parser: argparse.ArgumentParser):
-    parser.add_argument("--do-finetune",
+    parser.add_argument(
+        "--do-finetune",
         type=str2bool,
         default=True,
         help="Whether to fine-tune.",
@@ -114,7 +115,7 @@ def add_finetune_arguments(parser: argparse.ArgumentParser):
         help="""
         Whether to adapt. If true, we will mix 5% of the new data
         with 95% of the original data to fine-tune.
-        """
+        """,
     )
 
     parser.add_argument(

--- a/egs/librispeech/ASR/pruned_transducer_stateless7/finetune.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless7/finetune.py
@@ -102,8 +102,20 @@ def set_batch_count(model: Union[nn.Module, DDP], batch_count: float) -> None:
 
 
 def add_finetune_arguments(parser: argparse.ArgumentParser):
-    parser.add_argument("--do-finetune", type=str2bool, default=False)
-    parser.add_argument("--use-mux", type=str2bool, default=False)
+    parser.add_argument("--do-finetune",
+        type=str2bool,
+        default=True,
+        help="Whether to fine-tune.",
+    )
+    parser.add_argument(
+        "--use-mux",
+        type=str2bool,
+        default=False,
+        help="""
+        Whether to adapt. If true, we will mix 5% of the new data
+        with 95% of the original data to fine-tune.
+        """
+    )
 
     parser.add_argument(
         "--init-modules",

--- a/egs/librispeech/ASR/pruned_transducer_stateless7/finetune.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless7/finetune.py
@@ -921,7 +921,7 @@ def train_one_epoch(
             # in the batch and there is no normalization to it so far.
             scaler.scale(loss).backward()
             # Skip the warmup by adding a huge number to batch_count
-            if params.do_finetune = False:
+            if params.do_finetune:
                 set_batch_count(model, params.batch_idx_train + 100000)
             else:
                 set_batch_count(model, params.batch_idx_train)


### PR DESCRIPTION
This PR adds an adapting script for recipe pruned_transducer_stateless7.
For adapting already-trained models to new data, we mix 5% of the new/adaptation data with 95% of the original data by [`CutSet.mux` in Lhotse](https://lhotse.readthedocs.io/en/latest/api.html?highlight=mux#lhotse.cut.CutSet.mux) to fine-tune.

Our observation:
- Adapting can preserve the source domain's performance much better than fine-tuning directly on target data. 
- Adapting gets worse performance on the target domain than fine-tuning directly on target data. 

Usage:
```shell
export CUDA_VISIBLE_DEVICES="0,1"

./pruned_transducer_stateless7/finetune.py \
  --world-size 2 \
  --num-epochs 20 \
  --start-epoch 1 \
  --exp-dir pruned_transducer_stateless7/exp_giga_finetune \
  --subset S \
  --use-fp16 1 \
  --base-lr 0.005 \
  --lr-epochs 100 \
  --lr-batches 100000 \
  --bpe-model icefall-asr-librispeech-pruned-transducer-stateless7-2022-11-11/data/lang_bpe_500/bpe.model \
  --do-finetune True \
  --use-mux True \
  --finetune-ckpt icefall-asr-librispeech-pruned-transducer-stateless7-2022-11-11/exp/pretrained.pt \
  --max-duration 500
```

Here are some results of adapting a model trained with LibriSpeech on GigaSpeech S:
| GigaSpeech dev & test | LibriSpeech test-clean & test-other | config |
| --- | --- | --- | 
| 14.26 & 14.14 | 2.14 & 4.87 | epoch 20 avg 5 |
| 14.46 & 14.45 | 2.09 & 4.96 | epoch 15 avg 5 | 
| 14.94 & 14.86 | 2.18 & 5.15 | epoch 10 avg 4 |
| 15.50 & 15.49 | 2.29 & 5.32 | epoch 5 avg 2  |
| 16.59 & 16.45 | 2.32 & 5.57 | epoch 2 avg 1   |

Note:  we use the LR-related settings `--base-lr 0.005, --lr-epochs 100, --lr-batches 100000`
### [Baseline](https://github.com/k2-fsa/icefall/pull/944)
Train from scratch on GigaSpeech S
| GigaSpeech dev & test | config |
| --- | --- |
| 14.91 & 15.04 |  epoch 30 avg 14 |

Fine-tune from LibriSpeech
| GigaSpeech dev & test | config |
| --- | --- |
| 13.59 & 13.49 |  epoch 11 avg 10 |

Note: It gets much higher WERs on LibriSpeech (about 3.1/7.1).

### Full Result
| dev & test | sum | config |
| --- | --- | --- | 
| 14.26 & 14.14 | 28.40 | epoch 20 avg 5 |
| 14.27 & 14.13 | 28.40 | epoch 20 avg 7 |
| 14.28 & 14.13 | 28.41 | epoch 20 avg 6 |
| 14.3 & 14.14 | 28.44 | epoch 20 avg 8 |
| 14.31 & 14.16 | 28.47 | epoch 19 avg 6 |
| 14.29 & 14.19 | 28.48 | epoch 20 avg 4 |
| 14.31 & 14.17 | 28.48 | epoch 19 avg 5 |
| 14.31 & 14.18 | 28.49 | epoch 20 avg 9 |
| 14.31 & 14.19 | 28.50 | epoch 19 avg 7 |
| 14.3 & 14.23 | 28.53 | epoch 20 avg 3 |
| 14.32 & 14.22 | 28.54 | epoch 20 avg 10 |
| 14.32 & 14.24 | 28.56 | epoch 19 avg 4 |
| 14.34 & 14.23 | 28.57 | epoch 18 avg 6 |
| 14.35 & 14.22 | 28.57 | epoch 19 avg 8 |
| 14.32 & 14.26 | 28.58 | epoch 19 avg 9 |
| 14.34 & 14.25 | 28.59 | epoch 18 avg 7 |
| 14.38 & 14.22 | 28.60 | epoch 18 avg 5 |
| 14.39 & 14.23 | 28.62 | epoch 18 avg 4 |
| 14.37 & 14.28 | 28.65 | epoch 18 avg 8 |
| 14.38 & 14.27 | 28.65 | epoch 20 avg 11 |
| 14.39 & 14.28 | 28.67 | epoch 18 avg 3 |
| 14.38 & 14.29 | 28.67 | epoch 19 avg 3 |
| 14.35 & 14.32 | 28.67 | epoch 20 avg 2 |
| 14.4 & 14.28 | 28.68 | epoch 17 avg 4 |
| 14.39 & 14.29 | 28.68 | epoch 17 avg 5 |
| 14.39 & 14.3 | 28.69 | epoch 19 avg 10 |
| 14.4 & 14.31 | 28.71 | epoch 17 avg 6 |
| 14.4 & 14.31 | 28.71 | epoch 20 avg 12 |
| 14.4 & 14.32 | 28.72 | epoch 18 avg 9 |
| 14.42 & 14.33 | 28.75 | epoch 17 avg 7 |
| 14.4 & 14.36 | 28.76 | epoch 17 avg 8 |
| 14.43 & 14.33 | 28.76 | epoch 19 avg 11 |
| 14.45 & 14.32 | 28.77 | epoch 17 avg 3 |
| 14.43 & 14.34 | 28.77 | epoch 20 avg 13 |
| 14.4 & 14.38 | 28.78 | epoch 19 avg 2 |
| 14.43 & 14.36 | 28.79 | epoch 16 avg 4 |
| 14.42 & 14.37 | 28.79 | epoch 16 avg 5 |
| 14.44 & 14.36 | 28.80 | epoch 18 avg 10 |
| 14.45 & 14.37 | 28.82 | epoch 16 avg 3 |
| 14.44 & 14.38 | 28.82 | epoch 16 avg 6 |
| 14.46 & 14.36 | 28.82 | epoch 19 avg 12 |
| 14.46 & 14.39 | 28.85 | epoch 17 avg 2 |
| 14.47 & 14.38 | 28.85 | epoch 17 avg 9 |
| 14.47 & 14.38 | 28.85 | epoch 18 avg 2 |
| 14.48 & 14.37 | 28.85 | epoch 18 avg 11 |
| 14.46 & 14.41 | 28.87 | epoch 16 avg 7 |
| 14.49 & 14.38 | 28.87 | epoch 20 avg 14 |
| 14.46 & 14.45 | 28.91 | epoch 15 avg 5 |
| 14.51 & 14.41 | 28.92 | epoch 17 avg 10 |
| 14.51 & 14.41 | 28.92 | epoch 19 avg 13 |
| 14.49 & 14.44 | 28.93 | epoch 15 avg 4 |
| 14.49 & 14.44 | 28.93 | epoch 16 avg 8 |
| 14.51 & 14.44 | 28.95 | epoch 20 avg 15 |
| 14.49 & 14.46 | 28.95 | epoch 15 avg 6 |
| 14.54 & 14.42 | 28.96 | epoch 16 avg 2 |
| 14.51 & 14.45 | 28.96 | epoch 20 avg 1 |
| 14.53 & 14.44 | 28.97 | epoch 18 avg 12 |
| 14.52 & 14.46 | 28.98 | epoch 16 avg 9 |
| 14.48 & 14.52 | 29.00 | epoch 14 avg 4 |
| 14.52 & 14.48 | 29.00 | epoch 15 avg 7 |
| 14.53 & 14.48 | 29.01 | epoch 15 avg 3 |
| 14.54 & 14.47 | 29.01 | epoch 17 avg 11 |
| 14.57 & 14.46 | 29.03 | epoch 19 avg 14 |
| 14.53 & 14.53 | 29.06 | epoch 15 avg 2 |
| 14.54 & 14.53 | 29.07 | epoch 14 avg 6 |
| 14.56 & 14.51 | 29.07 | epoch 15 avg 8 |
| 14.58 & 14.49 | 29.07 | epoch 20 avg 16 |
| 14.57 & 14.51 | 29.08 | epoch 16 avg 10 |
| 14.54 & 14.55 | 29.09 | epoch 14 avg 5 |
| 14.6 & 14.49 | 29.09 | epoch 18 avg 13 |
| 14.61 & 14.52 | 29.13 | epoch 17 avg 12 |
| 14.61 & 14.52 | 29.13 | epoch 18 avg 1 |
| 14.53 & 14.6 | 29.13 | epoch 19 avg 1 |
| 14.57 & 14.58 | 29.15 | epoch 14 avg 3 |
| 14.6 & 14.56 | 29.16 | epoch 16 avg 11 |
| 14.6 & 14.57 | 29.17 | epoch 14 avg 7 |
| 14.64 & 14.53 | 29.17 | epoch 19 avg 15 |
| 14.58 & 14.61 | 29.19 | epoch 13 avg 3 |
| 14.63 & 14.56 | 29.19 | epoch 15 avg 9 |
| 14.65 & 14.55 | 29.20 | epoch 18 avg 14 |
| 14.6 & 14.61 | 29.21 | epoch 13 avg 4 |
| 14.67 & 14.55 | 29.22 | epoch 20 avg 17 |
| 14.61 & 14.62 | 29.23 | epoch 13 avg 5 |
| 14.63 & 14.61 | 29.24 | epoch 13 avg 6 |
| 14.66 & 14.6 | 29.26 | epoch 14 avg 8 |
| 14.68 & 14.58 | 29.26 | epoch 16 avg 1 |
| 14.68 & 14.58 | 29.26 | epoch 17 avg 13 |
| 14.68 & 14.59 | 29.27 | epoch 17 avg 1 |
| 14.68 & 14.59 | 29.27 | epoch 19 avg 16 |
| 14.68 & 14.61 | 29.29 | epoch 15 avg 10 |
| 14.69 & 14.61 | 29.30 | epoch 16 avg 12 |
| 14.7 & 14.64 | 29.34 | epoch 13 avg 7 |
| 14.67 & 14.67 | 29.34 | epoch 14 avg 2 |
| 14.72 & 14.63 | 29.35 | epoch 18 avg 15 |
| 14.71 & 14.66 | 29.37 | epoch 14 avg 9 |
| 14.74 & 14.63 | 29.37 | epoch 15 avg 1 |
| 14.71 & 14.67 | 29.38 | epoch 12 avg 5 |
| 14.7 & 14.69 | 29.39 | epoch 13 avg 2 |
| 14.74 & 14.65 | 29.39 | epoch 20 avg 18 |
| 14.71 & 14.69 | 29.40 | epoch 12 avg 4 |
| 14.69 & 14.72 | 29.41 | epoch 12 avg 3 |
| 14.74 & 14.67 | 29.41 | epoch 15 avg 11 |
| 14.76 & 14.66 | 29.42 | epoch 17 avg 14 |
| 14.76 & 14.69 | 29.45 | epoch 13 avg 8 |
| 14.71 & 14.75 | 29.46 | epoch 12 avg 2 |
| 14.76 & 14.7 | 29.46 | epoch 12 avg 6 |
| 14.75 & 14.71 | 29.46 | epoch 14 avg 10 |
| 14.8 & 14.68 | 29.48 | epoch 19 avg 17 |
| 14.81 & 14.7 | 29.51 | epoch 16 avg 13 |
| 14.81 & 14.71 | 29.52 | epoch 18 avg 16 |
| 14.75 & 14.8 | 29.55 | epoch 14 avg 1 |
| 14.81 & 14.75 | 29.56 | epoch 11 avg 4 |
| 14.8 & 14.76 | 29.56 | epoch 13 avg 9 |
| 14.82 & 14.76 | 29.58 | epoch 12 avg 7 |
| 14.81 & 14.79 | 29.60 | epoch 11 avg 3 |
| 14.83 & 14.78 | 29.61 | epoch 11 avg 5 |
| 14.84 & 14.77 | 29.61 | epoch 15 avg 12 |
| 14.87 & 14.77 | 29.64 | epoch 17 avg 15 |
| 14.88 & 14.77 | 29.65 | epoch 20 avg 19 |
| 14.86 & 14.8 | 29.66 | epoch 12 avg 8 |
| 14.86 & 14.81 | 29.67 | epoch 14 avg 11 |
| 14.9 & 14.82 | 29.72 | epoch 11 avg 6 |
| 14.9 & 14.82 | 29.72 | epoch 16 avg 14 |
| 14.92 & 14.81 | 29.73 | epoch 19 avg 18 |
| 14.9 & 14.84 | 29.74 | epoch 13 avg 10 |
| 14.86 & 14.89 | 29.75 | epoch 11 avg 2 |
| 14.91 & 14.86 | 29.77 | epoch 15 avg 13 |
| 14.88 & 14.89 | 29.77 | epoch 13 avg 1 |
| 14.94 & 14.84 | 29.78 | epoch 18 avg 17 |
| 14.92 & 14.87 | 29.79 | epoch 11 avg 7 |
| 14.89 & 14.9 | 29.79 | epoch 12 avg 1 |
| 14.94 & 14.86 | 29.80 | epoch 10 avg 4 |
| 14.97 & 14.85 | 29.82 | epoch 10 avg 3 |
| 14.95 & 14.87 | 29.82 | epoch 10 avg 5 |
| 14.96 & 14.9 | 29.86 | epoch 12 avg 9 |
| 14.97 & 14.89 | 29.86 | epoch 17 avg 16 |
| 14.96 & 14.91 | 29.87 | epoch 14 avg 12 |
| 14.98 & 14.93 | 29.91 | epoch 10 avg 2 |
| 15.01 & 14.91 | 29.92 | epoch 10 avg 6 |
| 15.01 & 14.93 | 29.94 | epoch 9 avg 3 |
| 15.01 & 14.93 | 29.94 | epoch 16 avg 15 |
| 15.03 & 14.94 | 29.97 | epoch 9 avg 4 |
| 15.02 & 14.95 | 29.97 | epoch 13 avg 11 |
| 15.03 & 14.95 | 29.98 | epoch 11 avg 8 |
| 15.03 & 14.99 | 30.02 | epoch 15 avg 14 |
| 15.1 & 14.94 | 30.04 | epoch 9 avg 2 |
| 15.02 & 15.02 | 30.04 | epoch 11 avg 1 |
| 15.08 & 14.98 | 30.06 | epoch 9 avg 5 |
| 15.07 & 14.99 | 30.06 | epoch 12 avg 10 |
| 15.1 & 15.0 | 30.10 | epoch 10 avg 7 |
| 15.1 & 15.04 | 30.14 | epoch 14 avg 13 |
| 15.11 & 15.04 | 30.15 | epoch 8 avg 3 |
| 15.12 & 15.05 | 30.17 | epoch 9 avg 6 |
| 15.14 & 15.07 | 30.21 | epoch 11 avg 9 |
| 15.15 & 15.1 | 30.25 | epoch 8 avg 2 |
| 15.1 & 15.15 | 30.25 | epoch 10 avg 1 |
| 15.17 & 15.08 | 30.25 | epoch 13 avg 12 |
| 15.17 & 15.09 | 30.26 | epoch 8 avg 4 |
| 15.17 & 15.1 | 30.27 | epoch 10 avg 8 |
| 15.19 & 15.14 | 30.33 | epoch 9 avg 1 |
| 15.21 & 15.13 | 30.34 | epoch 12 avg 11 |
| 15.23 & 15.12 | 30.35 | epoch 8 avg 5 |
| 15.24 & 15.13 | 30.37 | epoch 9 avg 7 |
| 15.25 & 15.19 | 30.44 | epoch 7 avg 3 |
| 15.23 & 15.22 | 30.45 | epoch 7 avg 4 |
| 15.28 & 15.2 | 30.48 | epoch 11 avg 10 |
| 15.24 & 15.24 | 30.48 | epoch 7 avg 2 |
| 15.31 & 15.22 | 30.53 | epoch 8 avg 6 |
| 15.31 & 15.23 | 30.54 | epoch 10 avg 9 |
| 15.34 & 15.25 | 30.59 | epoch 8 avg 1 |
| 15.33 & 15.31 | 30.64 | epoch 7 avg 5 |
| 15.37 & 15.29 | 30.66 | epoch 9 avg 8 |
| 15.34 & 15.33 | 30.67 | epoch 6 avg 2 |
| 15.34 & 15.33 | 30.67 | epoch 6 avg 3 |
| 15.41 & 15.39 | 30.80 | epoch 6 avg 4 |
| 15.45 & 15.36 | 30.81 | epoch 8 avg 7 |
| 15.45 & 15.38 | 30.83 | epoch 7 avg 1 |
| 15.54 & 15.44 | 30.98 | epoch 7 avg 6 |
| 15.5 & 15.49 | 30.99 | epoch 5 avg 2 |
| 15.51 & 15.49 | 31.00 | epoch 6 avg 1 |
| 15.56 & 15.54 | 31.10 | epoch 5 avg 3 |
| 15.62 & 15.54 | 31.16 | epoch 6 avg 5 |
| 15.61 & 15.65 | 31.26 | epoch 5 avg 1 |
| 15.76 & 15.66 | 31.42 | epoch 5 avg 4 |
| 15.73 & 15.72 | 31.45 | epoch 4 avg 2 |
| 15.75 & 15.84 | 31.59 | epoch 4 avg 1 |
| 15.93 & 15.83 | 31.76 | epoch 4 avg 3 |
| 16.08 & 16.1 | 32.18 | epoch 3 avg 1 |
| 16.2 & 16.06 | 32.26 | epoch 3 avg 2 |
| 16.59 & 16.45 | 33.04 | epoch 2 avg 1 |

### Ablation Study
#### Skip warm-up
| dev & test | sum | config |
| --- | --- | --- | 
| 14.96 & 14.87 | 29.83 | epoch 10 avg 4 |
| 15.0 & 14.88 | 29.88 | epoch 10 avg 3 |
| 15.03 & 14.9 | 29.93 | epoch 10 avg 5 |
| 15.08 & 14.92 | 30.00 | epoch 10 avg 2 |
| 15.06 & 14.96 | 30.02 | epoch 9 avg 3 |
| 15.06 & 15.03 | 30.09 | epoch 9 avg 2 |
| 15.11 & 14.98 | 30.09 | epoch 10 avg 6 |
| 15.11 & 14.99 | 30.10 | epoch 9 avg 4 |
| 15.18 & 15.05 | 30.23 | epoch 9 avg 5 |
| 15.18 & 15.08 | 30.26 | epoch 8 avg 3 |
| 15.21 & 15.05 | 30.26 | epoch 10 avg 7 |
| 15.23 & 15.11 | 30.34 | epoch 10 avg 1 |
| 15.21 & 15.15 | 30.36 | epoch 8 avg 2 |
| 15.22 & 15.16 | 30.38 | epoch 9 avg 1 |
| 15.27 & 15.14 | 30.41 | epoch 9 avg 6 |
| 15.29 & 15.14 | 30.43 | epoch 8 avg 4 |
| 15.3 & 15.15 | 30.45 | epoch 10 avg 8 |
| 15.38 & 15.22 | 30.60 | epoch 8 avg 5 |
| 15.37 & 15.24 | 30.61 | epoch 9 avg 7 |
| 15.4 & 15.23 | 30.63 | epoch 7 avg 2 |
| 15.35 & 15.3 | 30.65 | epoch 8 avg 1 |
| 15.43 & 15.24 | 30.67 | epoch 7 avg 3 |
| 15.45 & 15.29 | 30.74 | epoch 10 avg 9 |
| 15.48 & 15.29 | 30.77 | epoch 7 avg 4 |
| 15.46 & 15.33 | 30.79 | epoch 8 avg 6 |
| 15.46 & 15.39 | 30.85 | epoch 7 avg 1 |
| 15.52 & 15.35 | 30.87 | epoch 9 avg 8 |
| 15.57 & 15.39 | 30.96 | epoch 6 avg 2 |
| 15.58 & 15.38 | 30.96 | epoch 7 avg 5 |
| 15.63 & 15.41 | 31.04 | epoch 6 avg 3 |
| 15.63 & 15.44 | 31.07 | epoch 8 avg 7 |
| 15.61 & 15.48 | 31.09 | epoch 6 avg 1 |
| 15.68 & 15.43 | 31.11 | epoch 6 avg 4 |
| 15.72 & 15.49 | 31.21 | epoch 7 avg 6 |
| 15.76 & 15.53 | 31.29 | epoch 5 avg 2 |
| 15.8 & 15.55 | 31.35 | epoch 5 avg 3 |
| 15.81 & 15.55 | 31.36 | epoch 6 avg 5 |
| 15.82 & 15.66 | 31.48 | epoch 5 avg 1 |
| 15.9 & 15.68 | 31.58 | epoch 5 avg 4 |
| 15.91 & 15.73 | 31.64 | epoch 4 avg 2 |
| 16.02 & 15.82 | 31.84 | epoch 4 avg 1 |
| 16.02 & 15.83 | 31.85 | epoch 4 avg 3 |
| 16.16 & 16.05 | 32.21 | epoch 3 avg 1 |
| 16.18 & 16.05 | 32.23 | epoch 3 avg 2 |
| 16.54 & 16.47 | 33.01 | epoch 2 avg 1 |