### PR TITLE
Fix logging torch.dtype.

### DIFF
--- a/icefall/utils.py
+++ b/icefall/utils.py
@@ -186,7 +186,7 @@ class AttributeDict(dict):
         tmp = {}
         for k, v in self.items():
             # PosixPath is ont JSON serializable
-            if isinstance(v, pathlib.Path) or isinstance(v, torch.device):
+            if isinstance(v, (pathlib.Path, torch.device, torch.dtype)):
                 v = str(v)
             tmp[k] = v
         return json.dumps(tmp, indent=indent, sort_keys=True)


### PR DESCRIPTION
This PR fixes the following log messages:

![659311747655353_ pic](https://github.com/user-attachments/assets/c3b54958-ea76-4fd8-aca3-983d7900b59b)
