### PR TITLE
Speed up yesno training to finish in ~10s on CPU

### DIFF
--- a/egs/yesno/ASR/tdnn/asr_datamodule.py
+++ b/egs/yesno/ASR/tdnn/asr_datamodule.py
@@ -209,7 +209,7 @@ class YesNoAsrDataModule(DataModule):
             sampler=train_sampler,
             batch_size=None,
             num_workers=self.args.num_workers,
-            persistent_workers=False,
+            persistent_workers=True,
         )
 
         return train_dl
@@ -236,6 +236,7 @@ class YesNoAsrDataModule(DataModule):
             batch_size=None,
             sampler=sampler,
             num_workers=self.args.num_workers,
+            persistent_workers=True,
         )
         return test_dl
 


### PR DESCRIPTION
Setting `persistent_workers=True` when creating DataLoader removes a significant overhead at the start of each epoch and validation. Thanks to this, it finishes in ~10s vs a couple of minutes.