### PR TITLE
Fix finalize error in ContextGraph implementation.

### DIFF
--- a/icefall/context_graph.py
+++ b/icefall/context_graph.py
@@ -240,8 +240,11 @@ class ContextGraph:
           the score is zero, otherwise the score is the score of a implicit fail arc
           to root. The next state is always root.
         """
-        # The score of the fail arc
-        score = -state.node_score
+        if state.is_end:
+            score = 0.0
+        else:
+            # The score of the fail arc
+            score = -state.node_score
         return (score, self.root)
 
     def draw(


### PR DESCRIPTION
For Aho-Corasicks algorithm, at the end of beam search, we should subtract scores of edges `state.node_score` only if current state is not an end of word.
Fix is simple.
cc @pkufool 