### PR TITLE
Add num_features to train.py for training WSASR

### DIFF
--- a/egs/librispeech/WSASR/conformer_ctc2/train.py
+++ b/egs/librispeech/WSASR/conformer_ctc2/train.py
@@ -31,7 +31,7 @@ export CUDA_VISIBLE_DEVICES="0,1,2,3"
   --exp-dir conformer_ctc2/exp \
   --lang-dir data/lang_bpe_200 \
   --otc-token "<star>" \
-  --num_features 80 \
+  --num-features 80 \
   --allow-bypass-arc true \
   --allow-self-loop-arc true \
   --initial-bypass-weight -19 \
@@ -162,7 +162,7 @@ def get_parser():
     )
   
     parser.add_argument(
-        "--num_features",
+        "--num-features",
         type=int,
         default=768,
         help="""Number of features extracted in feature extraction stage.last dimension of feature vector.

--- a/egs/librispeech/WSASR/conformer_ctc2/train.py
+++ b/egs/librispeech/WSASR/conformer_ctc2/train.py
@@ -31,7 +31,7 @@ export CUDA_VISIBLE_DEVICES="0,1,2,3"
   --exp-dir conformer_ctc2/exp \
   --lang-dir data/lang_bpe_200 \
   --otc-token "<star>" \
-  --num_features 80
+  --num_features 80 \
   --allow-bypass-arc true \
   --allow-self-loop-arc true \
   --initial-bypass-weight -19 \

--- a/egs/librispeech/WSASR/conformer_ctc2/train.py
+++ b/egs/librispeech/WSASR/conformer_ctc2/train.py
@@ -31,7 +31,7 @@ export CUDA_VISIBLE_DEVICES="0,1,2,3"
   --exp-dir conformer_ctc2/exp \
   --lang-dir data/lang_bpe_200 \
   --otc-token "<star>" \
-  --num-features 80 \
+  --num-features 768 \
   --allow-bypass-arc true \
   --allow-self-loop-arc true \
   --initial-bypass-weight -19 \
@@ -383,8 +383,8 @@ def get_params() -> AttributeDict:
         - warm_step: The warm_step for Noam optimizer.
     """
     parser = get_parser()
+    LibriSpeechAsrDataModule.add_arguments(parser)
     args = parser.parse_args()
-    feature_dim = args.num_features
     params = AttributeDict(
         {
             "best_train_loss": float("inf"),
@@ -397,7 +397,7 @@ def get_params() -> AttributeDict:
             "valid_interval": 800,  # For the 100h subset, use 800
             "alignment_interval": 25,
             # parameters for conformer
-            "feature_dim": feature_dim,
+            "feature_dim": args.num_features,
             "subsampling_factor": 2,
             "encoder_dim": 512,
             "nhead": 8,

--- a/egs/librispeech/WSASR/conformer_ctc2/train.py
+++ b/egs/librispeech/WSASR/conformer_ctc2/train.py
@@ -31,7 +31,7 @@ export CUDA_VISIBLE_DEVICES="0,1,2,3"
   --exp-dir conformer_ctc2/exp \
   --lang-dir data/lang_bpe_200 \
   --otc-token "<star>" \
-  --num-features 768 \
+  --feature-dim 768 \
   --allow-bypass-arc true \
   --allow-self-loop-arc true \
   --initial-bypass-weight -19 \

--- a/egs/librispeech/WSASR/conformer_ctc2/train.py
+++ b/egs/librispeech/WSASR/conformer_ctc2/train.py
@@ -385,7 +385,7 @@ def get_params() -> AttributeDict:
             "valid_interval": 800,  # For the 100h subset, use 800
             "alignment_interval": 25,
             # parameters for conformer
-            "feature_dim": 768,
+            "feature_dim": 80, # when using fbank features for training
             "subsampling_factor": 2,
             "encoder_dim": 512,
             "nhead": 8,

--- a/egs/librispeech/WSASR/conformer_ctc2/train.py
+++ b/egs/librispeech/WSASR/conformer_ctc2/train.py
@@ -31,6 +31,7 @@ export CUDA_VISIBLE_DEVICES="0,1,2,3"
   --exp-dir conformer_ctc2/exp \
   --lang-dir data/lang_bpe_200 \
   --otc-token "<star>" \
+  --num_features 80
   --allow-bypass-arc true \
   --allow-self-loop-arc true \
   --initial-bypass-weight -19 \
@@ -158,6 +159,14 @@ def get_parser():
         It contains language related input files such as
         "lexicon.txt"
         """,
+    )
+  
+    parser.add_argument(
+        "--num_features",
+        type=int,
+        default=768,
+        help="""Number of features extracted in feature extraction stage.last dimension of feature vector.
+        80 when using fbank features and 768 or 1024 whn using wave2vec""",
     )
 
     parser.add_argument(
@@ -373,6 +382,9 @@ def get_params() -> AttributeDict:
 
         - warm_step: The warm_step for Noam optimizer.
     """
+    parser = get_parser()
+    args = parser.parse_args()
+    feature_dim = args.num_features
     params = AttributeDict(
         {
             "best_train_loss": float("inf"),
@@ -385,7 +397,7 @@ def get_params() -> AttributeDict:
             "valid_interval": 800,  # For the 100h subset, use 800
             "alignment_interval": 25,
             # parameters for conformer
-            "feature_dim": 80, # when using fbank features for training
+            "feature_dim": feature_dim,
             "subsampling_factor": 2,
             "encoder_dim": 512,
             "nhead": 8,

--- a/egs/librispeech/WSASR/conformer_ctc2/train.py
+++ b/egs/librispeech/WSASR/conformer_ctc2/train.py
@@ -162,7 +162,7 @@ def get_parser():
     )
   
     parser.add_argument(
-        "--num-features",
+        "--feature-dim",
         type=int,
         default=768,
         help="""Number of features extracted in feature extraction stage.last dimension of feature vector.

--- a/egs/librispeech/WSASR/conformer_ctc2/train.py
+++ b/egs/librispeech/WSASR/conformer_ctc2/train.py
@@ -397,7 +397,6 @@ def get_params() -> AttributeDict:
             "valid_interval": 800,  # For the 100h subset, use 800
             "alignment_interval": 25,
             # parameters for conformer
-            "feature_dim": args.num_features,
             "subsampling_factor": 2,
             "encoder_dim": 512,
             "nhead": 8,

--- a/egs/librispeech/WSASR/conformer_ctc2/train.py
+++ b/egs/librispeech/WSASR/conformer_ctc2/train.py
@@ -382,9 +382,6 @@ def get_params() -> AttributeDict:
 
         - warm_step: The warm_step for Noam optimizer.
     """
-    parser = get_parser()
-    LibriSpeechAsrDataModule.add_arguments(parser)
-    args = parser.parse_args()
     params = AttributeDict(
         {
             "best_train_loss": float("inf"),


### PR DESCRIPTION
Based on this [issue](https://github.com/k2-fsa/icefall/issues/1506). I add num-features to input args for train.py to set feature_dim parameter. This parameter setting is based on feature extraction method.