### PR TITLE
fixed broken link in Readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ Once you have trained a model in icefall, you may want to deploy it with C++,
 without Python dependencies.
 
 Please refer to the documentation
-<https://icefall.readthedocs.io/en/latest/recipes/librispeech/conformer_ctc.html#deployment-with-c>
+<https://icefall.readthedocs.io/en/latest/recipes/Non-streaming-ASR/librispeech/conformer_ctc.html#deployment-with-c>
 for how to do this.
 
 We also provide a Colab notebook, showing you how to run a torch scripted model in [k2][k2] with C++.


### PR DESCRIPTION
This issue resolves #1341 
Fixed the broken link of Deployment with C++ 
Now it redirects to 

![Screenshot 2023-10-26 112611](https://github.com/k2-fsa/icefall/assets/70795867/1e9e4fe7-8333-49ad-bc8b-5f0c6bd830fa)
