### PR TITLE
add linear warmup for cr-ctc loss

### DIFF
--- a/egs/aishell/ASR/zipformer/train.py
+++ b/egs/aishell/ASR/zipformer/train.py
@@ -882,8 +882,10 @@ def compute_loss(
         if params.use_ctc:
             loss += params.ctc_loss_scale * ctc_loss
             if use_cr_ctc:
-                loss += params.cr_loss_scale * cr_loss
-    
+                # linear warmup
+                cr_loss_scale = min(batch_idx_train / warm_step, 1.0) * params.cr_loss_scale
+                loss += cr_loss_scale * cr_loss
+
     assert loss.requires_grad == is_training
 
     info = MetricsTracker()

--- a/egs/librispeech/ASR/zipformer/train.py
+++ b/egs/librispeech/ASR/zipformer/train.py
@@ -967,7 +967,9 @@ def compute_loss(
         if params.use_ctc:
             loss += params.ctc_loss_scale * ctc_loss
             if use_cr_ctc:
-                loss += params.cr_loss_scale * cr_loss
+                # linear warmup
+                cr_loss_scale = min(batch_idx_train / warm_step, 1.0) * params.cr_loss_scale
+                loss += cr_loss_scale * cr_loss
 
         if params.use_attention_decoder:
             loss += params.attention_decoder_loss_scale * attention_decoder_loss


### PR DESCRIPTION
- this prevents cr-ctc loss from diverging at the beginning of the training

<img width="1093" height="483" alt="crctc_warmup" src="https://github.com/user-attachments/assets/62904081-6664-40c4-ac35-be05ab77235f" />


Sometimes, the training was diverging with message:
`"If you see this error, it means that the gradient scale is too small."`

Investigation revealed that the cr-ctc loss can spike to high values at the beginning of the training (<1000 steps).
The influence of the cr-ctc loss should be diminished at the beginning of the training, when the ctc loss has
not learned the task yet.

Three variants were explored:
- original implementation
- linear warmup (0.0 .. 1.0) over initial 2k steps
- disabling cr-ctc for initial 2k steps

According to the `train/tot_cr_loss` curve the the linear warmup looks the best.

Best regards,
Karel from BUT