### PR TITLE
Fix bug: When resuming training from a checkpoint, model_avg was not assigned, resulting in a None error.

### DIFF
--- a/egs/wenetspeech/KWS/zipformer/finetune.py
+++ b/egs/wenetspeech/KWS/zipformer/finetune.py
@@ -593,6 +593,9 @@ def run(rank, world_size, args):
 
     if params.continue_finetune:
         assert params.start_epoch > 0, params.start_epoch
+        if rank == 0:
+            # model_avg is only used with rank 0
+            model_avg = copy.deepcopy(model).to(torch.float64)
         checkpoints = load_checkpoint_if_available(
             params=params, model=model, model_avg=model_avg
         )


### PR DESCRIPTION
Considering moving the entire if rank == 0 code block outside could cause issues because:

1. If moved above, when continue_finetune is false, the model in copy.deepcopy(model) has not yet called model.load_state_dict().

2. If moved below, when continue_finetune is true, model_avg would come from copy.deepcopy(model) rather than the model_avg saved in the checkpoint.