### PR TITLE
Minor fixes to the `optim.py`

### DIFF
--- a/egs/librispeech/ASR/zipformer/optim.py
+++ b/egs/librispeech/ASR/zipformer/optim.py
@@ -491,6 +491,12 @@ class ScaledAdam(BatchedOptimizer):
                 if self.show_dominant_parameters:
                     assert p.shape[0] == len(param_names)
                     self._show_gradient_dominating_parameter(tuples, tot_sumsq)
+            if ans != ans:  # e.g. ans is nan
+                ans = 0.0
+            if ans == 0.0:
+                for p, state, param_names in tuples:
+                    p.grad.zero_()  # get rid of infinity()
+
             return ans
 
     def _show_gradient_dominating_parameter(
@@ -573,7 +579,7 @@ class ScaledAdam(BatchedOptimizer):
 
         grad = p.grad
         if clipping_scale != 1.0:
-            grad = grad * clipping_scale
+            grad *= clipping_scale
         step = state["step"]
         delta = state["delta"]
 


### PR DESCRIPTION
"It reduces the chance of nan gradients ruining the model, and also it makes the clipping scale actually get applied; there was a bug before, where grad was not used because it was not passed into the other functions directly." -- from Dan