### PR TITLE
Fix CI test for zipformer CTC

### DIFF
--- a/egs/librispeech/ASR/zipformer/jit_pretrained_ctc.py
+++ b/egs/librispeech/ASR/zipformer/jit_pretrained_ctc.py
@@ -264,7 +264,7 @@ def main():
     params.update(vars(args))
 
     token_table = k2.SymbolTable.from_file(params.tokens)
-    params.vocab_size = num_tokens(token_table)
+    params.vocab_size = num_tokens(token_table) + 1
 
     logging.info(f"{params}")
 


### PR DESCRIPTION
See also
https://github.com/k2-fsa/icefall/pull/1130/files#r1252475093

It also fixes the following CI
https://github.com/k2-fsa/icefall/actions/runs/5456594778/jobs/9929614654
```
2023-07-04 15:59:40,115 INFO [pretrained_ctc.py:293] Number of model parameters: 65802947
Traceback (most recent call last):
  File "./zipformer/pretrained_ctc.py", line 445, in <module>
    main()
  File "/opt/hostedtoolcache/Python/3.8.17/x64/lib/python3.8/site-packages/torch/autograd/grad_mode.py", line 27, in decorate_context
    return func(*args, **kwargs)
  File "./zipformer/pretrained_ctc.py", line 296, in main
    model.load_state_dict(checkpoint["model"], strict=False)
  File "/opt/hostedtoolcache/Python/3.8.17/x64/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1671, in load_state_dict
    raise RuntimeError('Error(s) in loading state_dict for {}:\n\t{}'.format(
RuntimeError: Error(s) in loading state_dict for AsrModel:
	size mismatch for decoder.embedding.weight: copying a param with shape torch.Size([500, 512]) from checkpoint, the shape in current model is torch.Size([499, 512]).
	size mismatch for joiner.output_linear.weight: copying a param with shape torch.Size([500, 512]) from checkpoint, the shape in current model is torch.Size([499, 512]).
```