### PR TITLE
Publish CPU docker images for PyTorch 2.13.0

### DIFF
--- a/.github/scripts/docker/Dockerfile
+++ b/.github/scripts/docker/Dockerfile
@@ -1,9 +1,6 @@
-ARG BASE_IMAGE=pytorch/manylinux2_28-builder:cpu
-FROM ${BASE_IMAGE}
-
 ARG PYTHON_VERSION=3.10
-ARG PYTHON_MAJOR=3
-ARG PYTHON_MINOR=10
+FROM python:${PYTHON_VERSION}
+
 ARG TORCHAUDIO_VERSION="2.10.0"
 ARG TORCH_VERSION="2.10.0"
 ARG K2_VERSION="1.24.4.dev20260625"
@@ -12,13 +9,8 @@ ARG KALDIFEAT_VERSION="1.25.5.dev20260626"
 ARG _K2_VERSION="${K2_VERSION}+cpu.torch${TORCH_VERSION}"
 ARG _KALDIFEAT_VERSION="${KALDIFEAT_VERSION}+cpu.torch${TORCH_VERSION}"
 
-# Set up Python from the manylinux image (/opt/python/cpXY-cpXY/)
-ENV PYTHON_INSTALL_DIR=/opt/python/cp${PYTHON_MAJOR}${PYTHON_MINOR}-cp${PYTHON_MAJOR}${PYTHON_MINOR}
-ENV PATH="${PYTHON_INSTALL_DIR}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-ENV PYTHONPATH="${PYTHON_INSTALL_DIR}/lib/python${PYTHON_VERSION}/site-packages"
-
-RUN yum install -y epel-release && \
-    yum install -y \
+RUN apt-get update -y && \
+    apt-get install -qq -y \
     cmake \
     ffmpeg \
     git \
@@ -28,7 +20,8 @@ RUN yum install -y epel-release && \
     tree \
     vim \
     && \
-    yum clean all
+    apt-get clean && \
+    rm -rf /var/cache/apt/archives /var/lib/apt/lists
 
 
 LABEL authors="Fangjun Kuang <csukuangfj@gmail.com>"

--- a/.github/scripts/docker/Dockerfile
+++ b/.github/scripts/docker/Dockerfile
@@ -1,16 +1,24 @@
-ARG PYTHON_VERSION=3.8
-FROM python:${PYTHON_VERSION}
+ARG BASE_IMAGE=pytorch/manylinux2_28-builder:cpu
+FROM ${BASE_IMAGE}
 
-ARG TORCHAUDIO_VERSION="0.13.0"
-ARG TORCH_VERSION="1.13.0"
-ARG K2_VERSION="1.24.4.dev20231220"
-ARG KALDIFEAT_VERSION="1.25.3.dev20231221"
+ARG PYTHON_VERSION=3.10
+ARG PYTHON_MAJOR=3
+ARG PYTHON_MINOR=10
+ARG TORCHAUDIO_VERSION="2.10.0"
+ARG TORCH_VERSION="2.10.0"
+ARG K2_VERSION="1.24.4.dev20260625"
+ARG KALDIFEAT_VERSION="1.25.5.dev20260626"
 
 ARG _K2_VERSION="${K2_VERSION}+cpu.torch${TORCH_VERSION}"
 ARG _KALDIFEAT_VERSION="${KALDIFEAT_VERSION}+cpu.torch${TORCH_VERSION}"
 
-RUN apt-get update -y && \
-    apt-get install -qq -y \
+# Set up Python from the manylinux image (/opt/python/cpXY-cpXY/)
+ENV PYTHON_INSTALL_DIR=/opt/python/cp${PYTHON_MAJOR}${PYTHON_MINOR}-cp${PYTHON_MAJOR}${PYTHON_MINOR}
+ENV PATH="${PYTHON_INSTALL_DIR}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+ENV PYTHONPATH="${PYTHON_INSTALL_DIR}/lib/python${PYTHON_VERSION}/site-packages"
+
+RUN yum install -y epel-release && \
+    yum install -y \
     cmake \
     ffmpeg \
     git \
@@ -20,8 +28,7 @@ RUN apt-get update -y && \
     tree \
     vim \
     && \
-    apt-get clean && \
-    rm -rf /var/cache/apt/archives /var/lib/apt/lists
+    yum clean all
 
 
 LABEL authors="Fangjun Kuang <csukuangfj@gmail.com>"

--- a/.github/scripts/docker/Dockerfile
+++ b/.github/scripts/docker/Dockerfile
@@ -55,9 +55,9 @@ RUN pip install --no-cache-dir \
       "numpy<2.0" \
       onnxoptimizer \
       onnxsim \
