### PR TITLE
Allow Streaming Zipformer Models to Be Exported as Non-Streaming Models

### DIFF
--- a/egs/librispeech/ASR/zipformer/export-onnx-ctc.py
+++ b/egs/librispeech/ASR/zipformer/export-onnx-ctc.py
@@ -231,7 +231,7 @@ class OnnxModel(nn.Module):
             - log_probs_len, a 1-D int64 tensor of shape (N,)
         """
         x, x_lens = self.encoder_embed(x, x_lens)
-        src_key_padding_mask = make_pad_mask(x_lens)
+        src_key_padding_mask = make_pad_mask(x_lens).to(torch.int32)
         x = x.permute(1, 0, 2)
         encoder_out, log_probs_len = self.encoder(x, x_lens, src_key_padding_mask)
         encoder_out = encoder_out.permute(1, 0, 2)

--- a/egs/librispeech/ASR/zipformer/export-onnx-streaming-ctc.py
+++ b/egs/librispeech/ASR/zipformer/export-onnx-streaming-ctc.py
@@ -273,7 +273,7 @@ class OnnxModel(nn.Module):
         )
         assert x.size(1) == self.chunk_size, (x.size(1), self.chunk_size)
 
-        src_key_padding_mask = torch.zeros(N, self.chunk_size, dtype=torch.bool)
+        src_key_padding_mask = torch.zeros(N, self.chunk_size, dtype=torch.int32)
 
         # processed_mask is used to mask out initial states
         processed_mask = torch.arange(left_context_len, device=x.device).expand(
@@ -281,7 +281,7 @@ class OnnxModel(nn.Module):
         )
         processed_lens = states[-1]  # (batch,)
         # (batch, left_context_size)
-        processed_mask = (processed_lens.unsqueeze(1) <= processed_mask).flip(1)
+        processed_mask = (processed_lens.unsqueeze(1) <= processed_mask).to(torch.int32).flip(1)
         # Update processed lengths
         new_processed_lens = processed_lens + x_lens
         # (batch, left_context_size + chunk_size)
@@ -641,11 +641,13 @@ def main():
     )
     logging.info(f"Exported model to {model_filename}")
 
-    if params.enable_int8_quantization:
-        # Generate int8 quantization models
-        # See https://onnxruntime.ai/docs/performance/model-optimizations/quantization.html#data-type-selection
+    if not params.enable_int8_quantization:
+        return
 
-        logging.info("Generate int8 quantization models")
+    # Generate int8 quantization models
+    # See https://onnxruntime.ai/docs/performance/model-optimizations/quantization.html#data-type-selection
+
+    logging.info("Generate int8 quantization models")
 
     if params.use_external_data:
         model_filename_int8 = f"ctc-{suffix}.int8.onnx"

--- a/egs/librispeech/ASR/zipformer/export-onnx-streaming.py
+++ b/egs/librispeech/ASR/zipformer/export-onnx-streaming.py
@@ -844,7 +844,6 @@ def main():
         use_external_data=params.use_external_data,
     )
     logging.info(f"Exported encoder to {encoder_filename}")
-    return
 
     logging.info("Exporting decoder")
     decoder_filename = params.exp_dir / f"decoder-{suffix}.onnx"

--- a/egs/librispeech/ASR/zipformer/export-onnx-streaming.py
+++ b/egs/librispeech/ASR/zipformer/export-onnx-streaming.py
@@ -301,9 +301,9 @@ class OnnxEncoder(nn.Module):
         )
         processed_lens = states[-1]  # (batch,)
         # (batch, left_context_size)
-        processed_mask = (processed_lens.unsqueeze(1) <= processed_mask).to(
-            torch.int32
-        ).flip(1)
+        processed_mask = (
+            (processed_lens.unsqueeze(1) <= processed_mask).to(torch.int32).flip(1)
+        )
         # Update processed lengths
         new_processed_lens = processed_lens + x_lens
         # (batch, left_context_size + chunk_size)
@@ -856,7 +856,6 @@ def main():
         use_int32_inputs=params.use_int32_inputs,
     )
     logging.info(f"Exported decoder to {decoder_filename}")
-    return
 
     logging.info("Exporting joiner")
     joiner_filename = params.exp_dir / f"joiner-{suffix}.onnx"

--- a/egs/librispeech/ASR/zipformer/export-onnx-streaming.py
+++ b/egs/librispeech/ASR/zipformer/export-onnx-streaming.py
@@ -108,6 +108,14 @@ def get_parser():
     )
 
     parser.add_argument(
+        "--use-int32-inputs",
+        type=int,
+        default=0,
+        help="""1 to use int32_t as input types if applicable. 0 to use
+        int64_t otherwise.""",
+    )
+
+    parser.add_argument(
         "--epoch",
         type=int,
         default=28,
@@ -285,7 +293,7 @@ class OnnxEncoder(nn.Module):
         )
         assert x.size(1) == self.chunk_size, (x.size(1), self.chunk_size)
 
-        src_key_padding_mask = torch.zeros(N, self.chunk_size, dtype=torch.bool)
+        src_key_padding_mask = torch.zeros(N, self.chunk_size, dtype=torch.int32)
 
         # processed_mask is used to mask out initial states
         processed_mask = torch.arange(left_context_len, device=x.device).expand(
@@ -293,7 +301,9 @@ class OnnxEncoder(nn.Module):
         )
         processed_lens = states[-1]  # (batch,)
         # (batch, left_context_size)
-        processed_mask = (processed_lens.unsqueeze(1) <= processed_mask).flip(1)
+        processed_mask = (processed_lens.unsqueeze(1) <= processed_mask).to(
+            torch.int32
+        ).flip(1)
         # Update processed lengths
         new_processed_lens = processed_lens + x_lens
         # (batch, left_context_size + chunk_size)
@@ -318,7 +328,7 @@ class OnnxEncoder(nn.Module):
 
         new_states = new_encoder_states + [
             new_cached_embed_left_pad,
-            new_processed_lens,
+            new_processed_lens.to(states[-1].dtype),
         ]
 
         return encoder_out, new_states
@@ -406,6 +416,7 @@ def export_encoder_model_onnx(
     dynamic_batch: bool = True,
     use_whisper_features: bool = False,
     use_external_data: bool = False,
+    use_int32_inputs: int = 0,
 ) -> None:
     encoder_model.encoder.__class__.forward = (
         encoder_model.encoder.__class__.streaming_forward
@@ -418,6 +429,12 @@ def export_encoder_model_onnx(
 
     x = torch.rand(1, T, feature_dim, dtype=torch.float32)
     init_state = encoder_model.get_init_states()
+
+    if use_int32_inputs:
+        init_state = [
+            s if s.dtype != torch.int64 else s.to(torch.int32) for s in init_state
+        ]
+
     num_encoders = len(encoder_model.encoder.encoder_dim)
     logging.info(f"num_encoders: {num_encoders}")
     logging.info(f"len(init_state): {len(init_state)}")
@@ -566,6 +583,7 @@ def export_decoder_model_onnx(
     decoder_filename: str,
     opset_version: int = 11,
     dynamic_batch: bool = True,
+    use_int32_inputs: int = 0,
 ) -> None:
     """Export the decoder model to ONNX format.
 
