### PR TITLE
Add export script for the yesno recipe.

### DIFF
--- a/.github/workflows/run-yesno-recipe.yml
+++ b/.github/workflows/run-yesno-recipe.yml
@@ -108,7 +108,7 @@ jobs:
           python3 ./tdnn/export.py --epoch 14 --avg 2 --jit 1
 
           python3 ./tdnn/jit_pretrained.py \
-            --checkpoint ./tdnn/exp/cpu_jit.pt \
+            --nn-model ./tdnn/exp/cpu_jit.pt \
             --HLG ./data/lang_phone/HLG.pt \
             --words-file ./data/lang_phone/words.txt \
             download/waves_yesno/0_0_0_1_0_0_0_1.wav \
@@ -135,7 +135,7 @@ jobs:
 
           echo "Test int8 model"
           python3 ./tdnn/onnx_pretrained.py \
-            --nn-model ./tdnn/exp/model-epoch-14-avg-2.onnx \
+            --nn-model ./tdnn/exp/model-epoch-14-avg-2.int8.onnx \
             --HLG ./data/lang_phone/HLG.pt \
             --words-file ./data/lang_phone/words.txt \
             download/waves_yesno/0_0_0_1_0_0_0_1.wav \

--- a/.github/workflows/run-yesno-recipe.yml
+++ b/.github/workflows/run-yesno-recipe.yml
@@ -66,6 +66,7 @@ jobs:
           pip install --no-binary protobuf protobuf==3.20.*
 
           pip install --no-deps --force-reinstall https://huggingface.co/csukuangfj/k2/resolve/main/cpu/k2-1.24.3.dev20230508+cpu.torch1.13.1-cp38-cp38-linux_x86_64.whl
+          pip install kaldifeat==1.25.0.dev20230726+cpu.torch1.13.1 -f https://csukuangfj.github.io/kaldifeat/cpu.html
 
       - name: Run yesno recipe
         shell: bash

--- a/.github/workflows/run-yesno-recipe.yml
+++ b/.github/workflows/run-yesno-recipe.yml
@@ -20,7 +20,6 @@ on:
   push:
     branches:
       - master
-      - yesno-export
   pull_request:
     branches:
       - master
@@ -140,3 +139,10 @@ jobs:
             --words-file ./data/lang_phone/words.txt \
             download/waves_yesno/0_0_0_1_0_0_0_1.wav \
             download/waves_yesno/0_0_1_0_0_0_1_0.wav
+
+      - name: Show generated files
+        shell: bash
+        working-directory: ${{github.workspace}}
+        run: |
+          cd egs/yesno/ASR
+          ls -lh tdnn/exp

--- a/.github/workflows/run-yesno-recipe.yml
+++ b/.github/workflows/run-yesno-recipe.yml
@@ -20,6 +20,7 @@ on:
   push:
     branches:
       - master
+      - yesno-export
   pull_request:
     branches:
       - master
@@ -43,11 +44,6 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-
-      - name: Install graphviz
-        shell: bash
-        run: |
-          sudo apt-get -qq install graphviz
 
       - name: Setup Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
@@ -78,9 +74,68 @@ jobs:
           export PYTHONPATH=$PWD:$PYTHONPATH
           echo $PYTHONPATH
 
-
           cd egs/yesno/ASR
           ./prepare.sh
           python3 ./tdnn/train.py
           python3 ./tdnn/decode.py
