### PR TITLE
Support modified CTC topology

### DIFF
--- a/egs/librispeech/ASR/zipformer/onnx_pretrained_ctc_H.py
+++ b/egs/librispeech/ASR/zipformer/onnx_pretrained_ctc_H.py
@@ -92,6 +92,7 @@ class OnnxModel:
         session_opts = ort.SessionOptions()
         session_opts.inter_op_num_threads = 1
         session_opts.intra_op_num_threads = 1
+        session_opts.log_severity_level = 3 # error level
 
         self.session_opts = session_opts
 

--- a/egs/librispeech/ASR/zipformer/onnx_pretrained_ctc_HL.py
+++ b/egs/librispeech/ASR/zipformer/onnx_pretrained_ctc_HL.py
@@ -92,6 +92,7 @@ class OnnxModel:
         session_opts = ort.SessionOptions()
         session_opts.inter_op_num_threads = 1
         session_opts.intra_op_num_threads = 1
+        session_opts.log_severity_level = 3 # error level
 
         self.session_opts = session_opts
 

--- a/egs/librispeech/ASR/zipformer/onnx_pretrained_ctc_HLG.py
+++ b/egs/librispeech/ASR/zipformer/onnx_pretrained_ctc_HLG.py
@@ -92,6 +92,7 @@ class OnnxModel:
         session_opts = ort.SessionOptions()
         session_opts.inter_op_num_threads = 1
         session_opts.intra_op_num_threads = 1
+        session_opts.log_severity_level = 3 # error level
 
         self.session_opts = session_opts
 

--- a/icefall/ctc/__init__.py
+++ b/icefall/ctc/__init__.py
@@ -3,4 +3,9 @@ from .prepare_lang import (
     make_lexicon_fst_no_silence,
     make_lexicon_fst_with_silence,
 )
-from .topo import add_disambig_self_loops, add_one, build_standard_ctc_topo
+from .topo import (
+    add_disambig_self_loops,
+    add_one,
+    build_ctc_topo_max_repeat0,
+    build_standard_ctc_topo,
+)

--- a/icefall/ctc/test_ctc_topo.py
+++ b/icefall/ctc/test_ctc_topo.py
@@ -11,7 +11,12 @@ from prepare_lang import (
     make_lexicon_fst_no_silence,
     make_lexicon_fst_with_silence,
 )
-from topo import add_disambig_self_loops, add_one, build_standard_ctc_topo
+from topo import (
+    add_disambig_self_loops,
+    add_one,
+    build_standard_ctc_topo,
+    build_ctc_topo_max_repeat0,
+)
 
 
 def test_yesno():
@@ -131,7 +136,30 @@ def test_librispeech():
     print(sp.encode(["HELLOA", "WORLD"]))
 
 
+def test_build_ctc_topo_max_repeat0():
+    H = build_ctc_topo_max_repeat0(max_token_id=3)
+    isym = kaldifst.SymbolTable()
+    isym.add_symbol(symbol="<blk>", key=0)
+    isym.add_symbol(symbol="C", key=1)
+    isym.add_symbol(symbol="A", key=2)
+    isym.add_symbol(symbol="T", key=3)
+
+    osym = kaldifst.SymbolTable()
+    osym.add_symbol(symbol="<eps>", key=0)
+    osym.add_symbol(symbol="C", key=1)
+    osym.add_symbol(symbol="A", key=2)
+    osym.add_symbol(symbol="T", key=3)
+
+    H.input_symbols = isym
+    H.output_symbols = osym
+
+    fst_dot = kaldifst.draw(H, acceptor=False, portrait=True)
+    source = graphviz.Source(fst_dot)
+    source.render(outfile="ctc_topo_max_repeat0.pdf")
+
+
 def main():
+    test_build_ctc_topo_max_repeat0()
     test_yesno()
     test_librispeech()
 


### PR DESCRIPTION
# LibriSpeech
## File size of the standard ctc topology
```
(py38) fangjuns-MacBook-Pro:lang_bpe_500 fangjun$ ls -lh H{,L,LG}.fst
-rw-r--r--  1 fangjun  staff   3.8M Oct  9 19:43 H.fst
-rw-r--r--  1 fangjun  staff    27M Oct  9 19:43 HL.fst
-rw-r--r--  1 fangjun  staff   334M Oct  9 19:47 HLG.fst
```

## File size of modified ctc topology
```
(py38) fangjuns-MacBook-Pro:lang_bpe_500 fangjun$ ls -lh *0.fst
-rw-r--r--  1 fangjun  staff   299M Oct  9 19:53 HLG_0.fst
-rw-r--r--  1 fangjun  staff    24M Oct  9 19:49 HL_0.fst
-rw-r--r--  1 fangjun  staff   3.8M Oct  9 19:48 H_0.fst
```

By modified we mean the resulting CTC topology does not allow any repeat at all.