### PR TITLE
Fix exporting streaming zipformer models to onnx

### DIFF
--- a/egs/librispeech/ASR/zipformer/export-onnx-streaming.py
+++ b/egs/librispeech/ASR/zipformer/export-onnx-streaming.py
@@ -74,7 +74,6 @@ import onnx
 import torch
 import torch.nn as nn
 from decoder import Decoder
-from onnxconverter_common import float16
 from onnxruntime.quantization import QuantType, quantize_dynamic
 from scaling_converter import convert_scaled_to_non_scaled
 from train import add_model_arguments, get_model, get_params
@@ -756,6 +755,7 @@ def main():
     logging.info(f"Exported joiner to {joiner_filename}")
 
     if(params.fp16) :
+        from onnxconverter_common import float16
         logging.info("Generate fp16 models")
 
         encoder = onnx.load(encoder_filename)


### PR DESCRIPTION
It is to fix the following warning messages when fixing the batch size of the kws model to 1:
```
2024-09-11 14:57:33.363528468 [W:onnxruntime:, graph.cc:108 MergeShapeInfo] Error merging shape info for output. '/downsample/Concat_1_output_0' source:{17,1,128} target:{16,1,128}. Falling back to lenient merge.
2024-09-11 14:57:33.363944876 [W:onnxruntime:, graph.cc:108 MergeShapeInfo] Error merging shape info for output. '/downsample_1/Concat_1_output_0' source:{17,1,128} target:{16,1,128}. Falling back to lenient merge.
2024-09-11 14:57:33.364352529 [W:onnxruntime:, graph.cc:108 MergeShapeInfo] Error merging shape info for output. '/downsample_2/Concat_1_output_0' source:{17,1,128} target:{16,1,128}. Falling back to lenient merge.
2024-09-11 14:57:33.364754380 [W:onnxruntime:, graph.cc:108 MergeShapeInfo] Error merging shape info for output. '/downsample_3/Concat_1_output_0' source:{17,1,128} target:{16,1,128}. Falling back to lenient merge.
2024-09-11 14:57:33.365155584 [W:onnxruntime:, graph.cc:108 MergeShapeInfo] Error merging shape info for output. '/downsample_4/Concat_1_output_0' source:{17,1,128} target:{16,1,128}. Falling back to lenient merge.
2024-09-11 14:57:33.365553111 [W:onnxruntime:, graph.cc:108 MergeShapeInfo] Error merging shape info for output. '/downsample_output/Concat_1_output_0' source:{17,1,128} target:{16,1,128}. Falling back to lenient merge.
```

With this fix, you can re-export the kws model to onnx as follows:
```bash
cd egs/wenetspeech/KWS
wget https://github.com/pkufool/keyword-spotting-models/releases/download/v0.11/icefall-kws-zipformer-wenetspeech-20240219.tar.gz
tar xvf icefall-kws-zipformer-wenetspeech-20240219.tar.gz

pushed icefall-kws-zipformer-wenetspeech-20240219/exp
ln -s pretrained.pt epoch-99.pt
popd

./zipformer/export-onnx-streaming.py \
  --tokens ./icefall-kws-zipformer-wenetspeech-20240219/data/lang_partial_tone/tokens.txt \
  --exp-dir ./icefall-kws-zipformer-wenetspeech-20240219/exp \
  --epoch 99 \
  --avg 1 \
  --use-averaged-model 0 \
  \
  --num-encoder-layers "1,1,1,1,1,1" \
  --downsampling-factor "1,2,4,8,4,2" \
  --feedforward-dim "192,192,192,192,192,192" \
  --num-heads "4,4,4,8,4,4" \
  --encoder-dim "128,128,128,128,128,128" \
  --query-head-dim 32 \
  --value-head-dim 12 \
  --pos-head-dim 4 \
  --pos-dim 48 \
  --encoder-unmasked-dim "128,128,128,128,128,128" \
  --cnn-module-kernel "31,31,15,15,15,31" \
  --decoder-dim 320 \
  --joiner-dim 320 \
  --causal True \
  --chunk-size 16 \
  --left-context-frames 64

cd icefall-kws-zipformer-wenetspeech-20240219/exp

python3 -m onnxruntime.tools.make_dynamic_shape_fixed --dim_param N --dim_value 1 ./encoder-epoch-99-avg-1-chunk-16-left-64.onnx tmp.fixed.onnx

python3 -m onnxruntime.quantization.preprocess --input ./tmp.fixed.onnx --output tmp.fixed.pre.onnx

# The original warning messages should disappear
```