### PR TITLE
Support int8 quantization in decoder

### DIFF
--- a/egs/librispeech/ASR/zipformer/export-onnx-streaming.py
+++ b/egs/librispeech/ASR/zipformer/export-onnx-streaming.py
@@ -757,7 +757,7 @@ def main():
     quantize_dynamic(
         model_input=decoder_filename,
         model_output=decoder_filename_int8,
-        op_types_to_quantize=["MatMul"],
+        op_types_to_quantize=["MatMul", "Gather"],
         weight_type=QuantType.QInt8,
     )
 

--- a/egs/librispeech/ASR/zipformer/export-onnx.py
+++ b/egs/librispeech/ASR/zipformer/export-onnx.py
@@ -602,7 +602,7 @@ def main():
     quantize_dynamic(
         model_input=decoder_filename,
         model_output=decoder_filename_int8,
-        op_types_to_quantize=["MatMul"],
+        op_types_to_quantize=["MatMul", "Gather"],
         weight_type=QuantType.QInt8,
     )
 


### PR DESCRIPTION
Before the fix:

![image](https://github.com/k2-fsa/icefall/assets/11765074/f0cf1eee-790a-4818-825b-e3ffddb9f2f4)


After the fix:
![image](https://github.com/k2-fsa/icefall/assets/11765074/e44e8610-81ed-4ef2-b505-93ac9d8a7838)