@@ -588,7 +606,11 @@ def export_decoder_model_onnx(
     context_size = decoder_model.decoder.context_size
     vocab_size = decoder_model.decoder.vocab_size
 
-    y = torch.zeros(1, context_size, dtype=torch.int64)
+    if use_int32_inputs:
+        y = torch.zeros(1, context_size, dtype=torch.int32)
+    else:
+        y = torch.zeros(1, context_size, dtype=torch.int64)
+
     decoder_model = torch.jit.script(decoder_model)
     torch.onnx.export(
         decoder_model,
@@ -817,10 +839,12 @@ def main():
         opset_version=opset_version,
         feature_dim=params.feature_dim,
         dynamic_batch=params.dynamic_batch == 1,
+        use_int32_inputs=params.use_int32_inputs,
         use_whisper_features=params.use_whisper_features,
         use_external_data=params.use_external_data,
     )
     logging.info(f"Exported encoder to {encoder_filename}")
+    return
 
     logging.info("Exporting decoder")
     decoder_filename = params.exp_dir / f"decoder-{suffix}.onnx"
@@ -829,8 +853,10 @@ def main():
         decoder_filename,
         opset_version=opset_version,
         dynamic_batch=params.dynamic_batch == 1,
+        use_int32_inputs=params.use_int32_inputs,
     )
     logging.info(f"Exported decoder to {decoder_filename}")
+    return
 
     logging.info("Exporting joiner")
     joiner_filename = params.exp_dir / f"joiner-{suffix}.onnx"

