### PR TITLE
potential fix to k2SSL hubert_ce encoder forward function

### DIFF
--- a/egs/librispeech/SSL/zipformer/hubert_ce.py
+++ b/egs/librispeech/SSL/zipformer/hubert_ce.py
@@ -429,7 +429,7 @@ class HubertModel(nn.Module):
         # padding_mask: (B, T), bool
         # mask_indices: (B, T), bool
         x = x.transpose(0, 1)
-        x, x_lens = self.encoder(x, (~padding_mask).sum(dim=-1))
+        x, x_lens = self.encoder(x, (~padding_mask).sum(dim=-1) if padding_mask else None)
         x = x.transpose(0, 1)
 
         if features_only:


### PR DESCRIPTION
Issue Description:
When I want to dump features at the middle layer of encoder, i.e. zipformer, I will call [extract_features](https://github.com/k2-fsa/icefall/blob/master/egs/librispeech/SSL/zipformer/hubert_ce.py#L471) like fairseq [dump_hubert_feature](https://github.com/facebookresearch/fairseq/blob/main/examples/hubert/simple_kmeans/dump_hubert_feature.py#L62) . However, current encoder forward calling does not support None padding_mask.

Fix:
Handle None padding_mask when invoking encoder forward calling