### PR TITLE
Avoid using lr from checkpoint.

### DIFF
--- a/egs/librispeech/ASR/zipformer/optim.py
+++ b/egs/librispeech/ASR/zipformer/optim.py
@@ -787,7 +787,7 @@ class LRScheduler(object):
         is not the optimizer.
         """
         return {
-             # the use might try to override the base_lr, so don't include this in the state.
+             # the user might try to override the base_lr, so don't include this in the state.
              # previously they were included.
              # "base_lrs": self.base_lrs,
             "epoch": self.epoch,

--- a/egs/librispeech/ASR/zipformer/optim.py
+++ b/egs/librispeech/ASR/zipformer/optim.py
@@ -787,7 +787,9 @@ class LRScheduler(object):
         is not the optimizer.
         """
         return {
-            "base_lrs": self.base_lrs,
+             # the use might try to override the base_lr, so don't include this in the state.
+             # previously they were included.
+             # "base_lrs": self.base_lrs,
             "epoch": self.epoch,
             "batch": self.batch,
         }
@@ -799,7 +801,12 @@ class LRScheduler(object):
             state_dict (dict): scheduler state. Should be an object returned
                 from a call to :meth:`state_dict`.
         """
+        # the things with base_lrs are a work-around for a previous problem
+        # where base_lrs were written with the state dict.
+        base_lrs = self.base_lrs
         self.__dict__.update(state_dict)
+        self.base_lrs = base_lrs
+
 
     def get_last_lr(self) -> List[float]:
         """Return last computed learning rate by current scheduler.  Will be a list of float."""


### PR DESCRIPTION
Changes from Dan:
> Guys, I was just running an Icefall training script where I tried to change the learning rate after training it for some time, and it used the original learning rate because it loaded the original scheduler state.  The following would fix it.