### PR TITLE
Fix a bug in finetune.py --use-mux

### DIFF
--- a/egs/librispeech/ASR/zipformer/finetune.py
+++ b/egs/librispeech/ASR/zipformer/finetune.py
@@ -140,8 +140,8 @@ def add_finetune_arguments(parser: argparse.ArgumentParser):
         type=str2bool,
         default=False,
         help="""
-        Whether to adapt. If true, we will mix 5% of the new data
-        with 95% of the original data to fine-tune. This is useful
+        Whether to adapt. If true, we will mix 5%% of the new data
+        with 95%% of the original data to fine-tune. This is useful
         if you want to maintain the performance on the original domain
         """,
     )
@@ -1134,7 +1134,7 @@ def train_one_epoch(
                 f"Epoch {params.cur_epoch}, "
                 f"batch {batch_idx}, loss[{loss_info}], "
                 f"tot_loss[{tot_loss}], batch size: {batch_size}, "
-                f"lr: {cur_lr:.2e}, "
+                f"lr: {cur_lr: .2e}, "
                 + (f"grad_scale: {scaler._scale.item()}" if params.use_fp16 else "")
             )
 


### PR DESCRIPTION
Fixed a bug in finetune.py related to --use-mux. The original value was 95%, which caused an issue when running finetune --help. By changing it to 95%%, the bug is resolved.