### PR TITLE
fixed `prepare.sh` for the commonvoice recipe

### DIFF
--- a/egs/commonvoice/ASR/prepare.sh
+++ b/egs/commonvoice/ASR/prepare.sh
@@ -339,7 +339,7 @@ if [ $stage -le 9 ] && [ $stop_stage -ge 9 ]; then
         # 2. chmod +x ./jq
         # 3. cp jq /usr/bin
         gunzip -c ${file} \
-          | jq '.text' | sed 's/"//g' > $lang_dir/transcript_words.txt
+          | jq '.supervisions[].text' | sed 's/"//g' > $lang_dir/transcript_words.txt
 
         # Ensure space only appears once
         sed -i 's/\t/ /g' $lang_dir/transcript_words.txt


### PR DESCRIPTION
Details can be found at:

> There is a bug in CommonVoice(EN) recipe（prepare.sh: line 342 ）：**"text"** is in **"supervisions"**, so it should be extracted by using **jq '.supervisions[].text'** ![image](https://private-user-images.githubusercontent.com/8839139/374822152-79a319b5-bdbc-4256-8f6d-fbfd225afdb8.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3Mjg0NTQxMTksIm5iZiI6MTcyODQ1MzgxOSwicGF0aCI6Ii84ODM5MTM5LzM3NDgyMjE1Mi03OWEzMTliNS1iZGJjLTQyNTYtOGY2ZC1mYmZkMjI1YWZkYjgucG5nP1gtQW16LUFsZ29yaXRobT1BV1M0LUhNQUMtU0hBMjU2JlgtQW16LUNyZWRlbnRpYWw9QUtJQVZDT0RZTFNBNTNQUUs0WkElMkYyMDI0MTAwOSUyRnVzLWVhc3QtMSUyRnMzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyNDEwMDlUMDYwMzM5WiZYLUFtei1FeHBpcmVzPTMwMCZYLUFtei1TaWduYXR1cmU9MjUyZmFhMmEyMDc5YmMxNDJlM2VmNTlmYzA5MWVmOTJkZDA5NDgzMWNkMGFjNWJmZWRmNDY0YTE4MzBmNmU1MyZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QifQ.OECFryEppSIRF1MmroFJqgdPhTQot-5Q8GpL1oAMROo)
