### PR TITLE
Support AudioSet training with weighted sampler 

### DIFF
--- a/egs/audioset/AT/RESULTS.md
+++ b/egs/audioset/AT/RESULTS.md
@@ -35,15 +35,39 @@ python zipformer/train.py \
     --master-port 13455
 ```
 
+We recommend that you train the model with weighted sampler, as the model converges
+faster with better performance:
+
+| Model | mAP |
+| ------ | ------- |
+| Zipformer-AT, train with weighted sampler | 46.6 |
+
 The evaluation command is:
 
 ```bash
-python zipformer/evaluate.py \
-    --epoch 32 \
-    --avg 8 \
-    --exp-dir zipformer/exp_at_as_full \
-    --max-duration 500
+export CUDA_VISIBLE_DEVICES="4,5,6,7"
+subset=full
+weighted_sampler=1
+bucket_sampler=0
+lr_epochs=15
+
+python zipformer/train.py \
+    --world-size 4 \
+    --audioset-subset $subset \
+    --num-epochs 120 \
+    --start-epoch 1 \
+    --use-fp16 1 \
+    --num-events 527 \
+    --lr-epochs $lr_epochs \
+    --exp-dir zipformer/exp_AS_${subset}_weighted_sampler${weighted_sampler} \
+    --weighted-sampler $weighted_sampler \
+    --bucketing-sampler $bucket_sampler \
+    --max-duration 1000 \
+    --enable-musan True \
+    --master-port 13452
 ```
+
+The command for evaluation is the same. The pre-trained model can be downloaded from https://huggingface.co/marcoyang/icefall-audio-tagging-audioset-zipformer-M-weighted-sampler
 
 
 #### small-scaled model, number of model parameters: 22125218, i.e., 22.13 M

--- a/egs/audioset/AT/local/compute_weight.py
+++ b/egs/audioset/AT/local/compute_weight.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+# Copyright    2023  Xiaomi Corp.        (authors: Xiaoyu Yang)
+#
+# See ../../../../LICENSE for clarification regarding multiple authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This file generates the manifest and computes the fbank features for AudioSet
+dataset. The generated manifests and features are stored in data/fbank.
+"""
+
+import argparse
+
+import lhotse
+from lhotse import load_manifest
+
+def get_parser():
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+
+    parser.add_argument(
+        "--input-manifest",
+        type=str,
+        default="data/fbank/cuts_audioset_full.jsonl.gz"
+    )
+
+    parser.add_argument(
+        "--output",
+        type=str,
+        required=True,
+
+    )
+    return parser
+
+def main():
+    # Reference: https://github.com/YuanGongND/ast/blob/master/egs/audioset/gen_weight_file.py
+    parser = get_parser()
+    args = parser.parse_args()
+
+    cuts = load_manifest(args.input_manifest)
+
+    print(f"A total of {len(cuts)} cuts.")
+
+    label_count = [0] * 527 # a total of 527 classes
+    for c in cuts:
+        audio_event = c.supervisions[0].audio_event
+        labels = list(map(int, audio_event.split(";")))
+        for label in labels:
+            label_count[label] += 1
+
+    with open(args.output, "w") as f:
+        for c in cuts:
+            audio_event = c.supervisions[0].audio_event
+            labels = list(map(int, audio_event.split(";")))
+            weight = 0
+            for label in labels:
+                weight += 1000 / (label_count[label] + 0.01)
+            f.write(f"{c.id} {weight}\n")
+            
+if __name__ == "__main__":
+    main()

--- a/egs/audioset/AT/local/compute_weight.py
+++ b/egs/audioset/AT/local/compute_weight.py
@@ -25,24 +25,23 @@ import argparse
 import lhotse
 from lhotse import load_manifest
 
+
 def get_parser():
     parser = argparse.ArgumentParser(
         formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
 
     parser.add_argument(
-        "--input-manifest",
-        type=str,
-        default="data/fbank/cuts_audioset_full.jsonl.gz"
+        "--input-manifest", type=str, default="data/fbank/cuts_audioset_full.jsonl.gz"
     )
 
     parser.add_argument(
         "--output",
         type=str,
         required=True,
-
     )
     return parser
+
 
 def main():
     # Reference: https://github.com/YuanGongND/ast/blob/master/egs/audioset/gen_weight_file.py
@@ -53,7 +52,7 @@ def main():
 
     print(f"A total of {len(cuts)} cuts.")
 
-    label_count = [0] * 527 # a total of 527 classes
+    label_count = [0] * 527  # a total of 527 classes
     for c in cuts:
         audio_event = c.supervisions[0].audio_event
         labels = list(map(int, audio_event.split(";")))
@@ -68,6 +67,7 @@ def main():
             for label in labels:
                 weight += 1000 / (label_count[label] + 0.01)
             f.write(f"{c.id} {weight}\n")
-            
+
+
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Weighted sampler is known to improve the mAP of models trained on AudioSet. This PR adds support training Zipformer audio tagging model with weighted sampler. The mAP comparison is below:

| weighted sampler | mAP | Full Audioset iterations| 
| -------------------- | ----- | ------------------- | 
| No | 45.1 |  ~30 round |
| Yes | 46.6 |  ~10 round |

With weighted sampler, we achieve faster and better convergence. The pre-trained model can be downloaded here: https://huggingface.co/marcoyang/icefall-audio-tagging-audioset-zipformer-M-weighted-sampler