### PR TITLE
Fix running exported model on GPU.

### DIFF
--- a/egs/librispeech/ASR/zipformer/zipformer.py
+++ b/egs/librispeech/ASR/zipformer/zipformer.py
@@ -2190,7 +2190,7 @@ class ConvolutionModule(nn.Module):
 
         x = self.in_proj(x)  # (time, batch, 2*channels)
 
-        x, s = x.chunk(2, dim=-1)
+        x, s = x.chunk(2, dim=2)
         s = self.sigmoid(s)
         x = x * s
         # (time, batch, channels)


### PR DESCRIPTION
This PR fixes the following error when running the exported model on GPU.

I think it is a PyTorch bug that it does not support `dim=-1` in `torch.chunk` when running on GPU from Python.

```
Traceback (most recent call last):
  File "./sherpa/bin/streaming_server.py", line 531, in stream_consumer_task
    await loop.run_in_executor(
  File "/star-fj/fangjun/open-source/pyenv/versions/3.8.0/lib/python3.8/concurrent/futures/thread.py", line 57, in run
    result = self.fn(*self.args, **self.kwargs)
RuntimeError: The following operation failed in the TorchScript interpreter.
Traceback of TorchScript, serialized code (most recent call last):
  File "code/__torch__.py", line 41, in forward
    encoder_states = torch.slice(states, None, -2)
    encoder = self.encoder
    _8 = (encoder).streaming_forward(x0, x_lens, encoder_states, src_key_padding_mask0, )
          ~~~~~~~~~~~~~~~~~~~~~~~~~~ <--- HERE
    encoder_out, encoder_out_lens, new_encoder_states, = _8
    encoder_out0 = torch.permute(encoder_out, [1, 0, 2])
  File "code/__torch__/zipformer.py", line 434, in streaming_forward
    _108 = torch.floordiv((left_context_frames)[0], ds)
    _109 = torch.slice(src_key_padding_mask, -1, None, None, ds)
    _110 = (_0).streaming_forward(x14, _107, _108, _109, )
            ~~~~~~~~~~~~~~~~~~~~~ <--- HERE
    x15, new_layer_states, = _110
    layer_offset = torch.add(0, num_layers)
  File "code/__torch__/zipformer.py", line 563, in streaming_forward
    _1 = getattr(layers, "1")
    cached_key, cached_nonlin_attn, cached_val1, cached_val2, cached_conv1, cached_conv2, = torch.slice(states, 0, 6)
    _148 = (_0).streaming_forward(src, pos_emb, cached_key, cached_nonlin_attn, cached_val1, cached_val2, cached_conv1, cached_conv2, left_context_le
n, src_key_padding_mask, )
            ~~~~~~~~~~~~~~~~~~~~~ <--- HERE
    output, new_cached_key, new_cached_nonlin_attn, new_cached_val1, new_cached_val2, new_cached_conv1, new_cached_conv2, = _148
    _149 = [new_cached_key, new_cached_nonlin_attn, new_cached_val1, new_cached_val2, new_cached_conv1, new_cached_conv2]
  File "code/__torch__/zipformer.py", line 794, in streaming_forward
    conv_module1 = self.conv_module1
    _198 = torch.slice(torch.slice(src_key_padding_mask), 1, left_context_len)
    _199 = (conv_module1).streaming_forward(src15, cached_conv1, _198, )
            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ <--- HERE
    src_conv, cached_conv16, = _199
    src16 = torch.add(src15, src_conv)
Traceback of TorchScript, original code (most recent call last):
  File "./zipformer/export.py", line 289, in forward
            encoder_out_lens,
            new_encoder_states,
        ) = self.encoder.streaming_forward(
            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ <--- HERE
            x=x,
            x_lens=x_lens,
  File "/ceph-zw/workspace/zipformer/icefall_zipformer/egs/librispeech/ASR/zipformer/zipformer.py", line 441, in streaming_forward
            x = convert_num_channels(x, self.encoder_dim[i])

            x, new_layer_states = module.streaming_forward(
                                  ~~~~~~~~~~~~~~~~~~~~~~~~ <--- HERE
                x,
                states=states[layer_offset * 6 : (layer_offset + num_layers) * 6],
  File "/ceph-zw/workspace/zipformer/icefall_zipformer/egs/librispeech/ASR/zipformer/zipformer.py", line 1026, in streaming_forward
                new_cached_conv1,
                new_cached_conv2
            ) = mod.streaming_forward(
                ~~~~~~~~~~~~~~~~~~~~~ <--- HERE
                output,
                pos_emb,
  File "/ceph-zw/workspace/zipformer/icefall_zipformer/egs/librispeech/ASR/zipformer/zipformer.py", line 856, in streaming_forward
        src = src + self_attn

        src_conv, cached_conv1 = self.conv_module1.streaming_forward(
                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ <--- HERE
            src,
            cache=cached_conv1,
RuntimeError: vector::_M_range_check: __n (which is 18446744073709551615) >= this->size() (which is 3)

Traceback (most recent call last):
  File "./sherpa/bin/streaming_server.py", line 853, in <module>
    main()
  File "/star-fj/fangjun/py38/lib/python3.8/site-packages/torch/autograd/grad_mode.py", line 28, in decorate_context
    return func(*args, **kwargs)
  File "./sherpa/bin/streaming_server.py", line 830, in main
    asyncio.run(server.run(port))
  File "/star-fj/fangjun/open-source/pyenv/versions/3.8.0/lib/python3.8/asyncio/runners.py", line 43, in run
    return loop.run_until_complete(main)
  File "/star-fj/fangjun/open-source/pyenv/versions/3.8.0/lib/python3.8/asyncio/base_events.py", line 595, in run_until_complete
    self.run_forever()
  File "/star-fj/fangjun/open-source/pyenv/versions/3.8.0/lib/python3.8/asyncio/base_events.py", line 563, in run_forever
    self._run_once()
  File "/star-fj/fangjun/open-source/pyenv/versions/3.8.0/lib/python3.8/asyncio/base_events.py", line 1808, in _run_once
    event_list = self._selector.select(timeout)
  File "/star-fj/fangjun/open-source/pyenv/versions/3.8.0/lib/python3.8/selectors.py", line 468, in select
    fd_event_list = self._selector.poll(timeout, max_ev)
KeyboardInterrupt
```