### PR TITLE
Add force=True to logging.basicConfig

### DIFF
--- a/icefall/utils.py
+++ b/icefall/utils.py
@@ -163,6 +163,7 @@ def setup_logger(
         format=formatter,
         level=level,
         filemode="w",
+        force=True,
     )
     if use_console:
         console = logging.StreamHandler()


### PR DESCRIPTION
From dan, "probably in my version of torch inside setup_dist(), had already set up the logger, and in order to get the setup_logger stuff to work I had to add force=True to the invocation to basic_config. "