### PR TITLE
fix open-commands path in kws

### DIFF
--- a/egs/wenetspeech/KWS/prepare.sh
+++ b/egs/wenetspeech/KWS/prepare.sh
@@ -63,8 +63,8 @@ if [ $stage -le 1 ] && [ $stop_stage -ge 1 ]; then
     ln -svf $(realpath ./open-commands/CN/small/commands.txt) commands_small.txt
     ln -svf $(realpath ./open-commands/CN/large/commands.txt) commands_large.txt
     pushd open-commands
-    ./script/prepare.sh --stage 1 --stop-stage 1
-    ./script/prepare.sh --stage 3 --stop-stage 5
+    ./scripts/prepare.sh --stage 1 --stop-stage 1
+    ./scripts/prepare.sh --stage 3 --stop-stage 5
     popd
     popd
     pushd data/fbank


### PR DESCRIPTION
https://github.com/k2-fsa/icefall/blob/3b257dd5ae79bff99470ec1cbbeaa8fae84f956a/egs/wenetspeech/KWS/prepare.sh#L66
As shown in the figure below, the path of `open-commands->scripts` is incorrect, this MR just fix open-commands path in kws.
![image](https://github.com/user-attachments/assets/66a9d758-ae39-40c1-842d-a7acd40264a6)

