### PR TITLE
Fix ONNX export for the latest non-streaming zipformer.

### DIFF
--- a/egs/librispeech/ASR/zipformer/scaling_converter.py
+++ b/egs/librispeech/ASR/zipformer/scaling_converter.py
@@ -26,7 +26,16 @@ from typing import List, Tuple
 
 import torch
 import torch.nn as nn
-from scaling import Balancer, Dropout3, ScaleGrad, Whiten
+from scaling import (
+    Balancer,
+    Dropout3,
+    ScaleGrad,
+    SwooshL,
+    SwooshLOnnx,
+    SwooshR,
+    SwooshROnnx,
+    Whiten,
+)
 from zipformer import CompactRelPositionalEncoding
 
 
@@ -75,6 +84,10 @@ def convert_scaled_to_non_scaled(
     for name, m in model.named_modules():
         if isinstance(m, (Balancer, Dropout3, ScaleGrad, Whiten)):
             d[name] = nn.Identity()
+        elif is_onnx and isinstance(m, SwooshR):
+            d[name] = SwooshROnnx()
+        elif is_onnx and isinstance(m, SwooshL):
+            d[name] = SwooshLOnnx()
         elif is_onnx and isinstance(m, CompactRelPositionalEncoding):
             # We want to recreate the positional encoding vector when
             # the input changes, so we have to use torch.jit.script()


### PR DESCRIPTION
See https://github.com/k2-fsa/icefall/commit/c3e23ec8d2a3ed2547bd94dee7280bd3f193a47e#commitcomment-120481693

# TODO
- [ ] Add GitHub actions to covert ONNX export-related scripts in separate pull requests.


@joazoa

Please try this pull request. I have tested it locally that  both `zipformer/export-onnx.py` and `zipformer/export-onnx-streaming.py`  work as expected with this change. Also, the exported non-streaming and streaming models are able to decode files with `onnx_pretrained.py` and `onnx_pretrained-streaming.py`, respectively.