### PR TITLE
Support multiple parallel augmentations.

### DIFF
--- a/icefall/speech_recognition_dataset.py
+++ b/icefall/speech_recognition_dataset.py
@@ -1,0 +1,145 @@
+from typing import Callable, List
+
+import torch
+from lhotse import validate
+from lhotse.cut import Cut, CutSet
+from lhotse.dataset.input_strategies import BatchIO, PrecomputedFeatures
+from lhotse.utils import ifnone
+from lhotse.workarounds import Hdf5MemoryIssueFix
+from torch.utils.data.dataloader import default_collate
+
+
+class ConsistencyRegularizationSpeechRecognitionDataset(torch.utils.data.Dataset):
+    def __init__(
+        self,
+        return_cuts: bool = False,
+        cut_transforms: List[Callable[[Cut], Cut]] = None,
+        input_strategy: BatchIO = PrecomputedFeatures(),
+    ):
+        super().__init__()
+        self.return_cuts = return_cuts
+        self.cut_transforms = ifnone(cut_transforms, [])
+        self.input_strategy = input_strategy
+
+        # This attribute is a workaround to constantly growing HDF5 memory
+        # throughout the epoch. It regularly closes open file handles to
+        # reset the internal HDF5 caches.
+        self.hdf5_fix = Hdf5MemoryIssueFix(reset_interval=100)
+
+    def __getitem__(self, cuts: CutSet) -> dict:
+        """
+        Return a dict
+
+        .. code-block::
+
+            {
+                'inputs': float tensor with shape determined by :attr:`input_strategy`:
+                          - single-channel:
+                            - features: (B, T, F)
+                            - audio: (B, T)
+                          - multi-channel: currently not supported
+                'supervisions': [
+                    'sequence_idx': Tensor[int] of shape (S,)
+                    'text': List[str] of len S
+
+                    # For feature input strategies
+                    'start_frame': Tensor[int] of shape (S,)
+                    'num_frames': Tensor[int] of shape (S,)
+
+                    # For audio input strategies
+                    'start_sample': Tensor[int] of shape (S,)
+                    'num_samples': Tensor[int] of shape (S,)
+
+                    # Optionally, when return_cuts=True
+                    'cut': List[AnyCut] of len S
+
+                ],
+                'aug': [
+                  # it contains augmented cut info
+                  {'inputs': xxx, 'supervisions': [xxx]},
+                  {'inputs': xxx, 'supervisions': [xxx]},
+                  {'inputs': xxx, 'supervisions': [xxx]},
+
+                  # where xxx means it contains similar info as the non-augmented version
+
+                  # aug[i] corresponds to self.cut_transforms[i]
+                ]
+            }
+        """
+        validate_for_asr(cuts)
+        self.hdf5_fix.update()
+
+        # Sort the cuts by duration so that the first one determines the batch time dimensions.
+        cuts = cuts.sort_by_duration(ascending=False)
+
+        batch = self._process(cuts)
+
+        if self.cut_transforms:
+            batch["aug"] = []
+
+            for i, tf in enumerate(self.cut_transforms):
+                transformed_cuts = cuts.map(tf)
+
+                batch["aug"].append(self._process(transformed_cuts))
+
+        return batch
+
+    def _process(self, cuts: CutSet):
+        # Get a tensor with batched feature matrices, shape (B, T, F)
+        # Collation performs auto-padding, if necessary.
+        input_tpl = self.input_strategy(cuts)
+        if len(input_tpl) == 3:
+            # An input strategy with fault tolerant audio reading mode.
+            # "cuts" may be a subset of the original "cuts" variable,
+            # that only has cuts for which we successfully read the audio.
+            inputs, _, cuts = input_tpl
+        else:
+            inputs, _ = input_tpl
+
+        # Get a dict of tensors that encode the positional information about supervisions
+        # in the batch of feature matrices. The tensors are named "sequence_idx",
+        # "start_frame/sample" and "num_frames/samples".
+        supervision_intervals = self.input_strategy.supervision_intervals(cuts)
+
+        batch = {
+            "inputs": inputs,
+            "supervisions": default_collate(
+                [
+                    {
+                        "text": supervision.text,
+                    }
+                    for sequence_idx, cut in enumerate(cuts)
+                    for supervision in cut.supervisions
+                ]
+            ),
+        }
+
+        # Update the 'supervisions' field with sequence_idx and start/num frames/samples
+        batch["supervisions"].update(supervision_intervals)
+        if self.return_cuts:
+            batch["supervisions"]["cut"] = [
+                cut for cut in cuts for sup in cut.supervisions
+            ]
+
+        return batch
+
+
+def validate_for_asr(cuts: CutSet) -> None:
+    validate(cuts)
+    tol = 2e-3  # 1ms
+    for cut in cuts:
+        for supervision in cut.supervisions:
+            assert supervision.start >= -tol, (
+                f"Supervisions starting before the cut are not supported for ASR"
+                f" (sup id: {supervision.id}, cut id: {cut.id})"
+            )
+
+            # Supervision start time is relative to Cut ...
+            # https://lhotse.readthedocs.io/en/v0.10_e/cuts.html
+            #
+            # 'supervision.end' is end of supervision inside the Cut
+            assert supervision.end <= cut.duration + tol, (
+                f"Supervisions ending after the cut "
+                f"are not supported for ASR"
+                f" (sup id: {supervision.id}, cut id: {cut.id})"
+            )