-          # TODO: Check that the WER is less than some value
+
+      - name: Test exporting to pretrained.pt
+        shell: bash
+        working-directory: ${{github.workspace}}
+        run: |
+          export PYTHONPATH=$PWD:$PYTHONPATH
+          echo $PYTHONPATH
+
+          cd egs/yesno/ASR
+          python3 ./tdnn/export.py --epoch 14 --avg 2
+
+          python3 ./tdnn/pretrained.py \
+            --checkpoint ./tdnn/exp/pretrained.pt \
+            --HLG ./data/lang_phone/HLG.pt \
+            --words-file ./data/lang_phone/words.txt \
+            download/waves_yesno/0_0_0_1_0_0_0_1.wav \
+            download/waves_yesno/0_0_1_0_0_0_1_0.wav
+
+      - name: Test exporting to torchscript
+        shell: bash
+        working-directory: ${{github.workspace}}
+        run: |
+          export PYTHONPATH=$PWD:$PYTHONPATH
+          echo $PYTHONPATH
+
+          cd egs/yesno/ASR
+          python3 ./tdnn/export.py --epoch 14 --avg 2 --jit 1
+
+          python3 ./tdnn/jit_pretrained.py \
+            --checkpoint ./tdnn/exp/cpu_jit.pt \
+            --HLG ./data/lang_phone/HLG.pt \
+            --words-file ./data/lang_phone/words.txt \
+            download/waves_yesno/0_0_0_1_0_0_0_1.wav \
+            download/waves_yesno/0_0_1_0_0_0_1_0.wav
+
+      - name: Test exporting to onnx
+        shell: bash
+        working-directory: ${{github.workspace}}
+        run: |
+          export PYTHONPATH=$PWD:$PYTHONPATH
+          echo $PYTHONPATH
+
+          cd egs/yesno/ASR
+          python3 ./tdnn/export_onnx.py --epoch 14 --avg 2
+
+          echo "Test float32 model"
+          python3 ./tdnn/onnx_pretrained.py \
+            --nn-model ./tdnn/exp/model-epoch-14-avg-2.onnx \
+            --HLG ./data/lang_phone/HLG.pt \
+            --words-file ./data/lang_phone/words.txt \
+            download/waves_yesno/0_0_0_1_0_0_0_1.wav \
+            download/waves_yesno/0_0_1_0_0_0_1_0.wav
+
+
+          echo "Test int8 model"
+          python3 ./tdnn/onnx_pretrained.py \
+            --nn-model ./tdnn/exp/model-epoch-14-avg-2.onnx \
+            --HLG ./data/lang_phone/HLG.pt \
+            --words-file ./data/lang_phone/words.txt \
+            download/waves_yesno/0_0_0_1_0_0_0_1.wav \
+            download/waves_yesno/0_0_1_0_0_0_1_0.wav

