### PR TITLE
Fix gigaspeech dataset iterator.

### DIFF
--- a/egs/librispeech/ASR/pruned_transducer_stateless7_streaming_multi/train.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless7_streaming_multi/train.py
@@ -50,7 +50,7 @@ import random
 import warnings
 from pathlib import Path
 from shutil import copyfile
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import Any, Dict, Iterator, Optional, Tuple, Union
 
 import k2
 import optim
@@ -798,7 +798,7 @@ def train_one_epoch(
     scheduler: LRSchedulerType,
     sp: spm.SentencePieceProcessor,
     train_dl: torch.utils.data.DataLoader,
-    giga_train_dl: torch.utils.data.DataLoader,
+    iter_giga: Iterator,
     valid_dl: torch.utils.data.DataLoader,
     rng: random.Random,
     scaler: "GradScaler",
@@ -849,7 +849,6 @@ def train_one_epoch(
     # This sets the probabilities for choosing which datasets
     dl_weights = [1 - params.giga_prob, params.giga_prob]
     iter_libri = iter(train_dl)
-    iter_giga = iter(giga_train_dl)
 
     batch_idx = 0
 
@@ -1223,6 +1222,7 @@ def run(rank, world_size, args):
     #         sp=sp,
     #         params=params,
     #     )
+    iter_giga = iter(giga_train_dl)
 
     scaler = create_grad_scaler(enabled=params.use_fp16, init_scale=1.0)
     if checkpoints and "grad_scaler" in checkpoints:
@@ -1247,7 +1247,7 @@ def run(rank, world_size, args):
             scheduler=scheduler,
             sp=sp,
             train_dl=train_dl,
-            giga_train_dl=giga_train_dl,
+            iter_giga=iter_giga,
             valid_dl=valid_dl,
             rng=rng,
             scaler=scaler,

--- a/egs/librispeech/ASR/pruned_transducer_stateless8/train.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless8/train.py
@@ -55,7 +55,7 @@ import random
 import warnings
 from pathlib import Path
 from shutil import copyfile
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import Any, Dict, Iterator, Optional, Tuple, Union
 
 import k2
 import optim
@@ -793,7 +793,7 @@ def train_one_epoch(
     scheduler: LRSchedulerType,
     sp: spm.SentencePieceProcessor,
     train_dl: torch.utils.data.DataLoader,
-    giga_train_dl: torch.utils.data.DataLoader,
+    iter_giga: Iterator,
     valid_dl: torch.utils.data.DataLoader,
     rng: random.Random,
     scaler: "GradScaler",
@@ -849,7 +849,6 @@ def train_one_epoch(
     dl_weights = [1 - params.giga_prob, params.giga_prob]
 
     iter_libri = iter(train_dl)
-    iter_giga = iter(giga_train_dl)
 
     batch_idx = 0
 
@@ -1225,6 +1224,8 @@ def run(rank, world_size, args):
             params=params,
         )
 
+    iter_giga = iter(giga_train_dl)
+
     scaler = create_grad_scaler(enabled=params.use_fp16, init_scale=1.0)
     if checkpoints and "grad_scaler" in checkpoints:
         logging.info("Loading grad scaler state dict")
@@ -1248,7 +1249,7 @@ def run(rank, world_size, args):
             scheduler=scheduler,
             sp=sp,
             train_dl=train_dl,
-            giga_train_dl=giga_train_dl,
+            iter_giga=iter_giga,
             valid_dl=valid_dl,
             rng=rng,
             scaler=scaler,


### PR DESCRIPTION
Previously, it was reset after every epoch, which may cause it to always use the first part of the gigaspeech dataset if you choose a small --giga-prob.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored internal training data handling across multiple ASR training scripts to improve data pipeline management. These changes optimize how training data is processed during model training without affecting the end-user experience or model behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->