### PR TITLE
Update pre-commit isort package to v5.11.5

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
       # E121,E123,E126,E226,E24,E704,W503,W504
 
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.11.5
     hooks:
       - id: isort
         args: ["--profile=black"]


### PR DESCRIPTION
Earlier versions of isort are not compatible with current version of poetry-core. This causes "pre-commit install" to fail. See: https://github.com/PyCQA/isort/issues/2077