### PR TITLE
Fix zipformer CI test

### DIFF
--- a/egs/librispeech/ASR/pruned_transducer_stateless7_streaming/export.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless7_streaming/export.py
@@ -856,6 +856,10 @@ def main():
         # Otherwise, one of its arguments is a ragged tensor and is not
         # torch scriptabe.
         model.__class__.forward = torch.jit.ignore(model.__class__.forward)
+        model.encoder.__class__.non_streaming_forward = model.encoder.__class__.forward
+        model.encoder.__class__.non_streaming_forward = torch.jit.export(
+            model.encoder.__class__.non_streaming_forward
+        )
         model.encoder.__class__.forward = model.encoder.__class__.streaming_forward
         logging.info("Using torch.jit.script")
         model = torch.jit.script(model)

--- a/egs/librispeech/ASR/pruned_transducer_stateless7_streaming/jit_pretrained.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless7_streaming/jit_pretrained.py
@@ -252,7 +252,7 @@ def main():
 
     feature_lengths = torch.tensor(feature_lengths, device=device)
 
-    encoder_out, encoder_out_lens = model.encoder(
+    encoder_out, encoder_out_lens = model.encoder.non_streaming_forward(
         x=features,
         x_lens=feature_lengths,
     )


### PR DESCRIPTION
Fix the following CI
https://github.com/k2-fsa/icefall/actions/runs/5456575719/jobs/9929567946

```
2023-07-04 15:55:08,897 INFO [jit_pretrained.py:243] Decoding started
Traceback (most recent call last):
  File "./pruned_transducer_stateless7_streaming/jit_pretrained.py", line 278, in <module>
    main()
  File "/opt/hostedtoolcache/Python/3.8.17/x64/lib/python3.8/site-packages/torch/autograd/grad_mode.py", line 27, in decorate_context
    return func(*args, **kwargs)
  File "./pruned_transducer_stateless7_streaming/jit_pretrained.py", line 255, in main
    encoder_out, encoder_out_lens = model.encoder(
  File "/opt/hostedtoolcache/Python/3.8.17/x64/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1194, in _call_impl
    return forward_call(*input, **kwargs)
RuntimeError: forward() is missing value for argument 'states'. Declaration: forward(__torch__.zipformer.Zipformer self, Tensor x, Tensor x_lens, Tensor[] states) -> ((Tensor, Tensor, Tensor[]))
```