--- a/egs/yesno/ASR/tdnn/decode.py
+++ b/egs/yesno/ASR/tdnn/decode.py
@@ -65,7 +65,6 @@ def get_params() -> AttributeDict:
         {
             "exp_dir": Path("tdnn/exp/"),
             "lang_dir": Path("data/lang_phone"),
-            "lm_dir": Path("data/lm"),
             "feature_dim": 23,
             "search_beam": 20,
             "output_beam": 8,

--- a/egs/yesno/ASR/tdnn/export.py
+++ b/egs/yesno/ASR/tdnn/export.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+
+"""
+This file is for exporting trained models to a checkpoint
+or to a torchscript model.
+
+(1) Generate the checkpoint tdnn/exp/pretrained.pt
+
+./tdnn/export.py \
+  --epoch 14 \
+  --avg 2
+
+See ./tdnn/pretrained.py for how to use the generated file.
+
+(2) Generate torchscript model tdnn/exp/cpu_jit.pt
+
+./tdnn/export.py \
+  --epoch 14 \
+  --avg 2 \
+  --jit 1
+
+See ./tdnn/jit_pretrained.py for how to use the generated file.
+"""
+
+import argparse
+import logging
+
+import torch
+from model import Tdnn
+from train import get_params
+
+from icefall.checkpoint import average_checkpoints, load_checkpoint
+from icefall.lexicon import Lexicon
+from icefall.utils import str2bool
+
+
+def get_parser():
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+
+    parser.add_argument(
+        "--epoch",
+        type=int,
+        default=14,
+        help="It specifies the checkpoint to use for decoding."
+        "Note: Epoch counts from 0.",
+    )
+
+    parser.add_argument(
+        "--avg",
+        type=int,
+        default=2,
+        help="Number of checkpoints to average. Automatically select "
+        "consecutive checkpoints before the checkpoint specified by "
+        "'--epoch'. ",
+    )
+
+    parser.add_argument(
+        "--jit",
+        type=str2bool,
+        default=False,
+        help="""True to save a model after applying torch.jit.script.
+        """,
+    )
+    return parser
+
+
+@torch.no_grad()
+def main():
+    args = get_parser().parse_args()
+
+    params = get_params()
+    params.update(vars(args))
+
+    logging.info(params)
+
+    lexicon = Lexicon(params.lang_dir)
+    max_token_id = max(lexicon.tokens)
+
+    model = Tdnn(
+        num_features=params.feature_dim,
+        num_classes=max_token_id + 1,  # +1 for the blank symbol
+    )
+    if params.avg == 1:
+        load_checkpoint(f"{params.exp_dir}/epoch-{params.epoch}.pt", model)
+    else:
+        start = params.epoch - params.avg + 1
+        filenames = []
+        for i in range(start, params.epoch + 1):
+            if start >= 0:
+                filenames.append(f"{params.exp_dir}/epoch-{i}.pt")
+        logging.info(f"averaging {filenames}")
+        model.load_state_dict(average_checkpoints(filenames))
+
+    model.to("cpu")
+    model.eval()
+
+    if params.jit:
+        logging.info("Using torch.jit.script")
+        model = torch.jit.script(model)
+        filename = params.exp_dir / "cpu_jit.pt"
+        model.save(str(filename))
+        logging.info(f"Saved to {filename}")
+    else:
+        logging.info("Not using torch.jit.script")
+        # Save it using a format so that it can be loaded
+        # by :func:`load_checkpoint`
+        filename = params.exp_dir / "pretrained.pt"
+        torch.save({"model": model.state_dict()}, str(filename))
+        logging.info(f"Saved to {filename}")
+
+
+if __name__ == "__main__":
+    formatter = "%(asctime)s %(levelname)s [%(filename)s:%(lineno)d] %(message)s"
+
+    logging.basicConfig(format=formatter, level=logging.INFO)
+    main()

--- a/egs/yesno/ASR/tdnn/export_onnx.py
+++ b/egs/yesno/ASR/tdnn/export_onnx.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+
+"""
+This file is for exporting trained models to onnx.
+
+Usage:
+
+    ./tdnn/export_onnx.py \
+      --epoch 14 \
+      --avg 2
+
+The above command generates the following two files:
+  - ./exp/model-epoch-14-avg-2.onnx
+  - ./exp/model-epoch-14-avg-2.int8.onnx
+
+See ./tdnn/onnx_pretrained.py for how to use them.
+"""
+
+import argparse
+import logging
+from typing import Dict
+
+import onnx
+import torch
+from model import Tdnn
+from onnxruntime.quantization import QuantType, quantize_dynamic
+from train import get_params
+
+from icefall.checkpoint import average_checkpoints, load_checkpoint
+from icefall.lexicon import Lexicon
+
+
+def get_parser():
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+
+    parser.add_argument(
+        "--epoch",
+        type=int,
+        default=14,
+        help="It specifies the checkpoint to use for decoding."
+        "Note: Epoch counts from 0.",
+    )
+
+    parser.add_argument(
+        "--avg",
+        type=int,
+        default=2,
+        help="Number of checkpoints to average. Automatically select "
+        "consecutive checkpoints before the checkpoint specified by "
+        "'--epoch'. ",
+    )
+
+    return parser
+
+
+def add_meta_data(filename: str, meta_data: Dict[str, str]):
+    """Add meta data to an ONNX model. It is changed in-place.
+
+    Args:
+      filename:
+        Filename of the ONNX model to be changed.
+      meta_data:
+        Key-value pairs.
+    """
+    model = onnx.load(filename)
+    for key, value in meta_data.items():
+        meta = model.metadata_props.add()
+        meta.key = key
+        meta.value = str(value)
+
+    onnx.save(model, filename)
+
+
+@torch.no_grad()
+def main():
+    args = get_parser().parse_args()
+
+    params = get_params()
+    params.update(vars(args))
+
+    logging.info(params)
+
+    lexicon = Lexicon(params.lang_dir)
+    max_token_id = max(lexicon.tokens)
+
+    model = Tdnn(
+        num_features=params.feature_dim,
+        num_classes=max_token_id + 1,  # +1 for the blank symbol
+    )
+    if params.avg == 1:
+        load_checkpoint(f"{params.exp_dir}/epoch-{params.epoch}.pt", model)
+    else:
+        start = params.epoch - params.avg + 1
+        filenames = []
+        for i in range(start, params.epoch + 1):
+            if start >= 0:
+                filenames.append(f"{params.exp_dir}/epoch-{i}.pt")
+        logging.info(f"averaging {filenames}")
+        model.load_state_dict(average_checkpoints(filenames))
+
+    model.to("cpu")
+    model.eval()
+
+    N = 1
+    T = 100
+    C = params.feature_dim
+    x = torch.rand(N, T, C)
+
+    opset_version = 13
+    onnx_filename = f"{params.exp_dir}/model-epoch-{params.epoch}-avg-{params.avg}.onnx"
+    torch.onnx.export(
+        model,
+        x,
+        onnx_filename,
+        verbose=False,
+        opset_version=opset_version,
+        input_names=["x"],
+        output_names=["log_prob"],
+        dynamic_axes={
+            "x": {0: "N", 1: "T"},
+            "log_prob": {0: "N", 1: "T"},
+        },
+    )
+
+    logging.info(f"Saved to {onnx_filename}")
+    meta_data = {
+        "model_type": "tdnn_lstm",
+        "version": "1",
+        "model_author": "k2-fsa",
+        "comment": "non-streaming tdnn for the yesno recipe",
+        "vocab_size": max_token_id + 1,
+    }
+
+    logging.info(f"meta_data: {meta_data}")
+
+    add_meta_data(filename=onnx_filename, meta_data=meta_data)
+
+    logging.info("Generate int8 quantization models")
+    onnx_filename_int8 = (
+        f"{params.exp_dir}/model-epoch-{params.epoch}-avg-{params.avg}.int8.onnx"
+    )
+
+    quantize_dynamic(
+        model_input=onnx_filename,
+        model_output=onnx_filename_int8,
+        op_types_to_quantize=["MatMul"],
+        weight_type=QuantType.QInt8,
+    )
+    logging.info(f"Saved to {onnx_filename_int8}")
+
+
+if __name__ == "__main__":
+    formatter = "%(asctime)s %(levelname)s [%(filename)s:%(lineno)d] %(message)s"
+
+    logging.basicConfig(format=formatter, level=logging.INFO)
+    main()


### PR DESCRIPTION
This PR adds code to export the tdnn model from the yesno recipe into the following format:
- torchscript via torch.jit.script()
- onnx via torch.onnx.export()

It also provides script to use the exported model for decoding.

# TODOs
- [ ] Change k2-fsa/sherpa-onnx to support the exported model
- [ ] Change k2-fsa/sherpa to support the exported model
- [ ] Provide a colab notebook to show the following items
  - [ ] data preparation
  - [ ] training
  - [ ] decoding
  - [ ] Export to ONNX and torchscript format
  - [ ] Usage with sherpa-onnx
    - [ ] C# API, Go API, Python API, non-streaming websocket server/client
 - [ ]  Add a huggingface space for it
 - [ ] Update doc to include a section `icefall for dummies`
   - Users should be able to learn how to do data preparation, training, decoding, model export, and deployment
   - Since the yesno dataset is quite small, the whole process can be finished in several minutes on CPU, e.g., less than 10 minutes or even less than 5 minutes 