-      onnx==1.17.0 \
+      onnx \
       onnxmltools \
-      onnxruntime==1.17.1 \
+      onnxruntime \
       piper_phonemize -f https://k2-fsa.github.io/icefall/piper_phonemize.html \
       pypinyin==0.50.0 \
       pytest \

--- a/.github/scripts/docker/generate_build_matrix.py
+++ b/.github/scripts/docker/generate_build_matrix.py
@@ -147,11 +147,6 @@ def get_matrix(min_torch_version, specified_torch_version, specified_python_vers
             if version_gt(p, "3.14") and not version_ge(t, "2.13"):
                 continue
 
-            if version_ge(t, "2.6.0"):
-                image = "pytorch/manylinux2_28-builder:cpu"
-            else:
-                image = "pytorch/manylinux-builder:cpu-27677ead7c8293c299a885ae2c474bf445e653a5"
-
             matrix.append(
                 {
                     "k2-version": get_k2_version(t),
@@ -160,7 +155,6 @@ def get_matrix(min_torch_version, specified_torch_version, specified_python_vers
                     "python-version": p,
                     "torch-version": t,
                     "torchaudio-version": get_torchaudio_version(t),
-                    "image": image,
                 }
             )
     return matrix

--- a/.github/scripts/docker/generate_build_matrix.py
+++ b/.github/scripts/docker/generate_build_matrix.py
@@ -58,6 +58,9 @@ def get_torchaudio_version(torch_version):
         return "2.0.1"
     elif torch_version == "2.0.1":
         return "2.0.2"
+    elif version_ge(torch_version, "2.11"):
+        # torchaudio only has versions up to 2.11.0
+        return "2.11.0"
     else:
         return torch_version
 

--- a/.github/scripts/docker/generate_build_matrix.py
+++ b/.github/scripts/docker/generate_build_matrix.py
@@ -62,13 +62,32 @@ def get_torchaudio_version(torch_version):
         return torch_version
 
 
+# Latest k2 version per torch version, from https://k2-fsa.github.io/k2/cpu.html
+def get_k2_version(torch_version):
+    # torch 2.13.0 has a newer k2 build
+    if version_ge(torch_version, "2.13"):
+        return "1.24.4.dev20260710"
+    # torch 1.10.0+ through 2.12.x
+    return "1.24.4.dev20260625"
+
+
+# Latest kaldifeat version per torch version, from https://csukuangfj.github.io/kaldifeat/cpu.html
+def get_kaldifeat_version(torch_version):
+    # torch 2.13.0 has a newer kaldifeat build
+    if version_ge(torch_version, "2.13"):
+        return "1.25.5.dev20260710"
+    # torch 1.13.0+ through 2.12.x
+    if version_ge(torch_version, "1.13"):
+        return "1.25.5.dev20260626"
+    # older torch versions
+    return "1.25.5.dev20241029"
+
+
 def get_matrix(min_torch_version, specified_torch_version, specified_python_version):
-    k2_version = "1.24.4.dev20250630"
-    kaldifeat_version = "1.25.5.dev20250630"
-    version = "20250630"
+    version = "20260712"
 
     # torchaudio 2.5.0 does not support python 3.13
-    python_version = ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+    python_version = ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "3.15"]
     torch_version = []
     torch_version += ["1.13.0", "1.13.1"]
     torch_version += ["2.0.0", "2.0.1"]
@@ -81,6 +100,12 @@ def get_matrix(min_torch_version, specified_torch_version, specified_python_vers
     torch_version += ["2.5.0"]
     torch_version += ["2.5.1"]
     torch_version += ["2.6.0", "2.7.0", "2.7.1"]
+    torch_version += ["2.8.0"]
+    torch_version += ["2.9.0", "2.9.1"]
+    torch_version += ["2.10.0"]
+    torch_version += ["2.11.0"]
+    torch_version += ["2.12.0", "2.12.1"]
+    torch_version += ["2.13.0"]
 
     if specified_torch_version:
         torch_version = [specified_torch_version]
@@ -110,17 +135,32 @@ def get_matrix(min_torch_version, specified_torch_version, specified_python_vers
                 # torch>=2.5 requires python 3.10
                 continue
 
-            k2_version_2 = k2_version
-            kaldifeat_version_2 = kaldifeat_version
+            # torch>=2.9 drops python 3.9
+            if not version_gt(p, "3.9") and version_ge(t, "2.9"):
+                continue
+
+            # torch>=2.9 supports python 3.14
+            if version_gt(p, "3.13") and not version_ge(t, "2.9"):
+                continue
+
+            # only torch>=2.13.0 supports python 3.15
+            if version_gt(p, "3.14") and not version_ge(t, "2.13"):
+                continue
+
+            if version_ge(t, "2.6.0"):
+                image = "pytorch/manylinux2_28-builder:cpu"
+            else:
+                image = "pytorch/manylinux-builder:cpu-27677ead7c8293c299a885ae2c474bf445e653a5"
 
             matrix.append(
                 {
-                    "k2-version": k2_version_2,
-                    "kaldifeat-version": kaldifeat_version_2,
+                    "k2-version": get_k2_version(t),
+                    "kaldifeat-version": get_kaldifeat_version(t),
                     "version": version,
                     "python-version": p,
                     "torch-version": t,
                     "torchaudio-version": get_torchaudio_version(t),
+                    "image": image,
                 }
             )
     return matrix

--- a/.github/scripts/generate-piper-phonemize-page.py
+++ b/.github/scripts/generate-piper-phonemize-page.py
@@ -77,8 +77,64 @@ def get_v1_3_0_files():
     return ans
 
 
+def get_v1_4_1_files():
+    prefix = (
+        "https://github.com/csukuangfj/piper-phonemize/releases/download/v1.4.1/"
+    )
+    files = [
+        "piper_phonemize-1.4.1-cp314-cp314-macosx_10_14_x86_64.whl",
+        "piper_phonemize-1.4.1-cp314-cp314-macosx_11_0_arm64.whl",
+        "piper_phonemize-1.4.1-cp314-cp314-manylinux_2_31_armv7l.whl",
+        "piper_phonemize-1.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl",
+        "piper_phonemize-1.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl",
+        "piper_phonemize-1.4.1-cp314-cp314-win32.whl",
+        "piper_phonemize-1.4.1-cp313-cp313-macosx_10_14_x86_64.whl",
+        "piper_phonemize-1.4.1-cp313-cp313-macosx_11_0_arm64.whl",
+        "piper_phonemize-1.4.1-cp313-cp313-manylinux_2_31_armv7l.whl",
+        "piper_phonemize-1.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl",
+        "piper_phonemize-1.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl",
+        "piper_phonemize-1.4.1-cp313-cp313-win32.whl",
+        "piper_phonemize-1.4.1-cp312-cp312-macosx_10_14_x86_64.whl",
+        "piper_phonemize-1.4.1-cp312-cp312-macosx_11_0_arm64.whl",
+        "piper_phonemize-1.4.1-cp312-cp312-manylinux_2_31_armv7l.whl",
+        "piper_phonemize-1.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl",
+        "piper_phonemize-1.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl",
+        "piper_phonemize-1.4.1-cp312-cp312-win32.whl",
+        "piper_phonemize-1.4.1-cp311-cp311-macosx_10_14_x86_64.whl",
+        "piper_phonemize-1.4.1-cp311-cp311-macosx_11_0_arm64.whl",
+        "piper_phonemize-1.4.1-cp311-cp311-manylinux_2_31_armv7l.whl",
+        "piper_phonemize-1.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl",
+        "piper_phonemize-1.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl",
+        "piper_phonemize-1.4.1-cp311-cp311-win32.whl",
+        "piper_phonemize-1.4.1-cp310-cp310-macosx_10_14_x86_64.whl",
+        "piper_phonemize-1.4.1-cp310-cp310-macosx_11_0_arm64.whl",
+        "piper_phonemize-1.4.1-cp310-cp310-manylinux_2_31_armv7l.whl",
+        "piper_phonemize-1.4.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl",
+        "piper_phonemize-1.4.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl",
+        "piper_phonemize-1.4.1-cp310-cp310-win32.whl",
+        "piper_phonemize-1.4.1-cp39-cp39-macosx_10_14_x86_64.whl",
+        "piper_phonemize-1.4.1-cp39-cp39-macosx_11_0_arm64.whl",
+        "piper_phonemize-1.4.1-cp39-cp39-manylinux_2_31_armv7l.whl",
+        "piper_phonemize-1.4.1-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl",
+        "piper_phonemize-1.4.1-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl",
+        "piper_phonemize-1.4.1-cp39-cp39-win32.whl",
+        "piper_phonemize-1.4.1-cp38-cp38-macosx_10_14_x86_64.whl",
+        "piper_phonemize-1.4.1-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl",
+        "piper_phonemize-1.4.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
+        "piper_phonemize-1.4.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+        "piper_phonemize-1.4.1-cp38-cp38-win32.whl",
+        "piper_phonemize-1.4.1-cp37-cp37m-macosx_10_14_x86_64.whl",
+        "piper_phonemize-1.4.1-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl",
+        "piper_phonemize-1.4.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
+        "piper_phonemize-1.4.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+        "piper_phonemize-1.4.1-cp37-cp37m-win32.whl",
+    ]
+    ans = [prefix + f for f in files]
+    return ans
+
+
 def main():
-    files = get_v1_3_0_files() + get_v1_2_0_files()
+    files = get_v1_4_1_files() + get_v1_3_0_files() + get_v1_2_0_files()
 
     with open("piper_phonemize.html", "w") as f:
         for url in files:

--- a/.github/workflows/build-cpu-docker.yml
+++ b/.github/workflows/build-cpu-docker.yml
@@ -62,17 +62,9 @@ jobs:
           cd .github/scripts/docker
           torch_version=${{ matrix.torch-version }}
           torchaudio_version=${{ matrix.torchaudio-version }}
-          python_version=${{ matrix.python-version }}
 
           echo "torch_version: $torch_version"
           echo "torchaudio_version: $torchaudio_version"
-          echo "python_version: $python_version"
-
-          # Extract major and minor Python version numbers
-          python_major=$(echo "$python_version" | cut -d. -f1)
-          python_minor=$(echo "$python_version" | cut -d. -f2)
-          echo "python_major: $python_major"
-          echo "python_minor: $python_minor"
 
           version=${{ matrix.version }}
 
@@ -81,10 +73,7 @@ jobs:
 
           docker build \
             -t $tag \
-            --build-arg BASE_IMAGE=${{ matrix.image }} \
-            --build-arg PYTHON_VERSION=$python_version \
-            --build-arg PYTHON_MAJOR=$python_major \
-            --build-arg PYTHON_MINOR=$python_minor \
+            --build-arg PYTHON_VERSION=${{ matrix.python-version }} \
             --build-arg TORCH_VERSION=$torch_version \
             --build-arg TORCHAUDIO_VERSION=$torchaudio_version \
             --build-arg K2_VERSION=${{ matrix.k2-version }} \

--- a/.github/workflows/build-cpu-docker.yml
+++ b/.github/workflows/build-cpu-docker.yml
@@ -1,5 +1,8 @@
 name: build-cpu-docker
 on:
+  push:
+    branches:
+      - docker-cpu
   workflow_dispatch:
 
 concurrency:
@@ -59,9 +62,17 @@ jobs:
           cd .github/scripts/docker
           torch_version=${{ matrix.torch-version }}
           torchaudio_version=${{ matrix.torchaudio-version }}
+          python_version=${{ matrix.python-version }}
 
           echo "torch_version: $torch_version"
           echo "torchaudio_version: $torchaudio_version"
+          echo "python_version: $python_version"
+
+          # Extract major and minor Python version numbers
+          python_major=$(echo "$python_version" | cut -d. -f1)
+          python_minor=$(echo "$python_version" | cut -d. -f2)
+          echo "python_major: $python_major"
+          echo "python_minor: $python_minor"
 
           version=${{ matrix.version }}
 
@@ -70,7 +81,10 @@ jobs:
 
           docker build \
             -t $tag \
-            --build-arg PYTHON_VERSION=${{ matrix.python-version }} \
+            --build-arg BASE_IMAGE=${{ matrix.image }} \
+            --build-arg PYTHON_VERSION=$python_version \
+            --build-arg PYTHON_MAJOR=$python_major \
+            --build-arg PYTHON_MINOR=$python_minor \
             --build-arg TORCH_VERSION=$torch_version \
             --build-arg TORCHAUDIO_VERSION=$torchaudio_version \
             --build-arg K2_VERSION=${{ matrix.k2-version }} \


### PR DESCRIPTION
See https://github.com/k2-fsa/icefall/pkgs/container/icefall

<img width="1964" height="1704" alt="Screenshot 2026-07-14 at 19 26 24" src="https://github.com/user-attachments/assets/6ada1248-1827-4961-9f39-8ea21929318c" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for newer Python versions, including Python 3.13–3.15.
  - Expanded compatibility with newer PyTorch, Torchaudio, K2, and Kaldifeat releases.
  - Added downloadable piper-phonemize 1.4.1 packages for supported platforms.

- **Build & Reliability**
  - Updated container builds to use Python 3.10 and newer audio and machine-learning components.
  - Added automatic CPU container builds when changes are pushed to the Docker CPU branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->