### PR TITLE
Fix black formatting in europarl_st beam_search.py

### DIFF
--- a/egs/europarl_st/SRT/lcma_srt/beam_search.py
+++ b/egs/europarl_st/SRT/lcma_srt/beam_search.py
@@ -1448,7 +1448,9 @@ def modified_beam_search(
         if lang_token_id is None:
             raise ValueError("force_first_lang=True but lang_token_id not provided")
         if not isinstance(lang_token_id, int):
-            raise TypeError("lang_token_id must be int (same target lang for entire batch).")
+            raise TypeError(
+                "lang_token_id must be int (same target lang for entire batch)."
+            )
 
     packed_encoder_out = torch.nn.utils.rnn.pack_padded_sequence(
         input=encoder_out,


### PR DESCRIPTION
`egs/europarl_st/SRT/lcma_srt/beam_search.py` (added in #2096) fails the `style_check` workflow — black 22.3.0 wants to reformat it, so style_check is currently red for every PR (e.g. it's what fails on #2097, whose change is an unrelated shell script).

Reformatted with the exact versions the workflow installs (`black==22.3.0`, `click==8.1.0`); `black --check` and `isort --check` both pass on the file now. No functional change (+3/-1).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the error message shown when an invalid language token ID is provided during beam search.
  * Clarified that the language token ID must be an integer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->