### PR TITLE
fix bug: undefined name 'partial'

### DIFF
--- a/egs/wenetspeech/KWS/zipformer/finetune.py
+++ b/egs/wenetspeech/KWS/zipformer/finetune.py
@@ -69,6 +69,7 @@ import argparse
 import copy
 import logging
 import warnings
+from functools import partial
 from pathlib import Path
 from typing import List, Optional, Tuple, Union
 


### PR DESCRIPTION
```python
./egs/wenetspeech/KWS/zipformer/finetune.py:664:20: F821 undefined name 'partial'
    _encode_text = partial(encode_text, token_table=token_table, params=params)
                   ^
1     F821 undefined name 'partial'
```