### PR TITLE
Adding Common Voice Preprocessing for Farsi

### DIFF
--- a/egs/commonvoice/ASR/local/preprocess_commonvoice.py
+++ b/egs/commonvoice/ASR/local/preprocess_commonvoice.py
@@ -52,6 +52,11 @@ def normalize_text(utt: str, language: str) -> str:
         return re.sub(r"[^A-ZÀÂÆÇÉÈÊËÎÏÔŒÙÛÜ' ]", "", utt).upper()
     elif language == "pl":
         return re.sub(r"[^a-ząćęłńóśźżA-ZĄĆĘŁŃÓŚŹŻ' ]", "", utt).upper()
+    elif language == "fa":
+        utt = utt.replace("ي", "ی").replace("ك", "ک")
+        utt = re.sub(r"[^\u0600-\u06FF0-9\u06F0-\u06F9\s]|[.,?!\-]", "", utt)
+        utt = re.sub(r"\s+", " ", utt).strip()
+        return utt
     elif language in ["yue", "zh-HK"]:
         # Mozilla Common Voice uses both "yue" and "zh-HK" for Cantonese
         # Not sure why they decided to do this...

--- a/egs/commonvoice/ASR/prepare.sh
+++ b/egs/commonvoice/ASR/prepare.sh
@@ -42,7 +42,7 @@ use_invalidated=false
 #     - speech
 
 dl_dir=$PWD/download
-release=cv-corpus-12.0-2022-12-07
+release=cv-corpus-12.0-2022-12-07 ## -> consider changing relaese name or download the file manually and move it to download folder.
 lang=fr
 perturb_speed=false
 


### PR DESCRIPTION
This pull request introduces a new normalization rule for Persian text in the `normalize_text` function and adds a comment in the `prepare.sh` script regarding the release file handling. Below is a breakdown of the most important changes:

### Text Normalization Enhancements:
* [`egs/commonvoice/ASR/local/preprocess_commonvoice.py`](diffhunk://#diff-b7e83dccc16dde658cbddd1d979fcbd8e055232bdceda59d36b350d33d661a44R55-R59): Added a new normalization rule for Persian (`fa`) text. This includes replacing Arabic characters with their Persian equivalents, removing unwanted characters, collapsing multiple spaces into one, and stripping leading/trailing spaces.

### Script Comments Update:
* [`egs/commonvoice/ASR/prepare.sh`](diffhunk://#diff-10fe2b0f123f9456c604f9173c866096ac048251999b4684320f72ffa1cd44dfL45-R45): Added a comment suggesting either changing the release name or manually downloading and moving the file to the `download` folder for better clarity and handling.