### PR TITLE
fix error in length computing

### DIFF
--- a/egs/librispeech/SSL/zipformer/hubert_ce.py
+++ b/egs/librispeech/SSL/zipformer/hubert_ce.py
@@ -429,7 +429,7 @@ class HubertModel(nn.Module):
         # padding_mask: (B, T), bool
         # mask_indices: (B, T), bool
         x = x.transpose(0, 1)
-        x, x_lens = self.encoder(x, ~padding_mask.sum(dim=-1))
+        x, x_lens = self.encoder(x, (~padding_mask).sum(dim=-1))
         x = x.transpose(0, 1)
 
         if features_only:


### PR DESCRIPTION
This PR fixs the bug in librispeech/SSL, which computes x_lens using padding_mask in a wrong way.
Fortunately, it did not cause any problem.