### PR TITLE
Fixing torch.ctc err

### DIFF
--- a/egs/librispeech/ASR/zipformer/model.py
+++ b/egs/librispeech/ASR/zipformer/model.py
@@ -164,9 +164,9 @@ class AsrModel(nn.Module):
 
         ctc_loss = torch.nn.functional.ctc_loss(
             log_probs=ctc_output.permute(1, 0, 2),  # (T, N, C)
-            targets=targets.to(torch.long),
-            input_lengths=encoder_out_lens.to(torch.long),
-            target_lengths=target_lengths.to(torch.long),
+            targets=targets.cpu(),
+            input_lengths=encoder_out_lens.cpu(),
+            target_lengths=target_lengths.cpu(),
             reduction="sum",
         )
         return ctc_loss

--- a/egs/librispeech/ASR/zipformer/model.py
+++ b/egs/librispeech/ASR/zipformer/model.py
@@ -164,9 +164,9 @@ class AsrModel(nn.Module):
 
         ctc_loss = torch.nn.functional.ctc_loss(
             log_probs=ctc_output.permute(1, 0, 2),  # (T, N, C)
-            targets=targets,
-            input_lengths=encoder_out_lens,
-            target_lengths=target_lengths,
+            targets=targets.to(torch.long),
+            input_lengths=encoder_out_lens.to(torch.long),
+            target_lengths=target_lengths.to(torch.long),
             reduction="sum",
         )
         return ctc_loss


### PR DESCRIPTION
`F.ctc_loss` throws error when batch size `N` is `1`. Using `torch.long` as recommended by the documentation fixes this error. 

```python
import torch
N = 1
T = 50
S = 31
V = 20
log_probs = torch.randn(T, N, V, device="cuda:0").log_softmax(2)
targets = torch.randint(1, 20, (S,), device="cuda:0", dtype=torch.int32)
input_lengths = torch.full((N,), T, device="cuda:0", dtype=torch.int32)
target_lengths = torch.tensor([S,], device="cuda:0", dtype=torch.int32)

torch.nn.functional.ctc_loss(log_probs, targets, input_lengths, target_lengths)
```

throws:
```python
RuntimeError: Expected tensor to have CPU Backend, but got tensor with CUDA Backend (while checking arguments for cudnn_ctc_loss)
```