### PR TITLE
Fix  corpus_dir in timit prep.

### DIFF
--- a/egs/timit/ASR/prepare.sh
+++ b/egs/timit/ASR/prepare.sh
@@ -91,7 +91,7 @@ if [ $stage -le 1 ] && [ $stop_stage -ge 1 ]; then
   # We assume that you have downloaded the timit corpus
   # to $dl_dir/timit
   mkdir -p data/manifests
-  lhotse prepare timit -p $num_phones -j $nj $dl_dir/timit/data data/manifests
+  lhotse prepare timit -p $num_phones -j $nj $dl_dir/timit data/manifests
 fi
 
 if [ $stage -le 2 ] && [ $stop_stage -ge 2 ]; then


### PR DESCRIPTION
Lhotse prep. for Timit expects corpus_dir to be "$dl_dir/timit" instead of "$dl_dir/timit/data"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated TIMIT dataset preparation path configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->