### PR DESCRIPTION
See also https://github.com/lhotse-speech/lhotse/issues/1477

(I prefer to put it inside icefall. If moving to lhotse is desired, I can do that.)

# Test code
```python3
#!/usr/bin/env python3

from functools import partial

import lhotse
from lhotse import Fbank, FbankConfig
from lhotse.dataset import SimpleCutSampler
from lhotse.dataset.input_strategies import (
    AudioSamples,
    OnTheFlyFeatures,
)
from torch.utils.data.dataloader import DataLoader

from speech_recognition_dataset import ConsistencyRegularizationSpeechRecognitionDataset


def create_cutset():
    recording0 = lhotse.Recording.from_file("./0.wav")
    sup0 = lhotse.SupervisionSegment(
        id="sup0",
        recording_id=recording0.id,
        start=0,
        duration=5,
        text="hello, how are you",
    )
    cut0 = lhotse.MonoCut(
        id="cut0",
        start=0,
        duration=6,
        channel=0,
        recording=recording0,
        supervisions=[sup0],
    )

    recording1 = lhotse.Recording.from_file("./1.wav")
    sup1 = lhotse.SupervisionSegment(
        id="sup1",
        recording_id=recording1.id,
        start=0,
        duration=3,
        text="fine, thank you",
    )
    cut1 = lhotse.MonoCut(
        id="cut1",
        start=0,
        duration=4,
        channel=0,
        recording=recording1,
        supervisions=[sup1],
    )

    return lhotse.CutSet([cut0, cut1])


def main():
    cutset = create_cutset()
    print([c for c in cutset])

    t1 = partial(lhotse.MonoCut.perturb_speed, factor=0.9)
    t2 = partial(lhotse.MonoCut.perturb_volume, factor=1.1)
    t3 = partial(lhotse.MonoCut.perturb_tempo, factor=1.2)
    transforms = [t1, t2, t3]

    train = ConsistencyRegularizationSpeechRecognitionDataset(
        input_strategy=OnTheFlyFeatures(Fbank(FbankConfig(num_mel_bins=80))),
        #  input_strategy=AudioSamples(),
        cut_transforms=transforms,
        #  return_cuts=True,
        return_cuts=False,
    )
    print(train)
    train_sampler = SimpleCutSampler(
        cutset,
        max_duration=20,
        shuffle=False,
    )

    train_dl = DataLoader(
        train,
        sampler=train_sampler,
        batch_size=None,
        num_workers=1,
        persistent_workers=False,
    )
    for b in train_dl:
        print(b["inputs"].shape, b["supervisions"])
        if "aug" in b:
            assert len(b["aug"]) == len(transforms)
            for i, aug in enumerate(b["aug"]):
                print(
                    transforms[i].func.__name__,
                    aug["inputs"].shape,
                    aug["supervisions"],
                )


if __name__ == "__main__":
    main()
```

The output is given below:
```
[MonoCut(id='cut0', start=0, duration=6, channel=0, supervisions=[SupervisionSegment(id='sup0', recording_id='0', start=0, duration=5, channel=0, text='hello, how are you', language=None, speaker=None, gender=None, custom=None, alignment=None)], features=None, recording=Recording(id='0', sources=[AudioSource(type='file', channels=[0], source='0.wav')], sampling_rate=16000, num_samples=106000, duration=6.625, channel_ids=[0], transforms=None), custom=None), MonoCut(id='cut1', start=0, duration=4, channel=0, supervisions=[SupervisionSegment(id='sup1', recording_id='1', start=0, duration=3, channel=0, text='fine, thank you', language=None, speaker=None, gender=None, custom=None, alignment=None)], features=None, recording=Recording(id='1', sources=[AudioSource(type='file', channels=[0], source='1.wav')], sampling_rate=16000, num_samples=81600, duration=5.1, channel_ids=[0], transforms=None), custom=None)]
<speech_recognition_dataset.ConsistencyRegularizationSpeechRecognitionDataset object at 0x119f1c8e0>
torch.Size([2, 600, 80]) {'text': ['hello, how are you', 'fine, thank you'], 'sequence_idx': tensor([0, 1], dtype=torch.int32), 'start_frame': tensor([0, 0], dtype=torch.int32), 'num_frames': tensor([500, 300], dtype=torch.int32)}
perturb_speed torch.Size([2, 667, 80]) {'text': ['hello, how are you', 'fine, thank you'], 'sequence_idx': tensor([0, 1], dtype=torch.int32), 'start_frame': tensor([0, 0], dtype=torch.int32), 'num_frames': tensor([556, 333], dtype=torch.int32)}
perturb_volume torch.Size([2, 600, 80]) {'text': ['hello, how are you', 'fine, thank you'], 'sequence_idx': tensor([0, 1], dtype=torch.int32), 'start_frame': tensor([0, 0], dtype=torch.int32), 'num_frames': tensor([500, 300], dtype=torch.int32)}
perturb_tempo torch.Size([2, 500, 80]) {'text': ['hello, how are you', 'fine, thank you'], 'sequence_idx': tensor([0, 1], dtype=torch.int32), 'start_frame': tensor([0, 0], dtype=torch.int32), 'num_frames': tensor([417, 250], dtype=torch.int32)}
```