### PR TITLE
Fix voxpopuli prepare.sh Stage 6 failing for any lang other than en

### DIFF
--- a/egs/voxpopuli/ASR/prepare.sh
+++ b/egs/voxpopuli/ASR/prepare.sh
@@ -161,8 +161,8 @@ if [ $stage -le 6 ] && [ $stop_stage -ge 6 ]; then
   for dataset in "dev" "test" "train"; do
     mkdir -p data/fbank/log/
     ./local/validate_cutset_manifest.py \
-      data/fbank/voxpopuli-asr-en_cuts_${dataset}.jsonl.gz \
-      2>&1 | tee data/fbank/log/validate_voxpopuli-asr-en_cuts_${dataset}.log
+      data/fbank/voxpopuli-${task}-${lang}_cuts_${dataset}.jsonl.gz \
+      2>&1 | tee data/fbank/log/validate_voxpopuli-${task}-${lang}_cuts_${dataset}.log
   done
 fi
 


### PR DESCRIPTION
Fixes #2064.

Stage 6 of `egs/voxpopuli/ASR/prepare.sh` hardcodes the `voxpopuli-asr-en` manifest prefix, while stages 3-5 build it as `voxpopuli-${task}-${lang}`. With any `lang` other than `en` (e.g. `lang=it`, the reporter's case), validation fails with `file not found: data/fbank/voxpopuli-asr-en_cuts_voxpopuli.jsonl.gz`.

This parameterizes the cuts path and the log path the same way as the other stages — the exact workaround described in the issue:

```
data/fbank/voxpopuli-${task}-${lang}_cuts_${dataset}.jsonl.gz
data/fbank/log/validate_voxpopuli-${task}-${lang}_cuts_${dataset}.log
```

Verified with `bash -n` and by resolving the path with `task=asr lang=it dataset=dev` → `data/fbank/voxpopuli-asr-it_cuts_dev.jsonl.gz`, matching what Stage 5 produces.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated VoxPopuli cutset validation to use task- and language-specific manifest files.
  * Validation output logs now match the same task and language context for clearer traceability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->