### PR TITLE
Fixed the issue of errors in fully silent sentences during evaluation.

### DIFF
--- a/egs/librispeech/ASR/pruned_transducer_stateless7_ctc_bs/frame_reducer.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless7_ctc_bs/frame_reducer.py
@@ -74,7 +74,7 @@ class FrameReducer(nn.Module):
         padding_mask = make_pad_mask(x_lens)
         non_blank_mask = (ctc_output[:, :, blank_id] < math.log(0.9)) * (~padding_mask)
 
-        if y_lens is not None or self.training == False:
+        if y_lens is not None or self.training is False:
             # Limit the maximum number of reduced frames
             if y_lens is not None:
                 limit_lens = T - y_lens
@@ -85,15 +85,15 @@ class FrameReducer(nn.Module):
             fake_limit_indexes = torch.topk(
                 ctc_output[:, :, blank_id], max_limit_len
             ).indices
-            T = (
+            _T = (
                 torch.arange(max_limit_len)
                 .expand_as(
                     fake_limit_indexes,
                 )
                 .to(device=x.device)
             )
-            T = torch.remainder(T, limit_lens.unsqueeze(1))
-            limit_indexes = torch.gather(fake_limit_indexes, 1, torch.tensor(T))
+            _T = torch.remainder(_T, limit_lens.unsqueeze(1))
+            limit_indexes = torch.gather(fake_limit_indexes, 1, _T)
             limit_mask = (torch.full_like(
                 non_blank_mask,
                 0,


### PR DESCRIPTION
When recognizing, if a sentence is completely silent, blank skip will reduce all frame. Exception occurs: 
Traceback (most recent call last):
  File "/data/k2/icefall/egs/xxxx/Rework/./pruned_transducer_stateless7_ctc_bs/ctc_guide_decode_bs.py", line 847, in <module>
    main()
  File "/data/k2/miniconda3/envs/k2-1080ti/lib/python3.9/site-packages/torch/autograd/grad_mode.py", line 27, in decorate_context
    return func(*args, **kwargs)
  File "/data/k2/icefall/egs/xxxx/Rework/./pruned_transducer_stateless7_ctc_bs/ctc_guide_decode_bs.py", line 828, in main
    results_dict = decode_dataset(
  File "/data/k2/icefall/egs/xxxx/Rework/./pruned_transducer_stateless7_ctc_bs/ctc_guide_decode_bs.py", line 571, in decode_dataset
    hyps_dict = decode_one_batch(
  File "/data/k2/icefall/egs/xxxx/Rework/./pruned_transducer_stateless7_ctc_bs/ctc_guide_decode_bs.py", line 464, in decode_one_batch
    hyp_tokens = greedy_search_batch(
  File "/data/k2/icefall/egs/xxxx/Rework/pruned_transducer_stateless7_ctc_bs/beam_search.py", line 633, in greedy_search_batch
    packed_encoder_out = torch.nn.utils.rnn.pack_padded_sequence(
  File "/data/k2/miniconda3/envs/k2-1080ti/lib/python3.9/site-packages/torch/nn/utils/rnn.py", line 262, in pack_padded_sequence
    _VF._pack_padded_sequence(input, lengths, batch_first)
RuntimeError: Length of all samples has to be greater than 0, but found an element in 'lengths' that is <= 0

Add code to fix (ensure at least one frame exist after frame reduce).