--- a/egs/librispeech/ASR/zipformer/export-onnx.py
+++ b/egs/librispeech/ASR/zipformer/export-onnx.py
@@ -118,12 +118,6 @@ def get_parser():
     )
 
     parser.add_argument(
-        "--max-len",
-        type=int,
-        required=True,
-    )
-
-    parser.add_argument(
         "--use-averaged-model",
         type=str2bool,
         default=True,
@@ -217,7 +211,8 @@ class OnnxEncoder(nn.Module):
     def forward(
         self,
         x: torch.Tensor,
-    ) -> torch.Tensor:
+        x_lens: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
         """Please see the help information of Zipformer.forward
 
         Args:
@@ -230,7 +225,6 @@ class OnnxEncoder(nn.Module):
             - encoder_out, A 3-D tensor of shape (N, T', joiner_dim)
             - encoder_out_lens, A 1-D tensor of shape (N,)
         """
-        x_lens = torch.tensor([x.shape[1]], dtype=torch.int32)
         x, x_lens = self.encoder_embed(x, x_lens)
         src_key_padding_mask = make_pad_mask(x_lens, x.shape[1])
         x = x.permute(1, 0, 2)
@@ -239,7 +233,7 @@ class OnnxEncoder(nn.Module):
         encoder_out = self.encoder_proj(encoder_out)
         # Now encoder_out is of shape (N, T, joiner_dim)
 
-        return encoder_out
+        return encoder_out, encoder_out_lens
 
 
 class OnnxDecoder(nn.Module):
@@ -295,7 +289,6 @@ class OnnxJoiner(nn.Module):
 def export_encoder_model_onnx(
     encoder_model: OnnxEncoder,
     encoder_filename: str,
-    max_len: int,
     opset_version: int = 11,
 ) -> None:
     """Export the given encoder model to ONNX format.
@@ -317,27 +310,25 @@ def export_encoder_model_onnx(
       opset_version:
         The opset version to use.
     """
-    x = torch.zeros(1, max_len, 80, dtype=torch.float32)
-    #  x_lens = torch.tensor([488], dtype=torch.int64)
+    x = torch.zeros(1, 100, 80, dtype=torch.float32)
+    x_lens = torch.tensor([100], dtype=torch.int64)
 
-    encoder_model = torch.jit.trace(encoder_model, x)
+    encoder_model = torch.jit.trace(encoder_model, (x, x_lens))
 
     torch.onnx.export(
         encoder_model,
-        x,
+        (x, x_lens),
         encoder_filename,
         verbose=False,
         opset_version=opset_version,
-        input_names=["x"],
-        output_names=["encoder_out"],
+        input_names=["x", "x_lens"],
+        output_names=["encoder_out", "encoder_out_lens"],
         dynamic_axes={
             "x": {0: "N", 1: "T"},
             "x_lens": {0: "N"},
             "encoder_out": {0: "N", 1: "T"},
             "encoder_out_lens": {0: "N"},
-        }
-        if False
-        else {},
+        },
     )
 
     meta_data = {
@@ -377,7 +368,7 @@ def export_decoder_model_onnx(
     context_size = decoder_model.decoder.context_size
     vocab_size = decoder_model.decoder.vocab_size
 
-    y = torch.zeros(1, context_size, dtype=torch.int32)
+    y = torch.zeros(10, context_size, dtype=torch.int64)
     decoder_model = torch.jit.script(decoder_model)
     torch.onnx.export(
         decoder_model,
@@ -390,9 +381,7 @@ def export_decoder_model_onnx(
         dynamic_axes={
             "y": {0: "N"},
             "decoder_out": {0: "N"},
-        }
-        if False
-        else {},
+        },
     )
 
     meta_data = {
@@ -420,8 +409,8 @@ def export_joiner_model_onnx(
     joiner_dim = joiner_model.output_linear.weight.shape[1]
     logging.info(f"joiner dim: {joiner_dim}")
 
-    projected_encoder_out = torch.rand(1, joiner_dim, dtype=torch.float32)
-    projected_decoder_out = torch.rand(1, joiner_dim, dtype=torch.float32)
+    projected_encoder_out = torch.rand(11, joiner_dim, dtype=torch.float32)
+    projected_decoder_out = torch.rand(11, joiner_dim, dtype=torch.float32)
 
     torch.onnx.export(
         joiner_model,
@@ -438,9 +427,7 @@ def export_joiner_model_onnx(
             "encoder_out": {0: "N"},
             "decoder_out": {0: "N"},
             "logit": {0: "N"},
-        }
-        if False
-        else {},
+        },
     )
     meta_data = {
         "joiner_dim": str(joiner_dim),
@@ -591,7 +578,6 @@ def main():
     export_encoder_model_onnx(
         encoder,
         encoder_filename,
-        max_len=params.max_len,
         opset_version=opset_version,
     )
     logging.info(f"Exported encoder to {encoder_filename}")
@@ -630,7 +616,6 @@ def main():
     # See https://onnxruntime.ai/docs/performance/model-optimizations/quantization.html#data-type-selection
 
     logging.info("Generate int8 quantization models")
-    return
 
     encoder_filename_int8 = params.exp_dir / f"encoder-{suffix}.int8.onnx"
     quantize_dynamic(

--- a/egs/librispeech/ASR/zipformer/export-onnx.py
+++ b/egs/librispeech/ASR/zipformer/export-onnx.py
@@ -118,6 +118,12 @@ def get_parser():
     )
 
     parser.add_argument(
+        "--max-len",
+        type=int,
+        required=True,
+    )
+
+    parser.add_argument(
         "--use-averaged-model",
         type=str2bool,
         default=True,
@@ -289,6 +295,7 @@ class OnnxJoiner(nn.Module):
 def export_encoder_model_onnx(
     encoder_model: OnnxEncoder,
     encoder_filename: str,
+    max_len: int,
     opset_version: int = 11,
 ) -> None:
     """Export the given encoder model to ONNX format.
@@ -310,10 +317,7 @@ def export_encoder_model_onnx(
       opset_version:
         The opset version to use.
     """
-    x = torch.zeros(1, 500, 80, dtype=torch.float32)
-    x = torch.zeros(1, 1000, 80, dtype=torch.float32)
-    x = torch.zeros(1, 800, 80, dtype=torch.float32)
-    x = torch.zeros(1, 300, 80, dtype=torch.float32)
+    x = torch.zeros(1, max_len, 80, dtype=torch.float32)
     #  x_lens = torch.tensor([488], dtype=torch.int64)
 
     encoder_model = torch.jit.trace(encoder_model, x)
@@ -587,6 +591,7 @@ def main():
     export_encoder_model_onnx(
         encoder,
         encoder_filename,
+        max_len=params.max_len,
         opset_version=opset_version,
     )
     logging.info(f"Exported encoder to {encoder_filename}")

--- a/egs/librispeech/ASR/zipformer/export-onnx.py
+++ b/egs/librispeech/ASR/zipformer/export-onnx.py
@@ -211,8 +211,7 @@ class OnnxEncoder(nn.Module):
     def forward(
         self,
         x: torch.Tensor,
-        x_lens: torch.Tensor,
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
+    ) -> torch.Tensor:
         """Please see the help information of Zipformer.forward
 
         Args:
@@ -225,6 +224,7 @@ class OnnxEncoder(nn.Module):
             - encoder_out, A 3-D tensor of shape (N, T', joiner_dim)
             - encoder_out_lens, A 1-D tensor of shape (N,)
         """
+        x_lens = torch.tensor([x.shape[1]], dtype=torch.int32)
         x, x_lens = self.encoder_embed(x, x_lens)
         src_key_padding_mask = make_pad_mask(x_lens, x.shape[1])
         x = x.permute(1, 0, 2)
@@ -233,7 +233,7 @@ class OnnxEncoder(nn.Module):
         encoder_out = self.encoder_proj(encoder_out)
         # Now encoder_out is of shape (N, T, joiner_dim)
 
-        return encoder_out, encoder_out_lens
+        return encoder_out
 
 
 class OnnxDecoder(nn.Module):
@@ -310,25 +310,30 @@ def export_encoder_model_onnx(
       opset_version:
         The opset version to use.
     """
-    x = torch.zeros(1, 100, 80, dtype=torch.float32)
-    x_lens = torch.tensor([100], dtype=torch.int64)
+    x = torch.zeros(1, 500, 80, dtype=torch.float32)
+    x = torch.zeros(1, 1000, 80, dtype=torch.float32)
+    x = torch.zeros(1, 800, 80, dtype=torch.float32)
+    x = torch.zeros(1, 300, 80, dtype=torch.float32)
+    #  x_lens = torch.tensor([488], dtype=torch.int64)
 
-    encoder_model = torch.jit.trace(encoder_model, (x, x_lens))
+    encoder_model = torch.jit.trace(encoder_model, x)
 
     torch.onnx.export(
         encoder_model,
-        (x, x_lens),
+        x,
         encoder_filename,
         verbose=False,
         opset_version=opset_version,
-        input_names=["x", "x_lens"],
-        output_names=["encoder_out", "encoder_out_lens"],
+        input_names=["x"],
+        output_names=["encoder_out"],
         dynamic_axes={
             "x": {0: "N", 1: "T"},
             "x_lens": {0: "N"},
             "encoder_out": {0: "N", 1: "T"},
             "encoder_out_lens": {0: "N"},
-        },
+        }
+        if False
+        else {},
     )
 
     meta_data = {
@@ -368,7 +373,7 @@ def export_decoder_model_onnx(
     context_size = decoder_model.decoder.context_size
     vocab_size = decoder_model.decoder.vocab_size
 
-    y = torch.zeros(10, context_size, dtype=torch.int64)
+    y = torch.zeros(1, context_size, dtype=torch.int32)
     decoder_model = torch.jit.script(decoder_model)
     torch.onnx.export(
         decoder_model,
@@ -381,7 +386,9 @@ def export_decoder_model_onnx(
         dynamic_axes={
             "y": {0: "N"},
             "decoder_out": {0: "N"},
-        },
+        }
+        if False
+        else {},
     )
 
     meta_data = {
@@ -409,8 +416,8 @@ def export_joiner_model_onnx(
     joiner_dim = joiner_model.output_linear.weight.shape[1]
     logging.info(f"joiner dim: {joiner_dim}")
 
-    projected_encoder_out = torch.rand(11, joiner_dim, dtype=torch.float32)
-    projected_decoder_out = torch.rand(11, joiner_dim, dtype=torch.float32)
+    projected_encoder_out = torch.rand(1, joiner_dim, dtype=torch.float32)
+    projected_decoder_out = torch.rand(1, joiner_dim, dtype=torch.float32)
 
     torch.onnx.export(
         joiner_model,
@@ -427,7 +434,9 @@ def export_joiner_model_onnx(
             "encoder_out": {0: "N"},
             "decoder_out": {0: "N"},
             "logit": {0: "N"},
-        },
+        }
+        if False
+        else {},
     )
     meta_data = {
         "joiner_dim": str(joiner_dim),
@@ -616,6 +625,7 @@ def main():
     # See https://onnxruntime.ai/docs/performance/model-optimizations/quantization.html#data-type-selection
 
     logging.info("Generate int8 quantization models")
+    return
 
     encoder_filename_int8 = params.exp_dir / f"encoder-{suffix}.int8.onnx"
     quantize_dynamic(

--- a/egs/librispeech/ASR/zipformer/export-streaming-as-non-streaming-onnx.py
+++ b/egs/librispeech/ASR/zipformer/export-streaming-as-non-streaming-onnx.py
@@ -6,58 +6,27 @@
 """
 This script exports a transducer model from PyTorch to ONNX.
 
-We use the pre-trained model from
-https://huggingface.co/Zengwei/icefall-asr-librispeech-zipformer-2023-05-15
-as an example to show how to use this file.
+If you train a streaming model and want to export a non-streaming version,
+please use this script.
 
-1. Download the pre-trained model
+Example:
 
-cd egs/librispeech/ASR
-
-repo_url=https://huggingface.co/Zengwei/icefall-asr-librispeech-zipformer-2023-05-15
-GIT_LFS_SKIP_SMUDGE=1 git clone $repo_url
-repo=$(basename $repo_url)
-
-pushd $repo
-git lfs pull --include "exp/pretrained.pt"
-
-cd exp
-ln -s pretrained.pt epoch-99.pt
-popd
-
-2. Export the model to ONNX
-
-./zipformer/export-onnx.py \
-  --tokens $repo/data/lang_bpe_500/tokens.txt \
-  --use-averaged-model 0 \
-  --epoch 99 \
-  --avg 1 \
-  --exp-dir $repo/exp \
-  --num-encoder-layers "2,2,3,4,3,2" \
-  --downsampling-factor "1,2,4,8,4,2" \
-  --feedforward-dim "512,768,1024,1536,1024,768" \
-  --num-heads "4,4,4,8,4,4" \
-  --encoder-dim "192,256,384,512,384,256" \
-  --query-head-dim 32 \
-  --value-head-dim 12 \
-  --pos-head-dim 4 \
-  --pos-dim 48 \
-  --encoder-unmasked-dim "192,192,256,256,256,192" \
-  --cnn-module-kernel "31,31,15,15,15,31" \
-  --decoder-dim 512 \
-  --joiner-dim 512 \
-  --causal False \
-  --chunk-size "16,32,64,-1" \
-  --left-context-frames "64,128,256,-1" \
-  --fp16 True
-It will generate the following 3 files inside $repo/exp:
-
-  - encoder-epoch-99-avg-1.onnx
-  - decoder-epoch-99-avg-1.onnx
-  - joiner-epoch-99-avg-1.onnx
-
-See ./onnx_pretrained.py and ./onnx_check.py for how to
-use the exported ONNX models.
+  ./zipformer/export-streaming-as-non-streaming-onnx.py \
+    --max-len -1 \
+    --epoch 99 \
+    --avg 1 \
+    --use-averaged-model 0 \
+    --exp-dir ./exp \
+    --tokens ./tokens.txt \
+    \
+    --num-encoder-layers 2,2,4,5,4,2 \
+    --feedforward-dim 512,768,1536,2048,1536,768 \
+    --encoder-dim 192,256,512,768,512,256 \
+    --encoder-unmasked-dim 192,192,256,320,256,192 \
+    --causal 1 \
+    --use-int32-inputs 1 \
+    --chunk-size "-1" \
+    --left-context-frames "-1"
 """
 
 import argparse
@@ -115,6 +84,34 @@ def get_parser():
         help="Number of checkpoints to average. Automatically select "
         "consecutive checkpoints before the checkpoint specified by "
         "'--epoch' and '--iter'",
+    )
+
+    parser.add_argument(
+        "--max-len",
+        type=int,
+        default=-1,
+    )
+
+    parser.add_argument(
+        "--dynamic-axes",
+        type=int,
+        default=1,
+        help="1 to support dynamic axes. 0 to diable dynamic axes",
+    )
+
+    parser.add_argument(
+        "--use-int32-inputs",
+        type=int,
+        default=0,
+        help="""1 to use int32_t as input types if applicable. 0 to use
+        int64_t otherwise.""",
+    )
+
+    parser.add_argument(
+        "--enable-int8-quantization",
+        type=int,
+        default=1,
+        help="1 to also export int8 onnx models.",
     )
 
     parser.add_argument(
@@ -211,8 +208,7 @@ class OnnxEncoder(nn.Module):
     def forward(
         self,
         x: torch.Tensor,
-        x_lens: torch.Tensor,
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
+    ) -> torch.Tensor:
         """Please see the help information of Zipformer.forward
 
         Args:
@@ -225,6 +221,7 @@ class OnnxEncoder(nn.Module):
             - encoder_out, A 3-D tensor of shape (N, T', joiner_dim)
             - encoder_out_lens, A 1-D tensor of shape (N,)
         """
+        x_lens = torch.tensor([x.shape[1]], dtype=torch.int32)
         x, x_lens = self.encoder_embed(x, x_lens)
         src_key_padding_mask = make_pad_mask(x_lens, x.shape[1]).to(torch.int32)
         x = x.permute(1, 0, 2)
@@ -233,7 +230,7 @@ class OnnxEncoder(nn.Module):
         encoder_out = self.encoder_proj(encoder_out)
         # Now encoder_out is of shape (N, T, joiner_dim)
 
-        return encoder_out, encoder_out_lens
+        return encoder_out
 
 
 class OnnxDecoder(nn.Module):
@@ -289,7 +286,10 @@ class OnnxJoiner(nn.Module):
 def export_encoder_model_onnx(
     encoder_model: OnnxEncoder,
     encoder_filename: str,
-    opset_version: int = 11,
+    max_len: int,
+    dynamic_axes: int,
+    use_int32_inputs: int,
+    opset_version: int = 13,
 ) -> None:
     """Export the given encoder model to ONNX format.
     The exported model has two inputs:
@@ -310,25 +310,36 @@ def export_encoder_model_onnx(
       opset_version:
         The opset version to use.
     """
-    x = torch.zeros(1, 100, 80, dtype=torch.float32)
-    x_lens = torch.tensor([100], dtype=torch.int64)
+    if max_len > 0:
+        x = torch.zeros(1, max_len, 80, dtype=torch.float32)
+    else:
+        x = torch.zeros(1, 3000, 80, dtype=torch.float32)
 
-    encoder_model = torch.jit.trace(encoder_model, (x, x_lens))
+    if use_int32_inputs:
+        x_lens = torch.tensor([x.shape[1]], dtype=torch.int32)
+    else:
+        x_lens = torch.tensor([x.shape[1]], dtype=torch.int64)
+    print("x_lens", x_lens)
+
+    encoder_model = torch.jit.trace(encoder_model, x)
+    print("x_lens", x_lens)
 
     torch.onnx.export(
         encoder_model,
-        (x, x_lens),
+        x,
         encoder_filename,
         verbose=False,
         opset_version=opset_version,
-        input_names=["x", "x_lens"],
-        output_names=["encoder_out", "encoder_out_lens"],
+        input_names=["x"],
+        output_names=["encoder_out"],
         dynamic_axes={
             "x": {0: "N", 1: "T"},
             "x_lens": {0: "N"},
             "encoder_out": {0: "N", 1: "T"},
             "encoder_out_lens": {0: "N"},
-        },
+        }
+        if dynamic_axes
+        else {},
     )
 
     meta_data = {
@@ -345,6 +356,8 @@ def export_encoder_model_onnx(
 def export_decoder_model_onnx(
     decoder_model: OnnxDecoder,
     decoder_filename: str,
+    use_int32_inputs,
+    dynamic_axes: int,
     opset_version: int = 11,
 ) -> None:
     """Export the decoder model to ONNX format.
@@ -368,7 +381,11 @@ def export_decoder_model_onnx(
     context_size = decoder_model.decoder.context_size
     vocab_size = decoder_model.decoder.vocab_size
 
-    y = torch.zeros(10, context_size, dtype=torch.int64)
+    if use_int32_inputs:
+        y = torch.zeros(1, context_size, dtype=torch.int32)
+    else:
+        y = torch.zeros(1, context_size, dtype=torch.int64)
+
     decoder_model = torch.jit.script(decoder_model)
     torch.onnx.export(
         decoder_model,
@@ -381,7 +398,9 @@ def export_decoder_model_onnx(
         dynamic_axes={
             "y": {0: "N"},
             "decoder_out": {0: "N"},
-        },
+        }
+        if dynamic_axes
+        else {},
     )
 
     meta_data = {
@@ -394,6 +413,7 @@ def export_decoder_model_onnx(
 def export_joiner_model_onnx(
     joiner_model: nn.Module,
     joiner_filename: str,
+    dynamic_axes: int,
     opset_version: int = 11,
 ) -> None:
     """Export the joiner model to ONNX format.
@@ -409,8 +429,8 @@ def export_joiner_model_onnx(
     joiner_dim = joiner_model.output_linear.weight.shape[1]
     logging.info(f"joiner dim: {joiner_dim}")
 
-    projected_encoder_out = torch.rand(11, joiner_dim, dtype=torch.float32)
-    projected_decoder_out = torch.rand(11, joiner_dim, dtype=torch.float32)
+    projected_encoder_out = torch.rand(1, joiner_dim, dtype=torch.float32)
+    projected_decoder_out = torch.rand(1, joiner_dim, dtype=torch.float32)
 
     torch.onnx.export(
         joiner_model,
@@ -427,7 +447,9 @@ def export_joiner_model_onnx(
             "encoder_out": {0: "N"},
             "decoder_out": {0: "N"},
             "logit": {0: "N"},
-        },
+        }
+        if dynamic_axes
+        else {},
     )
     meta_data = {
         "joiner_dim": str(joiner_dim),
@@ -578,6 +600,9 @@ def main():
     export_encoder_model_onnx(
         encoder,
         encoder_filename,
+        max_len=params.max_len,
+        dynamic_axes=params.dynamic_axes,
+        use_int32_inputs=params.use_int32_inputs,
         opset_version=opset_version,
     )
     logging.info(f"Exported encoder to {encoder_filename}")
@@ -587,6 +612,8 @@ def main():
     export_decoder_model_onnx(
         decoder,
         decoder_filename,
+        dynamic_axes=params.dynamic_axes,
+        use_int32_inputs=params.use_int32_inputs,
         opset_version=opset_version,
     )
     logging.info(f"Exported decoder to {decoder_filename}")
@@ -596,6 +623,7 @@ def main():
     export_joiner_model_onnx(
         joiner,
         joiner_filename,
+        dynamic_axes=params.dynamic_axes,
         opset_version=opset_version,
     )
     logging.info(f"Exported joiner to {joiner_filename}")
@@ -614,6 +642,9 @@ def main():
 
     # Generate int8 quantization models
     # See https://onnxruntime.ai/docs/performance/model-optimizations/quantization.html#data-type-selection
+
+    if not params.enable_int8_quantization:
+        return
 
     logging.info("Generate int8 quantization models")
 

--- a/egs/librispeech/ASR/zipformer/export-streaming-as-non-streaming-onnx.py
+++ b/egs/librispeech/ASR/zipformer/export-streaming-as-non-streaming-onnx.py
@@ -9,7 +9,7 @@ This script exports a transducer model from PyTorch to ONNX.
 If you train a streaming model and want to export a non-streaming version,
 please use this script.
 
-Example:
+Example 1: Export a streaming model as a non-streaming model.
 
   ./zipformer/export-streaming-as-non-streaming-onnx.py \
     --max-len -1 \
@@ -25,6 +25,29 @@ Example:
     --encoder-unmasked-dim 192,192,256,320,256,192 \
     --causal 1 \
     --use-int32-inputs 1 \
+    --chunk-size "-1" \
+    --left-context-frames "-1"
+
+Example 2: Export a streaming model as a non-streaming model suitable
+for NPU (e.g., Qualcomm NPU)
+
+  ./zipformer/export-streaming-as-non-streaming-onnx.py \
+    --keep-x-lens 0 \
+    --max-len 1000 \
+    --dynamic-axes 0 \
+    --use-int32-inputs 1 \
+    --enable-int8-quantization 0 \
+    --epoch 99 \
+    --avg 1 \
+    --use-averaged-model 0 \
+    --exp-dir ./exp \
+    --tokens ./tokens.txt \
+    \
+    --num-encoder-layers 2,2,4,5,4,2 \
+    --feedforward-dim 512,768,1536,2048,1536,768 \
+    --encoder-dim 192,256,512,768,512,256 \
+    --encoder-unmasked-dim 192,192,256,320,256,192 \
+    --causal 1 \
     --chunk-size "-1" \
     --left-context-frames "-1"
 """
@@ -90,6 +113,13 @@ def get_parser():
         "--max-len",
         type=int,
         default=-1,
+    )
+
+    parser.add_argument(
+        "--keep-x-lens",
+        type=int,
+        default=-1,
+        help="1 to keep the encoder input x_lens. 0 to discard it",
     )
 
     parser.add_argument(
@@ -205,10 +235,21 @@ class OnnxEncoder(nn.Module):
         self.encoder_embed = encoder_embed
         self.encoder_proj = encoder_proj
 
+    def forward2(self, x: torch.Tensor):
+        x_lens = torch.tensor([x.shape[1]], dtype=torch.int32)
+        x, x_lens = self.encoder_embed(x, x_lens)
+        src_key_padding_mask = make_pad_mask(x_lens, x.shape[1]).to(torch.int32)
+        x = x.permute(1, 0, 2)
+        encoder_out, encoder_out_lens = self.encoder(x, x_lens, src_key_padding_mask)
+        encoder_out = encoder_out.permute(1, 0, 2)
+        encoder_out = self.encoder_proj(encoder_out)
+        return encoder_out
+
     def forward(
         self,
         x: torch.Tensor,
-    ) -> torch.Tensor:
+        x_lens: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
         """Please see the help information of Zipformer.forward
 
         Args:
@@ -221,7 +262,6 @@ class OnnxEncoder(nn.Module):
             - encoder_out, A 3-D tensor of shape (N, T', joiner_dim)
             - encoder_out_lens, A 1-D tensor of shape (N,)
         """
-        x_lens = torch.tensor([x.shape[1]], dtype=torch.int32)
         x, x_lens = self.encoder_embed(x, x_lens)
         src_key_padding_mask = make_pad_mask(x_lens, x.shape[1]).to(torch.int32)
         x = x.permute(1, 0, 2)
@@ -230,7 +270,7 @@ class OnnxEncoder(nn.Module):
         encoder_out = self.encoder_proj(encoder_out)
         # Now encoder_out is of shape (N, T, joiner_dim)
 
-        return encoder_out
+        return encoder_out, encoder_out_lens
 
 
 class OnnxDecoder(nn.Module):
@@ -289,6 +329,7 @@ def export_encoder_model_onnx(
     max_len: int,
     dynamic_axes: int,
     use_int32_inputs: int,
+    keep_x_lens: int = 1,
     opset_version: int = 13,
 ) -> None:
     """Export the given encoder model to ONNX format.
@@ -319,27 +360,39 @@ def export_encoder_model_onnx(
         x_lens = torch.tensor([x.shape[1]], dtype=torch.int32)
     else:
         x_lens = torch.tensor([x.shape[1]], dtype=torch.int64)
-    print("x_lens", x_lens)
 
-    encoder_model = torch.jit.trace(encoder_model, x)
-    print("x_lens", x_lens)
-
-    torch.onnx.export(
-        encoder_model,
-        x,
-        encoder_filename,
-        verbose=False,
-        opset_version=opset_version,
-        input_names=["x"],
-        output_names=["encoder_out"],
-        dynamic_axes={
+    if keep_x_lens:
+        inputs = (x, x_lens)
+        input_names = ["x", "x_lens"]
+        output_names = ["encoder_out", "encoder_out_lens"]
+        dynamic_axes_dict = {
             "x": {0: "N", 1: "T"},
             "x_lens": {0: "N"},
             "encoder_out": {0: "N", 1: "T"},
             "encoder_out_lens": {0: "N"},
         }
-        if dynamic_axes
-        else {},
+    else:
+        encoder_model.__class__.forward = encoder_model.__class__.forward2
+
+        inputs = (x,)
+        input_names = ["x"]
+        output_names = ["encoder_out"]
+        dynamic_axes_dict = {
+            "x": {0: "N", 1: "T"},
+            "encoder_out": {0: "N", 1: "T"},
+        }
+
+    encoder_model = torch.jit.trace(encoder_model, inputs)
+
+    torch.onnx.export(
+        encoder_model,
+        inputs,
+        encoder_filename,
+        verbose=False,
+        opset_version=opset_version,
+        input_names=input_names,
+        output_names=output_names,
+        dynamic_axes=dynamic_axes_dict if dynamic_axes else {},
     )
 
     meta_data = {
@@ -604,6 +657,7 @@ def main():
         dynamic_axes=params.dynamic_axes,
         use_int32_inputs=params.use_int32_inputs,
         opset_version=opset_version,
+        keep_x_lens=params.keep_x_lens,
     )
     logging.info(f"Exported encoder to {encoder_filename}")
 

--- a/egs/librispeech/ASR/zipformer/export-streaming-as-non-streaming-onnx.py
+++ b/egs/librispeech/ASR/zipformer/export-streaming-as-non-streaming-onnx.py
@@ -236,7 +236,7 @@ class OnnxEncoder(nn.Module):
         self.encoder_proj = encoder_proj
 
     def forward2(self, x: torch.Tensor):
-        x_lens = torch.tensor([x.shape[1]], dtype=torch.int32)
+        x_lens = torch.tensor([x.shape[1]], dtype=torch.int32, device=x.device)
         x, x_lens = self.encoder_embed(x, x_lens)
         src_key_padding_mask = make_pad_mask(x_lens, x.shape[1]).to(torch.int32)
         x = x.permute(1, 0, 2)

--- a/egs/librispeech/ASR/zipformer/export.py
+++ b/egs/librispeech/ASR/zipformer/export.py
@@ -278,7 +278,7 @@ class EncoderModel(nn.Module):
         """
         x, x_lens = self.encoder_embed(features, feature_lengths)
 
-        src_key_padding_mask = make_pad_mask(x_lens)
+        src_key_padding_mask = make_pad_mask(x_lens).to(torch.int32)
         x = x.permute(1, 0, 2)  # (N, T, C) -> (T, N, C)
 
         encoder_out, encoder_out_lens = self.encoder(x, x_lens, src_key_padding_mask)
@@ -327,7 +327,7 @@ class StreamingEncoderModel(nn.Module):
         )
         assert x.size(1) == chunk_size, (x.size(1), chunk_size)
 
-        src_key_padding_mask = make_pad_mask(x_lens)
+        src_key_padding_mask = make_pad_mask(x_lens).to(torch.int32)
 
         # processed_mask is used to mask out initial states
         processed_mask = torch.arange(left_context_len, device=x.device).expand(
@@ -335,7 +335,7 @@ class StreamingEncoderModel(nn.Module):
         )
         processed_lens = states[-1]  # (batch,)
         # (batch, left_context_size)
-        processed_mask = (processed_lens.unsqueeze(1) <= processed_mask).flip(1)
+        processed_mask = (processed_lens.unsqueeze(1) <= processed_mask).to(torch.int32).flip(1)
         # Update processed lengths
         new_processed_lens = processed_lens + x_lens
 

--- a/egs/librispeech/ASR/zipformer/scaling_converter.py
+++ b/egs/librispeech/ASR/zipformer/scaling_converter.py
@@ -29,6 +29,7 @@ import torch
 import torch.nn as nn
 from scaling import (
     Balancer,
+    ChunkCausalDepthwiseConv1d,
     Dropout3,
     ScaleGrad,
     SwooshL,
@@ -39,9 +40,51 @@ from scaling import (
 )
 from zipformer import (
     CompactRelPositionalEncoding,
-    ChunkCausalDepthwiseConv1d,
     SimpleDownsample,
 )
+
+
+class NonStreamingChunkCausalDepthwiseConv1d(torch.nn.Module):
+    """A non-streaming replacement for ChunkCausalDepthwiseConv1d that avoids
+    dynamic-shape torch.zeros and conditionals, making it ONNX-export friendly.
+
+    In non-streaming mode (chunk_size=-1), the entire sequence is one chunk,
+    so we simplify the forward pass accordingly.
+    """
+
+    def __init__(self, original: ChunkCausalDepthwiseConv1d):
+        super().__init__()
+        self.causal_conv = original.causal_conv
+        self.chunkwise_conv = original.chunkwise_conv
+        self.chunkwise_conv_scale = original.chunkwise_conv_scale
+        self.kernel_size = original.kernel_size
+
+    def forward(self, x: torch.Tensor, chunk_size: int = -1) -> torch.Tensor:
+        (batch_size, num_channels, seq_len) = x.shape
+        left_pad = self.kernel_size // 2
+
+        x = torch.nn.functional.pad(x, (left_pad, 0))
+
+        x_causal = self.causal_conv(x[..., : left_pad + seq_len])
+
+        x_chunk = x[..., left_pad:]
+        x_chunk = self.chunkwise_conv(x_chunk)
+
+        left_edge = self.chunkwise_conv_scale[0]
+        right_edge = self.chunkwise_conv_scale[1]
+        # seq_len >= kernel_size in non-streaming mode, so we pad with zeros
+        t = seq_len - self.kernel_size
+        channels = left_edge.shape[0]
+        pad = torch.zeros(
+            channels, t, device=left_edge.device, dtype=left_edge.dtype
+        )
+        left_edge = torch.cat((left_edge, pad), dim=-1)
+        right_edge = torch.cat((pad, right_edge), dim=-1)
+        chunk_scale = 1.0 + (left_edge + right_edge)
+
+        x_chunk = x_chunk * chunk_scale
+
+        return x_chunk + x_causal
 
 
 # Copied from https://pytorch.org/docs/1.9.0/_modules/torch/nn/modules/module.html#Module.get_submodule  # noqa
@@ -93,11 +136,12 @@ def convert_scaled_to_non_scaled(
             d[name] = SwooshROnnx()
         elif is_onnx and isinstance(m, SwooshL):
             d[name] = SwooshLOnnx()
+        elif is_onnx and isinstance(m, ChunkCausalDepthwiseConv1d):
+            d[name] = torch.jit.script(NonStreamingChunkCausalDepthwiseConv1d(m))
         elif is_onnx and isinstance(
             m,
             (
                 CompactRelPositionalEncoding,
-                ChunkCausalDepthwiseConv1d,
                 SimpleDownsample,
             ),
         ):

--- a/egs/librispeech/ASR/zipformer/scaling_converter.py
+++ b/egs/librispeech/ASR/zipformer/scaling_converter.py
@@ -37,7 +37,11 @@ from scaling import (
     SwooshROnnx,
     Whiten,
 )
-from zipformer import CompactRelPositionalEncoding
+from zipformer import (
+    CompactRelPositionalEncoding,
+    ChunkCausalDepthwiseConv1d,
+    SimpleDownsample,
+)
 
 
 # Copied from https://pytorch.org/docs/1.9.0/_modules/torch/nn/modules/module.html#Module.get_submodule  # noqa
@@ -89,7 +93,14 @@ def convert_scaled_to_non_scaled(
             d[name] = SwooshROnnx()
         elif is_onnx and isinstance(m, SwooshL):
             d[name] = SwooshLOnnx()
-        elif is_onnx and isinstance(m, CompactRelPositionalEncoding):
+        elif is_onnx and isinstance(
+            m,
+            (
+                CompactRelPositionalEncoding,
+                ChunkCausalDepthwiseConv1d,
+                SimpleDownsample,
+            ),
+        ):
             # We want to recreate the positional encoding vector when
             # the input changes, so we have to use torch.jit.script()
             # to replace torch.jit.trace()

--- a/egs/librispeech/ASR/zipformer/zipformer.py
+++ b/egs/librispeech/ASR/zipformer/zipformer.py
@@ -1507,13 +1507,9 @@ class CompactRelPositionalEncoding(torch.nn.Module):
         x_size_left = x.size(0) + left_context_len
         # length of positive side: x.size(0) + left_context_len
         # length of negative side: x.size(0)
-        pos_emb = pe[
-            pe.size(0) // 2
-            - x_size_left
-            + 1 : pe.size(0) // 2  # noqa E203
-            + x.size(0),
-            :,
-        ]
+        start_pos = pe.size(0) // 2 - x_size_left + 1
+        end_pos = pe.size(0) // 2 + x.size(0)
+        pos_emb = pe[start_pos:end_pos]
         pos_emb = pos_emb.unsqueeze(0)
         return self.dropout(pos_emb)
 

--- a/egs/librispeech/ASR/zipformer/zipformer.py
+++ b/egs/librispeech/ASR/zipformer/zipformer.py
@@ -1427,7 +1427,7 @@ class CompactRelPositionalEncoding(torch.nn.Module):
         self,
         embed_dim: int,
         dropout_rate: FloatLike,
-        max_len: int = 1000,
+        max_len: int = 2000,
         length_factor: float = 1.0,
     ) -> None:
         """Construct a CompactRelPositionalEncoding object."""
@@ -1733,7 +1733,7 @@ class RelPositionMultiheadAttentionWeights(nn.Module):
                 seq_len,
             ), key_padding_mask.shape
             attn_scores = attn_scores.masked_fill(
-                key_padding_mask.unsqueeze(1),
+                key_padding_mask.to(torch.bool).unsqueeze(1),
                 -1000,
             )
 
@@ -1863,7 +1863,7 @@ class RelPositionMultiheadAttentionWeights(nn.Module):
         if key_padding_mask is not None:
             assert key_padding_mask.shape == (batch_size, k_len), key_padding_mask.shape
             attn_scores = attn_scores.masked_fill(
-                key_padding_mask.unsqueeze(1),
+                key_padding_mask.to(torch.bool).unsqueeze(1),
                 -1000,
             )
 
@@ -2354,7 +2354,7 @@ class ConvolutionModule(nn.Module):
         x = x.permute(1, 2, 0)  # (#batch, channels, time).
 
         if src_key_padding_mask is not None:
-            x = x.masked_fill(src_key_padding_mask.unsqueeze(1).expand_as(x), 0.0)
+            x = x.masked_fill(src_key_padding_mask.to(torch.bool).unsqueeze(1).expand_as(x), 0.0)
 
         if (
             not torch.jit.is_scripting()
@@ -2408,7 +2408,7 @@ class ConvolutionModule(nn.Module):
         x = x.permute(1, 2, 0)  # (#batch, channels, time).
 
         if src_key_padding_mask is not None:
-            x = x.masked_fill(src_key_padding_mask.unsqueeze(1).expand_as(x), 0.0)
+            x = x.masked_fill(src_key_padding_mask.to(torch.bool).unsqueeze(1).expand_as(x), 0.0)
 
         x, cache = self.depthwise_conv.streaming_forward(x, cache=cache)
 

--- a/egs/librispeech/ASR/zipformer/zipformer.py
+++ b/egs/librispeech/ASR/zipformer/zipformer.py
@@ -1348,17 +1348,19 @@ class SimpleDownsample(torch.nn.Module):
         # right-pad src, repeating the last element.
         pad = d_seq_len * ds - seq_len
 
-        if self.causal and torch.jit.is_tracing():
-            assert (
-                pad == 0
-            ), f"pad should be zero for exporting streaming models. Given {pad}"
-
         # If we are exporting a streaming model, then we skip the if statement
         if not self.causal or not torch.jit.is_tracing():
-            src_extra = src[src.shape[0] - 1 :].expand(pad, src.shape[1], src.shape[2])
-            src = torch.cat((src, src_extra), dim=0)
-
-        assert src.shape[0] == d_seq_len * ds, (src.shape, d_seq_len, ds)
+            if pad > 0:
+                src_extra = src[src.shape[0] - 1 :].expand(
+                    pad, src.shape[1], src.shape[2]
+                )
+                src = torch.cat((src, src_extra), dim=0)
+        elif self.causal and torch.jit.is_scripting():
+            if pad > 0:
+                src_extra = src[src.shape[0] - 1 :].expand(
+                    pad, src.shape[1], src.shape[2]
+                )
+                src = torch.cat((src, src_extra), dim=0)
 
         src = src.reshape(d_seq_len, ds, batch_size, in_channels)
 
@@ -1498,14 +1500,17 @@ class CompactRelPositionalEncoding(torch.nn.Module):
         Returns:
             positional embedding, of shape (batch, left_context_len + 2*time-1, `*`).
         """
-        self.extend_pe(x, left_context_len)
+        if not torch.jit.is_scripting():
+            self.extend_pe(x, left_context_len)
+        assert self.pe is not None
+        pe = self.pe
         x_size_left = x.size(0) + left_context_len
         # length of positive side: x.size(0) + left_context_len
         # length of negative side: x.size(0)
-        pos_emb = self.pe[
-            self.pe.size(0) // 2
+        pos_emb = pe[
+            pe.size(0) // 2
             - x_size_left
-            + 1 : self.pe.size(0) // 2  # noqa E203
+            + 1 : pe.size(0) // 2  # noqa E203
             + x.size(0),
             :,
         ]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Standalone non-streaming ONNX export CLI.
  * Opt-in int32-input support for ONNX exports.
  * Optional FP16 and int8 quantized export outputs.
  * Increased default positional length limit (1000 → 2000).

* **Bug Fixes**
  * Prevented unintended int8 file generation when quantization is disabled.

* **Refactor**
  * Unified masking and tensor-type handling across export and runtime paths.
  * Added ONNX-friendly non-streaming convolution wrapper and adjusted padding/attention behavior for export.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->