### PR TITLE
minor fixes to the matcha recipe

### DIFF
--- a/egs/ljspeech/TTS/matcha/train.py
+++ b/egs/ljspeech/TTS/matcha/train.py
@@ -488,9 +488,10 @@ def train_one_epoch(
 
                 loss = sum(losses.values())
 
-                optimizer.zero_grad()
                 scaler.scale(loss).backward()
                 scaler.step(optimizer)
+                scaler.update()
+                optimizer.zero_grad()
 
                 loss_info = MetricsTracker()
                 loss_info["samples"] = batch_size


### PR DESCRIPTION
```
2024-12-09 16:21:17,256 INFO [train.py:572] Maximum memory allocated so far is 1979MB
2024-12-09 16:21:17,398 INFO [checkpoint.py:75] Saving checkpoint to matcha/exp-new-3/bad-model-0.pt
Traceback (most recent call last):
  File "/home/qt06/icefall/egs/ljspeech/TTS/./matcha/train.py", line 723, in <module>
    main()
  File "/home/qt06/icefall/egs/ljspeech/TTS/./matcha/train.py", line 717, in main
    run(rank=0, world_size=1, args=args)
  File "/home/qt06/icefall/egs/ljspeech/TTS/./matcha/train.py", line 668, in run
    train_one_epoch(
  File "/home/qt06/icefall/egs/ljspeech/TTS/./matcha/train.py", line 498, in train_one_epoch
    scaler.step(optimizer)
  File "/home/qt06/icefall/.venv/lib/python3.12/site-packages/torch/amp/grad_scaler.py", line 392, in step
    raise RuntimeError(
RuntimeError: step() has already been called since the last update().
```