### PR TITLE
fixed sampling rate issue on compute_fbank_librispeech.py

### DIFF
--- a/egs/librispeech/ASR/local/compute_fbank_librispeech.py
+++ b/egs/librispeech/ASR/local/compute_fbank_librispeech.py
@@ -129,6 +129,10 @@ def compute_fbank_librispeech(
                 recordings=m["recordings"],
                 supervisions=m["supervisions"],
             )
+            
+            # Resample audio to 16kHz to match Fbank extractor's expected sampling rate
+            logging.info(f"Resampling audio to 16000 Hz")
+            cut_set = cut_set.resample(16000)
 
             if "train" in partition:
                 if bpe_model:


### PR DESCRIPTION
Fixed sampling rate convertion to 16000 HZ on librispeech fbank computing to match fbank extractors expected sampling rate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio data preprocessing by ensuring proper sampling rate standardization (16000 Hz) during the initial data preparation stage, enhancing downstream feature extraction and model training reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->