### PR TITLE
CommonVoice FR - Preprocessing stripped every lowercase character in the model

### DIFF
--- a/egs/commonvoice/ASR/local/preprocess_commonvoice.py
+++ b/egs/commonvoice/ASR/local/preprocess_commonvoice.py
@@ -49,7 +49,8 @@ def normalize_text(utt: str, language: str) -> str:
     if language == "en":
         return re.sub(r"[^a-zA-Z\s]", "", utt).upper()
     elif language == "fr":
-        return re.sub(r"[^A-ZÀÂÆÇÉÈÊËÎÏÔŒÙÛÜ' ]", "", utt).upper()
+        utt = utt.upper()
+        return re.sub(r"[^A-ZÀÂÆÇÉÈÊËÎÏÔŒÙÛÜ' ]", "", utt)
     elif language == "pl":
         return re.sub(r"[^a-ząćęłńóśźżA-ZĄĆĘŁŃÓŚŹŻ' ]", "", utt).upper()
     elif language in ["yue", "zh-HK"]:
@@ -139,7 +140,7 @@ def preprocess_commonvoice(
         if partition == "validated":
             logging.warning(
                 """
-                The 'validated' partition contains the data of both 'train', 'dev' 
+                The 'validated' partition contains the data of both 'train', 'dev'
                 and 'test' partitions. We filter out the 'dev' and 'test' partition
                 here.
                 """


### PR DESCRIPTION
### Description
While preparing and training a French ASR model using the Common Voice dataset, I noticed that the normalized text transcripts were almost completely blank or heavily truncated (e.g., only keeping the leading uppercase letters, spaces, and apostrophes).

After investigation, I found a logical bug in the `normalize_text` function for French: the regex filters out all characters that are not uppercase *before* the `.upper()` method is applied. As a result, all lowercase letters (which represent ~95% of the text in Common Voice) are silently deleted.

For example, `"L'éléphant"` is currently reduced to `"L'"` because the lowercase letters are stripped before they have a chance to be capitalized.

### Solution
This PR fixes the execution order in the `fr` block: the utterance is now converted to uppercase **before** running the regex filter. 

```python
elif language == "fr":
    utt = utt.upper()
    return re.sub(r"[^A-ZÀÂÆÇÉÈÊËÎÏÔŒÙÛÜ' ]", "", utt)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated warning message for the validated partition to clearly communicate that it includes both training and development data subsets.

* **Refactor**
  * Streamlined text normalization workflow for English language data preprocessing by reorganizing character filtering and text normalization operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->