### PR TITLE
Fix CI failures about yesno and gigaspeech

### DIFF
--- a/.github/scripts/docker/Dockerfile
+++ b/.github/scripts/docker/Dockerfile
@@ -42,6 +42,7 @@ RUN pip install --no-cache-dir \
       diffusers \
       dill \
       lilcom \
+      torchcodec \
       espnet_tts_frontend \
       graphviz \
       kaldi-decoder \

--- a/.github/scripts/docker/Dockerfile
+++ b/.github/scripts/docker/Dockerfile
@@ -71,7 +71,8 @@ RUN pip install --no-cache-dir \
 ARG TORCHCODEC_VERSION=""
 RUN if [ -n "${TORCHCODEC_VERSION}" ]; then \
       pip install --no-cache-dir torchcodec==${TORCHCODEC_VERSION}+cpu -f https://download.pytorch.org/whl/torchcodec; \
-    fi
+    fi && \
+    ldconfig
 
 # RUN git clone https://github.com/k2-fsa/icefall /workspace/icefall && \
 #     cd /workspace/icefall && \

--- a/.github/scripts/docker/Dockerfile
+++ b/.github/scripts/docker/Dockerfile
@@ -54,6 +54,7 @@ RUN pip install --no-cache-dir \
       numba \
       "numpy<2.0" \
       onnxoptimizer \
+      onnxscript \
       onnxsim \
       onnx \
       onnxmltools \

--- a/.github/scripts/docker/Dockerfile
+++ b/.github/scripts/docker/Dockerfile
@@ -42,7 +42,6 @@ RUN pip install --no-cache-dir \
       diffusers \
       dill \
       lilcom \
-      torchcodec \
       espnet_tts_frontend \
       graphviz \
       kaldi-decoder \
@@ -68,6 +67,11 @@ RUN pip install --no-cache-dir \
       six \
       tensorboard \
       typeguard
+
+# Install torchcodec (CPU version) only for torch >= 2.9.0
+RUN if python3 -c "import torch; v=torch.__version__.split('.'); exit(0 if (int(v[0]),int(v[1])) >= (2,9) else 1)"; then \
+      pip install --no-cache-dir torchcodec==0.14.0+cpu -f https://download.pytorch.org/whl/torchcodec; \
+    fi
 
 # RUN git clone https://github.com/k2-fsa/icefall /workspace/icefall && \
 #     cd /workspace/icefall && \

--- a/.github/scripts/docker/Dockerfile
+++ b/.github/scripts/docker/Dockerfile
@@ -70,7 +70,7 @@ RUN pip install --no-cache-dir \
 
 ARG TORCHCODEC_VERSION=""
 RUN if [ -n "${TORCHCODEC_VERSION}" ]; then \
-      pip install --no-cache-dir torchcodec==${TORCHCODEC_VERSION}+cpu -f https://download.pytorch.org/whl/torchcodec; \
+      pip install --no-cache-dir torchcodec==${TORCHCODEC_VERSION} -f https://download.pytorch.org/whl/torchcodec; \
     fi && \
     ldconfig
 

--- a/.github/scripts/docker/Dockerfile
+++ b/.github/scripts/docker/Dockerfile
@@ -70,7 +70,7 @@ RUN pip install --no-cache-dir \
 
 ARG TORCHCODEC_VERSION=""
 RUN if [ -n "${TORCHCODEC_VERSION}" ]; then \
-      pip install --no-cache-dir torchcodec==${TORCHCODEC_VERSION} -f https://download.pytorch.org/whl/torchcodec; \
+      pip install --no-cache-dir torchcodec==${TORCHCODEC_VERSION} --index-url=https://download.pytorch.org/whl/cpu; \
     fi && \
     ldconfig
 

--- a/.github/scripts/docker/Dockerfile
+++ b/.github/scripts/docker/Dockerfile
@@ -41,6 +41,7 @@ RUN pip install --no-cache-dir \
       cython \
       diffusers \
       dill \
+      lilcom \
       espnet_tts_frontend \
       graphviz \
       kaldi-decoder \

--- a/.github/scripts/docker/Dockerfile
+++ b/.github/scripts/docker/Dockerfile
@@ -68,9 +68,9 @@ RUN pip install --no-cache-dir \
       tensorboard \
       typeguard
 
-# Install torchcodec (CPU version) only for torch >= 2.9.0
-RUN if python3 -c "import torch; v=torch.__version__.split('.'); exit(0 if (int(v[0]),int(v[1])) >= (2,9) else 1)"; then \
-      pip install --no-cache-dir torchcodec==0.14.0+cpu -f https://download.pytorch.org/whl/torchcodec; \
+ARG TORCHCODEC_VERSION=""
+RUN if [ -n "${TORCHCODEC_VERSION}" ]; then \
+      pip install --no-cache-dir torchcodec==${TORCHCODEC_VERSION}+cpu -f https://download.pytorch.org/whl/torchcodec; \
     fi
 
 # RUN git clone https://github.com/k2-fsa/icefall /workspace/icefall && \

--- a/.github/scripts/docker/generate_build_matrix.py
+++ b/.github/scripts/docker/generate_build_matrix.py
@@ -86,8 +86,22 @@ def get_kaldifeat_version(torch_version):
     return "1.25.5.dev20241029"
 
 
+# torchcodec version per torch version, from
+# https://github.com/meta-pytorch/torchcodec#installing-torchcodec
+def get_torchcodec_version(torch_version):
+    if version_ge(torch_version, "2.12"):
+        return "0.14.0"
+    if version_ge(torch_version, "2.11"):
+        return "0.11.0"
+    if version_ge(torch_version, "2.10"):
+        return "0.10.0"
+    if version_ge(torch_version, "2.9"):
+        return "0.9.0"
+    return ""
+
+
 def get_matrix(min_torch_version, specified_torch_version, specified_python_version):
-    version = "20260712"
+    version = "20260715"
 
     # torchaudio 2.5.0 does not support python 3.13
     python_version = ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "3.15"]
@@ -154,6 +168,7 @@ def get_matrix(min_torch_version, specified_torch_version, specified_python_vers
                 {
                     "k2-version": get_k2_version(t),
                     "kaldifeat-version": get_kaldifeat_version(t),
+                    "torchcodec-version": get_torchcodec_version(t),
                     "version": version,
                     "python-version": p,
                     "torch-version": t,

--- a/.github/scripts/docker/generate_build_matrix.py
+++ b/.github/scripts/docker/generate_build_matrix.py
@@ -117,9 +117,11 @@ def get_matrix(min_torch_version, specified_torch_version, specified_python_vers
     torch_version += ["2.8.0"]
     torch_version += ["2.9.0", "2.9.1"]
     torch_version += ["2.10.0"]
-    torch_version += ["2.11.0"]
-    torch_version += ["2.12.0", "2.12.1"]
-    torch_version += ["2.13.0"]
+    #  torch_version += ["2.11.0"]
+    #  torch_version += ["2.12.0", "2.12.1"]
+    #  torch_version += ["2.13.0"]
+
+    min_torch_version = "2.9.0"
 
     if specified_torch_version:
         torch_version = [specified_torch_version]

--- a/.github/scripts/docker/generate_build_matrix.py
+++ b/.github/scripts/docker/generate_build_matrix.py
@@ -117,11 +117,9 @@ def get_matrix(min_torch_version, specified_torch_version, specified_python_vers
     torch_version += ["2.8.0"]
     torch_version += ["2.9.0", "2.9.1"]
     torch_version += ["2.10.0"]
-    #  torch_version += ["2.11.0"]
-    #  torch_version += ["2.12.0", "2.12.1"]
-    #  torch_version += ["2.13.0"]
-
-    min_torch_version = "2.9.0"
+    torch_version += ["2.11.0"]
+    torch_version += ["2.12.0", "2.12.1"]
+    torch_version += ["2.13.0"]
 
     if specified_torch_version:
         torch_version = [specified_torch_version]

--- a/.github/scripts/docker/generate_build_matrix.py
+++ b/.github/scripts/docker/generate_build_matrix.py
@@ -88,11 +88,12 @@ def get_kaldifeat_version(torch_version):
 
 # torchcodec version per torch version, from
 # https://github.com/meta-pytorch/torchcodec#installing-torchcodec
+# Note: +cpu suffix only exists for torchcodec >= 0.11.0
 def get_torchcodec_version(torch_version):
     if version_ge(torch_version, "2.12"):
-        return "0.14.0"
+        return "0.14.0+cpu"
     if version_ge(torch_version, "2.11"):
-        return "0.11.0"
+        return "0.11.0+cpu"
     if version_ge(torch_version, "2.10"):
         return "0.10.0"
     if version_ge(torch_version, "2.9"):

--- a/.github/scripts/docker/generate_build_matrix.py
+++ b/.github/scripts/docker/generate_build_matrix.py
@@ -88,16 +88,12 @@ def get_kaldifeat_version(torch_version):
 
 # torchcodec version per torch version, from
 # https://github.com/meta-pytorch/torchcodec#installing-torchcodec
-# Note: +cpu suffix only exists for torchcodec >= 0.11.0
+# Uses --index-url=https://download.pytorch.org/whl/cpu for CPU-only wheels
 def get_torchcodec_version(torch_version):
     if version_ge(torch_version, "2.12"):
-        return "0.14.0+cpu"
+        return "0.14.0"
     if version_ge(torch_version, "2.11"):
-        return "0.11.0+cpu"
-    if version_ge(torch_version, "2.10"):
-        return "0.10.0"
-    if version_ge(torch_version, "2.9"):
-        return "0.9.0"
+        return "0.11.0"
     return ""
 
 

--- a/.github/scripts/docker/notes.md
+++ b/.github/scripts/docker/notes.md
@@ -1,0 +1,8 @@
+# torchcodec
+```
+ImportError: TorchCodec is required for load_with_torchcodec. Please install torchcodec to use this function.
+```
+
+From torch >= 2.9.0, we need to also install torchcodec
+
+

--- a/.github/scripts/run-gigaspeech-pruned-transducer-stateless2-2022-05-12.sh
+++ b/.github/scripts/run-gigaspeech-pruned-transducer-stateless2-2022-05-12.sh
@@ -19,6 +19,17 @@ repo=$(basename $repo_url)
 
 echo "GITHUB_EVENT_NAME: ${GITHUB_EVENT_NAME}"
 echo "GITHUB_EVENT_LABEL_NAME: ${GITHUB_EVENT_LABEL_NAME}"
+
+# Only run the expensive decode step for torch >= 2.13.0
+torch_version=$(python3 -c "import torch; print(torch.__version__.split('+')[0])")
+log "torch version: $torch_version"
+if python3 -c "import sys; v='$torch_version'.split('.'); sys.exit(0 if (int(v[0]),int(v[1])) >= (2,13) else 1)"; then
+  log "torch >= 2.13.0, running decode step"
+else
+  log "torch < 2.13.0, skipping decode step"
+  exit 0
+fi
+
 if [[ x"${GITHUB_EVENT_NAME}" == x"schedule" || x"${GITHUB_EVENT_NAME}" == x"workflow_dispatch" || x"${GITHUB_EVENT_LABEL_NAME}" == x"run-decode"  ]]; then
   mkdir -p pruned_transducer_stateless2/exp
   ln -s $PWD/$repo/exp/pretrained-iter-3488000-avg-20.pt pruned_transducer_stateless2/exp/epoch-999.pt

--- a/.github/scripts/run-gigaspeech-pruned-transducer-stateless2-2022-05-12.sh
+++ b/.github/scripts/run-gigaspeech-pruned-transducer-stateless2-2022-05-12.sh
@@ -32,6 +32,7 @@ fi
 
 if [[ x"${GITHUB_EVENT_NAME}" == x"schedule" || x"${GITHUB_EVENT_NAME}" == x"workflow_dispatch" || x"${GITHUB_EVENT_LABEL_NAME}" == x"run-decode"  ]]; then
   mkdir -p pruned_transducer_stateless2/exp
+  mkdir -p data
   ln -s $PWD/$repo/exp/pretrained-iter-3488000-avg-20.pt pruned_transducer_stateless2/exp/epoch-999.pt
   ln -s $PWD/$repo/data/lang_bpe_500 data/
 

--- a/.github/scripts/run-gigaspeech-pruned-transducer-stateless2-2022-05-12.sh
+++ b/.github/scripts/run-gigaspeech-pruned-transducer-stateless2-2022-05-12.sh
@@ -32,7 +32,7 @@ fi
 
 if [[ x"${GITHUB_EVENT_NAME}" == x"schedule" || x"${GITHUB_EVENT_NAME}" == x"workflow_dispatch" || x"${GITHUB_EVENT_LABEL_NAME}" == x"run-decode"  ]]; then
   mkdir -p pruned_transducer_stateless2/exp
-  mkdir -p data
+  mkdir -p data/fbank
   ln -s $PWD/$repo/exp/pretrained-iter-3488000-avg-20.pt pruned_transducer_stateless2/exp/epoch-999.pt
   ln -s $PWD/$repo/data/lang_bpe_500 data/
 

--- a/.github/scripts/run-gigaspeech-zipformer-2023-10-17.sh
+++ b/.github/scripts/run-gigaspeech-zipformer-2023-10-17.sh
@@ -129,6 +129,17 @@ done
 
 echo "GITHUB_EVENT_NAME: ${GITHUB_EVENT_NAME}"
 echo "GITHUB_EVENT_LABEL_NAME: ${GITHUB_EVENT_LABEL_NAME}"
+
+# Only run the expensive decode step for torch >= 2.13.0
+torch_version=$(python3 -c "import torch; print(torch.__version__.split('+')[0])")
+log "torch version: $torch_version"
+if python3 -c "import sys; v='$torch_version'.split('.'); sys.exit(0 if (int(v[0]),int(v[1])) >= (2,13) else 1)"; then
+  log "torch >= 2.13.0, running decode step"
+else
+  log "torch < 2.13.0, skipping decode step"
+  exit 0
+fi
+
 if [[ x"${GITHUB_EVENT_NAME}" == x"schedule" || x"${GITHUB_EVENT_NAME}" == x"workflow_dispatch" || x"${GITHUB_EVENT_LABEL_NAME}" == x"run-decode"  ]]; then
   mkdir -p zipformer/exp
   ln -s $PWD/$repo/exp/pretrained.pt zipformer/exp/epoch-30.pt

--- a/.github/scripts/run-gigaspeech-zipformer-2023-10-17.sh
+++ b/.github/scripts/run-gigaspeech-zipformer-2023-10-17.sh
@@ -160,6 +160,7 @@ if [[ x"${GITHUB_EVENT_NAME}" == x"schedule" || x"${GITHUB_EVENT_NAME}" == x"wor
     log "Decoding with $method"
 
     ./zipformer/decode.py \
+      --on-the-fly-feats False \
       --decoding-method $method \
       --epoch 30 \
       --avg 1 \

--- a/.github/workflows/aishell.yml
+++ b/.github/workflows/aishell.yml
@@ -69,6 +69,7 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
-              python3 -m pip install onnxscript lilcom torchcodec
+              python3 -m pip install onnxscript lilcom
+              python3 -c "import torch; v=torch.__version__.split('.'); exit(0 if (int(v[0]),int(v[1])) >= (2,9) else 1)" && python3 -m pip install torchcodec==0.14.0+cpu -f https://download.pytorch.org/whl/torchcodec || true
 
               .github/scripts/aishell/ASR/run.sh

--- a/.github/workflows/aishell.yml
+++ b/.github/workflows/aishell.yml
@@ -69,7 +69,4 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
-              python3 -m pip install onnxscript lilcom
-              python3 -c "import torch; v=torch.__version__.split('.'); exit(0 if (int(v[0]),int(v[1])) >= (2,9) else 1)" && python3 -m pip install torchcodec==0.14.0+cpu -f https://download.pytorch.org/whl/torchcodec || true
-
               .github/scripts/aishell/ASR/run.sh

--- a/.github/workflows/aishell.yml
+++ b/.github/workflows/aishell.yml
@@ -63,6 +63,7 @@ jobs:
             image: ghcr.io/${{ github.repository_owner }}/icefall:cpu-py${{ matrix.python-version }}-torch${{ matrix.torch-version }}-v${{ matrix.version }}
             options: |
               --volume ${{ github.workspace }}/:/icefall
+              -e TORCHAUDIO_USE_BACKEND=soundfile
             shell: bash
             run: |
               export PYTHONPATH=/icefall:$PYTHONPATH

--- a/.github/workflows/aishell.yml
+++ b/.github/workflows/aishell.yml
@@ -31,8 +31,8 @@ jobs:
         id: set-matrix
         run: |
           # outputting for debugging purposes
-          python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10"
-          MATRIX=$(python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10")
+          python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10" --min-torch-version "2.2.0"
+          MATRIX=$(python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10" --min-torch-version "2.2.0")
           echo "::set-output name=matrix::${MATRIX}"
   aishell:
     needs: generate_build_matrix

--- a/.github/workflows/aishell.yml
+++ b/.github/workflows/aishell.yml
@@ -69,6 +69,6 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
-              python3 -m pip install onnxscript lilcom
+              python3 -m pip install onnxscript lilcom torchcodec
 
               .github/scripts/aishell/ASR/run.sh

--- a/.github/workflows/aishell.yml
+++ b/.github/workflows/aishell.yml
@@ -69,4 +69,6 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
+              python3 -m pip install onnxscript lilcom
+
               .github/scripts/aishell/ASR/run.sh

--- a/.github/workflows/audioset.yml
+++ b/.github/workflows/audioset.yml
@@ -64,6 +64,7 @@ jobs:
             image: ghcr.io/${{ github.repository_owner }}/icefall:cpu-py${{ matrix.python-version }}-torch${{ matrix.torch-version }}-v${{ matrix.version }}
             options: |
               --volume ${{ github.workspace }}/:/icefall
+              -e TORCHAUDIO_USE_BACKEND=soundfile
             shell: bash
             run: |
               export PYTHONPATH=/icefall:$PYTHONPATH

--- a/.github/workflows/audioset.yml
+++ b/.github/workflows/audioset.yml
@@ -30,8 +30,8 @@ jobs:
         id: set-matrix
         run: |
           # outputting for debugging purposes
-          python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10"
-          MATRIX=$(python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10")
+          python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10" --min-torch-version "2.2.0"
+          MATRIX=$(python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10" --min-torch-version "2.2.0")
           echo "::set-output name=matrix::${MATRIX}"
 
   audioset:
@@ -83,7 +83,7 @@ jobs:
           ls -lh ./model-onnx/*
 
       - name: Upload model to huggingface
-        if: matrix.python-version == '3.10' && matrix.torch-version == '2.3.0' && github.event_name == 'push'
+        if: matrix.python-version == '3.10' && matrix.torch-version == '2.13.0' && github.event_name == 'push'
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         uses: nick-fields/retry@v3
@@ -116,7 +116,7 @@ jobs:
             rm -rf huggingface
 
       - name: Prepare for release
-        if: matrix.python-version == '3.10' && matrix.torch-version == '2.3.0' && github.event_name == 'push'
+        if: matrix.python-version == '3.10' && matrix.torch-version == '2.13.0' && github.event_name == 'push'
         shell: bash
         run: |
           d=sherpa-onnx-zipformer-audio-tagging-2024-04-09
@@ -125,7 +125,7 @@ jobs:
           ls -lh
 
       - name: Release exported onnx models
-        if: matrix.python-version == '3.10' && matrix.torch-version == '2.3.0' && github.event_name == 'push'
+        if: matrix.python-version == '3.10' && matrix.torch-version == '2.13.0' && github.event_name == 'push'
         uses: svenstaro/upload-release-action@v2
         with:
           file_glob: true

--- a/.github/workflows/audioset.yml
+++ b/.github/workflows/audioset.yml
@@ -70,7 +70,8 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
-              python3 -m pip install onnxscript lilcom torchcodec
+              python3 -m pip install onnxscript lilcom
+              python3 -c "import torch; v=torch.__version__.split('.'); exit(0 if (int(v[0]),int(v[1])) >= (2,9) else 1)" && python3 -m pip install torchcodec==0.14.0+cpu -f https://download.pytorch.org/whl/torchcodec || true
 
               .github/scripts/audioset/AT/run.sh
 

--- a/.github/workflows/audioset.yml
+++ b/.github/workflows/audioset.yml
@@ -70,9 +70,6 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
-              python3 -m pip install onnxscript lilcom
-              python3 -c "import torch; v=torch.__version__.split('.'); exit(0 if (int(v[0]),int(v[1])) >= (2,9) else 1)" && python3 -m pip install torchcodec==0.14.0+cpu -f https://download.pytorch.org/whl/torchcodec || true
-
               .github/scripts/audioset/AT/run.sh
 
       - name: Show model files

--- a/.github/workflows/audioset.yml
+++ b/.github/workflows/audioset.yml
@@ -70,7 +70,7 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
-              python3 -m pip install onnxscript lilcom
+              python3 -m pip install onnxscript lilcom torchcodec
 
               .github/scripts/audioset/AT/run.sh
 

--- a/.github/workflows/audioset.yml
+++ b/.github/workflows/audioset.yml
@@ -70,6 +70,8 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
+              python3 -m pip install onnxscript lilcom
+
               .github/scripts/audioset/AT/run.sh
 
       - name: Show model files

--- a/.github/workflows/baker_zh.yml
+++ b/.github/workflows/baker_zh.yml
@@ -31,8 +31,8 @@ jobs:
         id: set-matrix
         run: |
           # outputting for debugging purposes
-          python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10"
-          MATRIX=$(python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10")
+          python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10" --min-torch-version "2.2.0"
+          MATRIX=$(python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10" --min-torch-version "2.2.0")
           echo "::set-output name=matrix::${MATRIX}"
 
   baker_zh:
@@ -84,43 +84,43 @@ jobs:
           ls -lh
 
       - uses: actions/upload-artifact@v4
-        if: matrix.python-version == '3.10' && matrix.torch-version == '2.3.0'
+        if: matrix.python-version == '3.10' && matrix.torch-version == '2.13.0'
         with:
           name: generated-test-files-${{ matrix.python-version }}-${{ matrix.torch-version }}
           path: ./*.wav
 
       - uses: actions/upload-artifact@v4
-        if: matrix.python-version == '3.10' && matrix.torch-version == '2.3.0'
+        if: matrix.python-version == '3.10' && matrix.torch-version == '2.13.0'
         with:
           name: step-2
           path: ./model-steps-2.onnx
 
       - uses: actions/upload-artifact@v4
-        if: matrix.python-version == '3.10' && matrix.torch-version == '2.3.0'
+        if: matrix.python-version == '3.10' && matrix.torch-version == '2.13.0'
         with:
           name: step-3
           path: ./model-steps-3.onnx
 
       - uses: actions/upload-artifact@v4
-        if: matrix.python-version == '3.10' && matrix.torch-version == '2.3.0'
+        if: matrix.python-version == '3.10' && matrix.torch-version == '2.13.0'
         with:
           name: step-4
           path: ./model-steps-4.onnx
 
       - uses: actions/upload-artifact@v4
-        if: matrix.python-version == '3.10' && matrix.torch-version == '2.3.0'
+        if: matrix.python-version == '3.10' && matrix.torch-version == '2.13.0'
         with:
           name: step-5
           path: ./model-steps-5.onnx
 
       - uses: actions/upload-artifact@v4
-        if: matrix.python-version == '3.10' && matrix.torch-version == '2.3.0'
+        if: matrix.python-version == '3.10' && matrix.torch-version == '2.13.0'
         with:
           name: step-6
           path: ./model-steps-6.onnx
 
       - name: Upload models to huggingface
-        if: matrix.python-version == '3.10' && matrix.torch-version == '2.3.0' && github.event_name == 'push'
+        if: matrix.python-version == '3.10' && matrix.torch-version == '2.13.0' && github.event_name == 'push'
         shell: bash
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
@@ -141,7 +141,7 @@ jobs:
           popd
 
       - name: Release exported onnx models
-        if: matrix.python-version == '3.10' && matrix.torch-version == '2.3.0' && github.event_name == 'push'
+        if: matrix.python-version == '3.10' && matrix.torch-version == '2.13.0' && github.event_name == 'push'
         uses: svenstaro/upload-release-action@v2
         with:
           file_glob: true

--- a/.github/workflows/baker_zh.yml
+++ b/.github/workflows/baker_zh.yml
@@ -65,6 +65,7 @@ jobs:
             image: ghcr.io/${{ github.repository_owner }}/icefall:cpu-py${{ matrix.python-version }}-torch${{ matrix.torch-version }}-v${{ matrix.version }}
             options: |
               --volume ${{ github.workspace }}/:/icefall
+              -e TORCHAUDIO_USE_BACKEND=soundfile
             shell: bash
             run: |
               export PYTHONPATH=/icefall:$PYTHONPATH

--- a/.github/workflows/baker_zh.yml
+++ b/.github/workflows/baker_zh.yml
@@ -76,7 +76,7 @@ jobs:
 
               git config --global --add safe.directory /icefall
 
-              python3 -m pip install onnxscript lilcom
+              python3 -m pip install onnxscript lilcom torchcodec
 
               .github/scripts/baker_zh/TTS/run-matcha.sh
 

--- a/.github/workflows/baker_zh.yml
+++ b/.github/workflows/baker_zh.yml
@@ -76,7 +76,8 @@ jobs:
 
               git config --global --add safe.directory /icefall
 
-              python3 -m pip install onnxscript lilcom torchcodec
+              python3 -m pip install onnxscript lilcom
+              python3 -c "import torch; v=torch.__version__.split('.'); exit(0 if (int(v[0]),int(v[1])) >= (2,9) else 1)" && python3 -m pip install torchcodec==0.14.0+cpu -f https://download.pytorch.org/whl/torchcodec || true
 
               .github/scripts/baker_zh/TTS/run-matcha.sh
 

--- a/.github/workflows/baker_zh.yml
+++ b/.github/workflows/baker_zh.yml
@@ -76,9 +76,6 @@ jobs:
 
               git config --global --add safe.directory /icefall
 
-              python3 -m pip install onnxscript lilcom
-              python3 -c "import torch; v=torch.__version__.split('.'); exit(0 if (int(v[0]),int(v[1])) >= (2,9) else 1)" && python3 -m pip install torchcodec==0.14.0+cpu -f https://download.pytorch.org/whl/torchcodec || true
-
               .github/scripts/baker_zh/TTS/run-matcha.sh
 
       - name: display files

--- a/.github/workflows/baker_zh.yml
+++ b/.github/workflows/baker_zh.yml
@@ -76,6 +76,8 @@ jobs:
 
               git config --global --add safe.directory /icefall
 
+              python3 -m pip install onnxscript lilcom
+
               .github/scripts/baker_zh/TTS/run-matcha.sh
 
       - name: display files

--- a/.github/workflows/build-cpu-docker.yml
+++ b/.github/workflows/build-cpu-docker.yml
@@ -50,7 +50,7 @@ jobs:
           df -h
 
       - name: 'Login to GitHub Container Registry'
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/build-cpu-docker.yml
+++ b/.github/workflows/build-cpu-docker.yml
@@ -78,6 +78,7 @@ jobs:
             --build-arg TORCHAUDIO_VERSION=$torchaudio_version \
             --build-arg K2_VERSION=${{ matrix.k2-version }} \
             --build-arg KALDIFEAT_VERSION=${{ matrix.kaldifeat-version }} \
+            --build-arg TORCHCODEC_VERSION=${{ matrix.torchcodec-version }} \
             .
 
           docker image ls

--- a/.github/workflows/build-cpu-docker.yml
+++ b/.github/workflows/build-cpu-docker.yml
@@ -24,8 +24,8 @@ jobs:
         id: set-matrix
         run: |
           # outputting for debugging purposes
-          python ./.github/scripts/docker/generate_build_matrix.py
-          MATRIX=$(python ./.github/scripts/docker/generate_build_matrix.py)
+          python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10"
+          MATRIX=$(python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10")
           echo "::set-output name=matrix::${MATRIX}"
   build-cpu-docker:
     needs: generate_build_matrix

--- a/.github/workflows/build-doc.yml
+++ b/.github/workflows/build-doc.yml
@@ -48,7 +48,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       # refer to https://github.com/actions/checkout
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -70,7 +70,7 @@ jobs:
           df -h
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/ksponspeech.yml
+++ b/.github/workflows/ksponspeech.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Cache kaldifeat
         id: my-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/tmp/kaldifeat

--- a/.github/workflows/ksponspeech.yml
+++ b/.github/workflows/ksponspeech.yml
@@ -51,9 +51,6 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
-              python3 -m pip install onnxscript lilcom
-              python3 -c "import torch; v=torch.__version__.split('.'); exit(0 if (int(v[0]),int(v[1])) >= (2,9) else 1)" && python3 -m pip install torchcodec==0.14.0+cpu -f https://download.pytorch.org/whl/torchcodec || true
-
               python3 -m torch.utils.collect_env
               python3 -m k2.version
               pip list

--- a/.github/workflows/ksponspeech.yml
+++ b/.github/workflows/ksponspeech.yml
@@ -51,6 +51,8 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
+              python3 -m pip install onnxscript lilcom
+
               python3 -m torch.utils.collect_env
               python3 -m k2.version
               pip list

--- a/.github/workflows/ksponspeech.yml
+++ b/.github/workflows/ksponspeech.yml
@@ -44,6 +44,7 @@ jobs:
             image: ghcr.io/${{ github.repository_owner }}/icefall:cpu-py${{ matrix.python-version }}-torch${{ matrix.torch-version }}-v${{ matrix.version }}
             options: |
               --volume ${{ github.workspace }}/:/icefall
+              -e TORCHAUDIO_USE_BACKEND=soundfile
               -e HF_TOKEN=${{ secrets.HF_TOKEN }}
             shell: bash
             run: |

--- a/.github/workflows/ksponspeech.yml
+++ b/.github/workflows/ksponspeech.yml
@@ -20,8 +20,8 @@ jobs:
       - name: Generating build matrix
         id: set-matrix
         run: |
-          python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10"
-          MATRIX=$(python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10")
+          python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10" --min-torch-version "2.2.0"
+          MATRIX=$(python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10" --min-torch-version "2.2.0")
           echo "::set-output name=matrix::${MATRIX}"
 
   ksponspeech:
@@ -70,6 +70,7 @@ jobs:
           ls -lh $src
 
       - name: Upload model to huggingface (2024-06-24)
+        if: matrix.torch-version == '2.13.0'
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         uses: nick-fields/retry@v3
@@ -104,6 +105,7 @@ jobs:
             rm -rf hf
 
       - name: Upload model to huggingface (2024-06-16)
+        if: matrix.torch-version == '2.13.0'
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         uses: nick-fields/retry@v3
@@ -139,6 +141,7 @@ jobs:
             rm -rf hf
 
       - name: Prepare for release (2024-06-16)
+        if: matrix.torch-version == '2.13.0'
         shell: bash
         run: |
           src=/tmp/model-2024-06-16
@@ -148,6 +151,7 @@ jobs:
           ls -lh
 
       - name: Prepare for release (2024-06-24)
+        if: matrix.torch-version == '2.13.0'
         shell: bash
         run: |
           src=/tmp/model-2024-06-24
@@ -157,6 +161,7 @@ jobs:
           ls -lh
 
       - name: Release exported onnx models
+        if: matrix.torch-version == '2.13.0'
         uses: svenstaro/upload-release-action@v2
         with:
           file_glob: true

--- a/.github/workflows/ksponspeech.yml
+++ b/.github/workflows/ksponspeech.yml
@@ -8,54 +8,54 @@ on:
   workflow_dispatch:
 
 jobs:
+  generate_build_matrix:
+    if: github.repository_owner == 'csukuangfj' || github.repository_owner == 'k2-fsa'
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Generating build matrix
+        id: set-matrix
+        run: |
+          python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10"
+          MATRIX=$(python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10")
+          echo "::set-output name=matrix::${MATRIX}"
+
   ksponspeech:
-    runs-on: ${{ matrix.os }}
+    needs: generate_build_matrix
+    name: py${{ matrix.python-version }} torch${{ matrix.torch-version }} v${{ matrix.version }}
+    runs-on: ubuntu-latest
     strategy:
-      matrix:
-        os: [ubuntu-latest]
-        python-version: [3.8]
       fail-fast: false
+      matrix:
+        ${{ fromJson(needs.generate_build_matrix.outputs.matrix) }}
 
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: 'pip'
-          cache-dependency-path: '**/requirements-ci.txt'
-
-      - name: Install Python dependencies
-        run: |
-          grep -v '^#' ./requirements-ci.txt  | xargs -n 1 -L 1 pip install
-          pip uninstall -y protobuf
-          pip install --no-binary protobuf protobuf==3.20.*
-
-      - name: Cache kaldifeat
-        id: my-cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/tmp/kaldifeat
-          key: cache-tmp-${{ matrix.python-version }}-2023-05-22
-
-      - name: Install kaldifeat
-        if: steps.my-cache.outputs.cache-hit != 'true'
-        shell: bash
-        run: |
-          .github/scripts/install-kaldifeat.sh
-
       - name: Test
-        shell: bash
-        run: |
-          export PYTHONPATH=$PWD:$PYTHONPATH
-          export PYTHONPATH=~/tmp/kaldifeat/kaldifeat/python:$PYTHONPATH
-          export PYTHONPATH=~/tmp/kaldifeat/build/lib:$PYTHONPATH
+        uses: addnab/docker-run-action@v3
+        with:
+            image: ghcr.io/${{ github.repository_owner }}/icefall:cpu-py${{ matrix.python-version }}-torch${{ matrix.torch-version }}-v${{ matrix.version }}
+            options: |
+              --volume ${{ github.workspace }}/:/icefall
+              -e HF_TOKEN=${{ secrets.HF_TOKEN }}
+            shell: bash
+            run: |
+              export PYTHONPATH=/icefall:$PYTHONPATH
+              cd /icefall
+              git config --global --add safe.directory /icefall
 
-          .github/scripts/ksponspeech/ASR/run.sh
+              python3 -m torch.utils.collect_env
+              python3 -m k2.version
+              pip list
+
+              .github/scripts/ksponspeech/ASR/run.sh
 
       - name: Show model files (2024-06-24)
         shell: bash

--- a/.github/workflows/ksponspeech.yml
+++ b/.github/workflows/ksponspeech.yml
@@ -51,7 +51,7 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
-              python3 -m pip install onnxscript lilcom
+              python3 -m pip install onnxscript lilcom torchcodec
 
               python3 -m torch.utils.collect_env
               python3 -m k2.version

--- a/.github/workflows/ksponspeech.yml
+++ b/.github/workflows/ksponspeech.yml
@@ -51,7 +51,8 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
-              python3 -m pip install onnxscript lilcom torchcodec
+              python3 -m pip install onnxscript lilcom
+              python3 -c "import torch; v=torch.__version__.split('.'); exit(0 if (int(v[0]),int(v[1])) >= (2,9) else 1)" && python3 -m pip install torchcodec==0.14.0+cpu -f https://download.pytorch.org/whl/torchcodec || true
 
               python3 -m torch.utils.collect_env
               python3 -m k2.version

--- a/.github/workflows/librispeech.yml
+++ b/.github/workflows/librispeech.yml
@@ -69,6 +69,7 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
-              python3 -m pip install onnxscript lilcom torchcodec
+              python3 -m pip install onnxscript lilcom
+              python3 -c "import torch; v=torch.__version__.split('.'); exit(0 if (int(v[0]),int(v[1])) >= (2,9) else 1)" && python3 -m pip install torchcodec==0.14.0+cpu -f https://download.pytorch.org/whl/torchcodec || true
 
               .github/scripts/librispeech/ASR/run.sh

--- a/.github/workflows/librispeech.yml
+++ b/.github/workflows/librispeech.yml
@@ -69,4 +69,6 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
+              python3 -m pip install onnxscript lilcom
+
               .github/scripts/librispeech/ASR/run.sh

--- a/.github/workflows/librispeech.yml
+++ b/.github/workflows/librispeech.yml
@@ -63,6 +63,7 @@ jobs:
             image: ghcr.io/${{ github.repository_owner }}/icefall:cpu-py${{ matrix.python-version }}-torch${{ matrix.torch-version }}-v${{ matrix.version }}
             options: |
               --volume ${{ github.workspace }}/:/icefall
+              -e TORCHAUDIO_USE_BACKEND=soundfile
             shell: bash
             run: |
               export PYTHONPATH=/icefall:$PYTHONPATH

--- a/.github/workflows/librispeech.yml
+++ b/.github/workflows/librispeech.yml
@@ -29,9 +29,9 @@ jobs:
         id: set-matrix
         run: |
           # outputting for debugging purposes
-          python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10"
-          # MATRIX=$(python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10")
-          MATRIX=$(python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10" --min-torch-version "2.6.0")
+          python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10" --min-torch-version "2.2.0"
+          # MATRIX=$(python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10" --min-torch-version "2.2.0")
+          MATRIX=$(python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10" --min-torch-version "2.2.0" --min-torch-version "2.6.0")
           echo "::set-output name=matrix::${MATRIX}"
   librispeech:
     needs: generate_build_matrix

--- a/.github/workflows/librispeech.yml
+++ b/.github/workflows/librispeech.yml
@@ -69,7 +69,4 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
-              python3 -m pip install onnxscript lilcom
-              python3 -c "import torch; v=torch.__version__.split('.'); exit(0 if (int(v[0]),int(v[1])) >= (2,9) else 1)" && python3 -m pip install torchcodec==0.14.0+cpu -f https://download.pytorch.org/whl/torchcodec || true
-
               .github/scripts/librispeech/ASR/run.sh

--- a/.github/workflows/librispeech.yml
+++ b/.github/workflows/librispeech.yml
@@ -69,6 +69,6 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
-              python3 -m pip install onnxscript lilcom
+              python3 -m pip install onnxscript lilcom torchcodec
 
               .github/scripts/librispeech/ASR/run.sh

--- a/.github/workflows/ljspeech.yml
+++ b/.github/workflows/ljspeech.yml
@@ -64,6 +64,7 @@ jobs:
             image: ghcr.io/${{ github.repository_owner }}/icefall:cpu-py${{ matrix.python-version }}-torch${{ matrix.torch-version }}-v${{ matrix.version }}
             options: |
               --volume ${{ github.workspace }}/:/icefall
+              -e TORCHAUDIO_USE_BACKEND=soundfile
             shell: bash
             run: |
               export PYTHONPATH=/icefall:$PYTHONPATH

--- a/.github/workflows/ljspeech.yml
+++ b/.github/workflows/ljspeech.yml
@@ -30,8 +30,8 @@ jobs:
         id: set-matrix
         run: |
           # outputting for debugging purposes
-          python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10"
-          MATRIX=$(python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10")
+          python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10" --min-torch-version "2.2.0"
+          MATRIX=$(python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10" --min-torch-version "2.2.0")
           echo "::set-output name=matrix::${MATRIX}"
 
   ljspeech:
@@ -83,13 +83,13 @@ jobs:
           ls -lh
 
       - uses: actions/upload-artifact@v4
-        if: matrix.python-version == '3.10' && matrix.torch-version == '2.3.0'
+        if: matrix.python-version == '3.10' && matrix.torch-version == '2.13.0'
         with:
           name: generated-test-files-${{ matrix.python-version }}-${{ matrix.torch-version }}
           path: ./*.wav
 
       - name: Release exported onnx models
-        if: matrix.python-version == '3.10' && matrix.torch-version == '2.3.0' && github.event_name == 'push'
+        if: matrix.python-version == '3.10' && matrix.torch-version == '2.13.0' && github.event_name == 'push'
         uses: svenstaro/upload-release-action@v2
         with:
           file_glob: true
@@ -100,37 +100,37 @@ jobs:
           tag: tts-models
 
       - uses: actions/upload-artifact@v4
-        if: matrix.python-version == '3.10' && matrix.torch-version == '2.3.0'
+        if: matrix.python-version == '3.10' && matrix.torch-version == '2.13.0'
         with:
           name: step-2
           path: ./model-steps-2.onnx
 
       - uses: actions/upload-artifact@v4
-        if: matrix.python-version == '3.10' && matrix.torch-version == '2.3.0'
+        if: matrix.python-version == '3.10' && matrix.torch-version == '2.13.0'
         with:
           name: step-3
           path: ./model-steps-3.onnx
 
       - uses: actions/upload-artifact@v4
-        if: matrix.python-version == '3.10' && matrix.torch-version == '2.3.0'
+        if: matrix.python-version == '3.10' && matrix.torch-version == '2.13.0'
         with:
           name: step-4
           path: ./model-steps-4.onnx
 
       - uses: actions/upload-artifact@v4
-        if: matrix.python-version == '3.10' && matrix.torch-version == '2.3.0'
+        if: matrix.python-version == '3.10' && matrix.torch-version == '2.13.0'
         with:
           name: step-5
           path: ./model-steps-5.onnx
 
       - uses: actions/upload-artifact@v4
-        if: matrix.python-version == '3.10' && matrix.torch-version == '2.3.0'
+        if: matrix.python-version == '3.10' && matrix.torch-version == '2.13.0'
         with:
           name: step-6
           path: ./model-steps-6.onnx
 
       - name: Upload models to huggingface
-        if: matrix.python-version == '3.10' && matrix.torch-version == '2.3.0'
+        if: matrix.python-version == '3.10' && matrix.torch-version == '2.13.0'
         shell: bash
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
@@ -155,7 +155,7 @@ jobs:
           popd
 
       - name: Release exported onnx models
-        if: matrix.python-version == '3.10' && matrix.torch-version == '2.3.0'
+        if: matrix.python-version == '3.10' && matrix.torch-version == '2.13.0'
         uses: svenstaro/upload-release-action@v2
         with:
           file_glob: true

--- a/.github/workflows/ljspeech.yml
+++ b/.github/workflows/ljspeech.yml
@@ -70,9 +70,6 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
-              python3 -m pip install onnxscript lilcom
-              python3 -c "import torch; v=torch.__version__.split('.'); exit(0 if (int(v[0]),int(v[1])) >= (2,9) else 1)" && python3 -m pip install torchcodec==0.14.0+cpu -f https://download.pytorch.org/whl/torchcodec || true
-
               pip install "matplotlib<=3.9.4"
 
               pip list

--- a/.github/workflows/ljspeech.yml
+++ b/.github/workflows/ljspeech.yml
@@ -70,7 +70,7 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
-              python3 -m pip install onnxscript lilcom
+              python3 -m pip install onnxscript lilcom torchcodec
 
               pip install "matplotlib<=3.9.4"
 

--- a/.github/workflows/ljspeech.yml
+++ b/.github/workflows/ljspeech.yml
@@ -70,6 +70,8 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
+              python3 -m pip install onnxscript lilcom
+
               pip install "matplotlib<=3.9.4"
 
               pip list

--- a/.github/workflows/ljspeech.yml
+++ b/.github/workflows/ljspeech.yml
@@ -70,7 +70,8 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
-              python3 -m pip install onnxscript lilcom torchcodec
+              python3 -m pip install onnxscript lilcom
+              python3 -c "import torch; v=torch.__version__.split('.'); exit(0 if (int(v[0]),int(v[1])) >= (2,9) else 1)" && python3 -m pip install torchcodec==0.14.0+cpu -f https://download.pytorch.org/whl/torchcodec || true
 
               pip install "matplotlib<=3.9.4"
 

--- a/.github/workflows/multi-zh-hans.yml
+++ b/.github/workflows/multi-zh-hans.yml
@@ -68,7 +68,7 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
-              python3 -m pip install onnxscript lilcom
+              python3 -m pip install onnxscript lilcom torchcodec
 
               .github/scripts/multi_zh-hans/ASR/run.sh
 

--- a/.github/workflows/multi-zh-hans.yml
+++ b/.github/workflows/multi-zh-hans.yml
@@ -61,6 +61,7 @@ jobs:
             image: ghcr.io/${{ github.repository_owner }}/icefall:cpu-py${{ matrix.python-version }}-torch${{ matrix.torch-version }}-v${{ matrix.version }}
             options: |
               --volume ${{ github.workspace }}/:/icefall
+              -e TORCHAUDIO_USE_BACKEND=soundfile
             shell: bash
             run: |
               export PYTHONPATH=/icefall:$PYTHONPATH

--- a/.github/workflows/multi-zh-hans.yml
+++ b/.github/workflows/multi-zh-hans.yml
@@ -68,9 +68,6 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
-              python3 -m pip install onnxscript lilcom
-              python3 -c "import torch; v=torch.__version__.split('.'); exit(0 if (int(v[0]),int(v[1])) >= (2,9) else 1)" && python3 -m pip install torchcodec==0.14.0+cpu -f https://download.pytorch.org/whl/torchcodec || true
-
               .github/scripts/multi_zh-hans/ASR/run.sh
 
       - name: Show models

--- a/.github/workflows/multi-zh-hans.yml
+++ b/.github/workflows/multi-zh-hans.yml
@@ -71,11 +71,13 @@ jobs:
               .github/scripts/multi_zh-hans/ASR/run.sh
 
       - name: Show models
+        if: matrix.torch-version == '2.13.0'
         shell: bash
         run: |
           ls -lh *.tar.bz2
 
       - name: upload model to https://github.com/k2-fsa/sherpa-onnx
+        if: matrix.torch-version == '2.13.0'
         uses: svenstaro/upload-release-action@v2
         with:
           file_glob: true

--- a/.github/workflows/multi-zh-hans.yml
+++ b/.github/workflows/multi-zh-hans.yml
@@ -68,6 +68,8 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
+              python3 -m pip install onnxscript lilcom
+
               .github/scripts/multi_zh-hans/ASR/run.sh
 
       - name: Show models

--- a/.github/workflows/multi-zh-hans.yml
+++ b/.github/workflows/multi-zh-hans.yml
@@ -68,7 +68,8 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
-              python3 -m pip install onnxscript lilcom torchcodec
+              python3 -m pip install onnxscript lilcom
+              python3 -c "import torch; v=torch.__version__.split('.'); exit(0 if (int(v[0]),int(v[1])) >= (2,9) else 1)" && python3 -m pip install torchcodec==0.14.0+cpu -f https://download.pytorch.org/whl/torchcodec || true
 
               .github/scripts/multi_zh-hans/ASR/run.sh
 

--- a/.github/workflows/rknn.yml
+++ b/.github/workflows/rknn.yml
@@ -45,6 +45,7 @@ jobs:
             image: ghcr.io/${{ github.repository_owner }}/icefall:cpu-py${{ matrix.python-version }}-torch${{ matrix.torch-version }}-v${{ matrix.version }}
             options: |
               --volume ${{ github.workspace }}/:/icefall
+              -e TORCHAUDIO_USE_BACKEND=soundfile
             shell: bash
             run: |
               cat /etc/*release

--- a/.github/workflows/run-docker-image.yml
+++ b/.github/workflows/run-docker-image.yml
@@ -17,7 +17,7 @@ jobs:
         image: ["torch2.4.0-cuda12.4", "torch2.4.0-cuda12.1", "torch2.4.0-cuda11.8", "torch2.3.1-cuda12.1", "torch2.3.1-cuda11.8", "torch2.2.2-cuda12.1", "torch2.2.2-cuda11.8", "torch2.2.1-cuda12.1", "torch2.2.1-cuda11.8", "torch2.2.0-cuda12.1", "torch2.2.0-cuda11.8", "torch2.1.0-cuda12.1", "torch2.1.0-cuda11.8", "torch2.0.0-cuda11.7", "torch1.13.0-cuda11.6", "torch1.12.1-cuda11.3", "torch1.9.0-cuda10.2"]
     steps:
       # refer to https://github.com/actions/checkout
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/run-gigaspeech-2022-05-13.yml
+++ b/.github/workflows/run-gigaspeech-2022-05-13.yml
@@ -62,10 +62,9 @@ jobs:
             image: ghcr.io/${{ github.repository_owner }}/icefall:cpu-py${{ matrix.python-version }}-torch${{ matrix.torch-version }}-v${{ matrix.version }}
             options: |
               --volume ${{ github.workspace }}/:/icefall
+              -e GITHUB_EVENT_NAME=${{ github.event_name }}
+              -e GITHUB_EVENT_LABEL_NAME=${{ github.event.label.name }}
             shell: bash
-            env: |
-              GITHUB_EVENT_NAME: ${{ github.event_name }}
-              GITHUB_EVENT_LABEL_NAME: ${{ github.event.label.name }}
             run: |
               export PYTHONPATH=/icefall:$PYTHONPATH
               cd /icefall
@@ -75,7 +74,7 @@ jobs:
               python3 -m k2.version
               pip list
 
-              sudo apt-get install -y -q git-lfs
+              apt-get install -y -q git-lfs
 
               .github/scripts/run-gigaspeech-pruned-transducer-stateless2-2022-05-12.sh
 

--- a/.github/workflows/run-gigaspeech-2022-05-13.yml
+++ b/.github/workflows/run-gigaspeech-2022-05-13.yml
@@ -80,7 +80,7 @@ jobs:
               .github/scripts/run-gigaspeech-pruned-transducer-stateless2-2022-05-12.sh
 
       - name: Display decoding results for gigaspeech pruned_transducer_stateless2
-        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event.label.name == 'run-decode'
+        if: matrix.torch-version == '2.13.0' && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event.label.name == 'run-decode')
         shell: bash
         run: |
           cd egs/gigaspeech/ASR/

--- a/.github/workflows/run-gigaspeech-2022-05-13.yml
+++ b/.github/workflows/run-gigaspeech-2022-05-13.yml
@@ -51,12 +51,12 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
@@ -70,7 +70,7 @@ jobs:
 
       - name: Cache kaldifeat
         id: my-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/tmp/kaldifeat

--- a/.github/workflows/run-gigaspeech-2022-05-13.yml
+++ b/.github/workflows/run-gigaspeech-2022-05-13.yml
@@ -37,8 +37,8 @@ jobs:
         id: set-matrix
         run: |
           # outputting for debugging purposes
-          python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10"
-          MATRIX=$(python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10")
+          python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10" --min-torch-version "2.2.0"
+          MATRIX=$(python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10" --min-torch-version "2.2.0")
           echo "::set-output name=matrix::${MATRIX}"
 
   run_gigaspeech_2022_05_13:
@@ -95,7 +95,7 @@ jobs:
 
       - name: Upload decoding results for gigaspeech pruned_transducer_stateless2
         uses: actions/upload-artifact@v4
-        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event.label.name == 'run-decode'
+        if: matrix.torch-version == '2.13.0' && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event.label.name == 'run-decode')
         with:
           name: torch-${{ matrix.torch-version }}-python-${{ matrix.python-version }}-ubuntu-latest-cpu-gigaspeech-pruned_transducer_stateless2-2022-05-12
           path: egs/gigaspeech/ASR/pruned_transducer_stateless2/exp/

--- a/.github/workflows/run-gigaspeech-2022-05-13.yml
+++ b/.github/workflows/run-gigaspeech-2022-05-13.yml
@@ -70,7 +70,7 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
-              python3 -m pip install onnxscript lilcom
+              python3 -m pip install onnxscript lilcom torchcodec
 
               python3 -m torch.utils.collect_env
               python3 -m k2.version

--- a/.github/workflows/run-gigaspeech-2022-05-13.yml
+++ b/.github/workflows/run-gigaspeech-2022-05-13.yml
@@ -62,6 +62,7 @@ jobs:
             image: ghcr.io/${{ github.repository_owner }}/icefall:cpu-py${{ matrix.python-version }}-torch${{ matrix.torch-version }}-v${{ matrix.version }}
             options: |
               --volume ${{ github.workspace }}/:/icefall
+              -e TORCHAUDIO_USE_BACKEND=soundfile
               -e GITHUB_EVENT_NAME=${{ github.event_name }}
               -e GITHUB_EVENT_LABEL_NAME=${{ github.event.label.name }}
             shell: bash

--- a/.github/workflows/run-gigaspeech-2022-05-13.yml
+++ b/.github/workflows/run-gigaspeech-2022-05-13.yml
@@ -1,19 +1,3 @@
-# Copyright      2021  Fangjun Kuang (csukuangfj@gmail.com)
-
-# See ../../LICENSE for clarification regarding multiple authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 name: run-gigaspeech-2022-05-13
 # stateless transducer + k2 pruned rnnt-loss + reworked conformer
 
@@ -40,70 +24,60 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  generate_build_matrix:
+    if: github.repository_owner == 'csukuangfj' || github.repository_owner == 'k2-fsa'
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Generating build matrix
+        id: set-matrix
+        run: |
+          # outputting for debugging purposes
+          python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10"
+          MATRIX=$(python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10")
+          echo "::set-output name=matrix::${MATRIX}"
+
   run_gigaspeech_2022_05_13:
     if: github.event_name == 'workflow_dispatch' || github.event.label.name == 'ready' || github.event.label.name == 'run-decode' || github.event_name == 'push' || github.event_name == 'schedule'
-    runs-on: ${{ matrix.os }}
+    needs: generate_build_matrix
+    name: py${{ matrix.python-version }} torch${{ matrix.torch-version }} v${{ matrix.version }}
+    runs-on: ubuntu-latest
     strategy:
-      matrix:
-        os: [ubuntu-latest]
-        python-version: [3.8]
-
       fail-fast: false
+      matrix:
+        ${{ fromJson(needs.generate_build_matrix.outputs.matrix) }}
 
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+      - name: Download GigaSpeech dev/test dataset and run inference
+        uses: addnab/docker-run-action@v3
         with:
-          python-version: ${{ matrix.python-version }}
-          cache: 'pip'
-          cache-dependency-path: '**/requirements-ci.txt'
+            image: ghcr.io/${{ github.repository_owner }}/icefall:cpu-py${{ matrix.python-version }}-torch${{ matrix.torch-version }}-v${{ matrix.version }}
+            options: |
+              --volume ${{ github.workspace }}/:/icefall
+            shell: bash
+            env: |
+              GITHUB_EVENT_NAME: ${{ github.event_name }}
+              GITHUB_EVENT_LABEL_NAME: ${{ github.event.label.name }}
+            run: |
+              export PYTHONPATH=/icefall:$PYTHONPATH
+              cd /icefall
+              git config --global --add safe.directory /icefall
 
-      - name: Install Python dependencies
-        run: |
-          grep -v '^#' ./requirements-ci.txt  | xargs -n 1 -L 1 pip install
-          pip uninstall -y protobuf
-          pip install --no-binary protobuf protobuf==3.20.*
+              python3 -m torch.utils.collect_env
+              python3 -m k2.version
+              pip list
 
-      - name: Cache kaldifeat
-        id: my-cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/tmp/kaldifeat
-          key: cache-tmp-${{ matrix.python-version }}-2023-05-22
+              sudo apt-get install -y -q git-lfs
 
-      - name: Install kaldifeat
-        if: steps.my-cache.outputs.cache-hit != 'true'
-        shell: bash
-        run: |
-          .github/scripts/install-kaldifeat.sh
-
-      - name: Download GigaSpeech dev/test dataset
-        shell: bash
-        run: |
-          sudo apt-get install -y -q git-lfs
-
-          .github/scripts/download-gigaspeech-dev-test-dataset.sh
-
-      - name: Inference with pre-trained model
-        shell: bash
-        env:
-          GITHUB_EVENT_NAME: ${{ github.event_name }}
-          GITHUB_EVENT_LABEL_NAME: ${{ github.event.label.name }}
-        run: |
-          ln -s ~/tmp/giga-dev-dataset-fbank/data egs/gigaspeech/ASR/
-
-          ls -lh egs/gigaspeech/ASR/data/fbank
-
-          export PYTHONPATH=$PWD:$PYTHONPATH
-          export PYTHONPATH=~/tmp/kaldifeat/kaldifeat/python:$PYTHONPATH
-          export PYTHONPATH=~/tmp/kaldifeat/build/lib:$PYTHONPATH
-
-          .github/scripts/run-gigaspeech-pruned-transducer-stateless2-2022-05-12.sh
+              .github/scripts/run-gigaspeech-pruned-transducer-stateless2-2022-05-12.sh
 
       - name: Display decoding results for gigaspeech pruned_transducer_stateless2
         if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event.label.name == 'run-decode'
@@ -124,5 +98,5 @@ jobs:
         uses: actions/upload-artifact@v4
         if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event.label.name == 'run-decode'
         with:
-          name: torch-${{ matrix.torch }}-python-${{ matrix.python-version }}-ubuntu-latest-cpu-gigaspeech-pruned_transducer_stateless2-2022-05-12
+          name: torch-${{ matrix.torch-version }}-python-${{ matrix.python-version }}-ubuntu-latest-cpu-gigaspeech-pruned_transducer_stateless2-2022-05-12
           path: egs/gigaspeech/ASR/pruned_transducer_stateless2/exp/

--- a/.github/workflows/run-gigaspeech-2022-05-13.yml
+++ b/.github/workflows/run-gigaspeech-2022-05-13.yml
@@ -70,6 +70,8 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
+              python3 -m pip install onnxscript lilcom
+
               python3 -m torch.utils.collect_env
               python3 -m k2.version
               pip list

--- a/.github/workflows/run-gigaspeech-2022-05-13.yml
+++ b/.github/workflows/run-gigaspeech-2022-05-13.yml
@@ -70,7 +70,8 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
-              python3 -m pip install onnxscript lilcom torchcodec
+              python3 -m pip install onnxscript lilcom
+              python3 -c "import torch; v=torch.__version__.split('.'); exit(0 if (int(v[0]),int(v[1])) >= (2,9) else 1)" && python3 -m pip install torchcodec==0.14.0+cpu -f https://download.pytorch.org/whl/torchcodec || true
 
               python3 -m torch.utils.collect_env
               python3 -m k2.version

--- a/.github/workflows/run-gigaspeech-2022-05-13.yml
+++ b/.github/workflows/run-gigaspeech-2022-05-13.yml
@@ -70,9 +70,6 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
-              python3 -m pip install onnxscript lilcom
-              python3 -c "import torch; v=torch.__version__.split('.'); exit(0 if (int(v[0]),int(v[1])) >= (2,9) else 1)" && python3 -m pip install torchcodec==0.14.0+cpu -f https://download.pytorch.org/whl/torchcodec || true
-
               python3 -m torch.utils.collect_env
               python3 -m k2.version
               pip list

--- a/.github/workflows/run-gigaspeech-zipformer-2023-10-17.yml
+++ b/.github/workflows/run-gigaspeech-zipformer-2023-10-17.yml
@@ -63,6 +63,7 @@ jobs:
             image: ghcr.io/${{ github.repository_owner }}/icefall:cpu-py${{ matrix.python-version }}-torch${{ matrix.torch-version }}-v${{ matrix.version }}
             options: |
               --volume ${{ github.workspace }}/:/icefall
+              -e TORCHAUDIO_USE_BACKEND=soundfile
               -e GITHUB_EVENT_NAME=${{ github.event_name }}
               -e GITHUB_EVENT_LABEL_NAME=${{ github.event.label.name }}
               -e HF_TOKEN=${{ secrets.HF_TOKEN }}

--- a/.github/workflows/run-gigaspeech-zipformer-2023-10-17.yml
+++ b/.github/workflows/run-gigaspeech-zipformer-2023-10-17.yml
@@ -72,7 +72,7 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
-              python3 -m pip install onnxscript lilcom
+              python3 -m pip install onnxscript lilcom torchcodec
 
               python3 -m torch.utils.collect_env
               python3 -m k2.version
@@ -94,7 +94,7 @@ jobs:
           tag: asr-models
 
       - name: Display decoding results for gigaspeech zipformer
-        if: github.event_name == 'schedule' || github.event.label.name == 'run-decode' || github.event_name == 'workflow_dispatch'
+        if: matrix.torch-version == '2.13.0' && (github.event_name == 'schedule' || github.event.label.name == 'run-decode' || github.event_name == 'workflow_dispatch')
         shell: bash
         run: |
           cd egs/gigaspeech/ASR/

--- a/.github/workflows/run-gigaspeech-zipformer-2023-10-17.yml
+++ b/.github/workflows/run-gigaspeech-zipformer-2023-10-17.yml
@@ -52,12 +52,12 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
@@ -71,7 +71,7 @@ jobs:
 
       - name: Cache kaldifeat
         id: my-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/tmp/kaldifeat

--- a/.github/workflows/run-gigaspeech-zipformer-2023-10-17.yml
+++ b/.github/workflows/run-gigaspeech-zipformer-2023-10-17.yml
@@ -63,11 +63,10 @@ jobs:
             image: ghcr.io/${{ github.repository_owner }}/icefall:cpu-py${{ matrix.python-version }}-torch${{ matrix.torch-version }}-v${{ matrix.version }}
             options: |
               --volume ${{ github.workspace }}/:/icefall
+              -e GITHUB_EVENT_NAME=${{ github.event_name }}
+              -e GITHUB_EVENT_LABEL_NAME=${{ github.event.label.name }}
+              -e HF_TOKEN=${{ secrets.HF_TOKEN }}
             shell: bash
-            env: |
-              GITHUB_EVENT_NAME: ${{ github.event_name }}
-              GITHUB_EVENT_LABEL_NAME: ${{ github.event.label.name }}
-              HF_TOKEN: ${{ secrets.HF_TOKEN }}
             run: |
               export PYTHONPATH=/icefall:$PYTHONPATH
               cd /icefall
@@ -77,7 +76,7 @@ jobs:
               python3 -m k2.version
               pip list
 
-              sudo apt-get install -y -q git-lfs tree
+              apt-get install -y -q git-lfs tree
 
               .github/scripts/run-gigaspeech-zipformer-2023-10-17.sh
 

--- a/.github/workflows/run-gigaspeech-zipformer-2023-10-17.yml
+++ b/.github/workflows/run-gigaspeech-zipformer-2023-10-17.yml
@@ -1,19 +1,3 @@
-# Copyright      2022  Fangjun Kuang (csukuangfj@gmail.com)
-
-# See ../../LICENSE for clarification regarding multiple authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 name: run-gigaspeech-zipformer-2023-10-17
 # zipformer
 
@@ -41,61 +25,61 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  run_gigaspeech_2023_10_17_zipformer:
-    if: github.event.label.name == 'zipformer' ||github.event.label.name == 'ready' || github.event.label.name == 'run-decode' || github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        python-version: [3.8]
+  generate_build_matrix:
+    if: github.repository_owner == 'csukuangfj' || github.repository_owner == 'k2-fsa'
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Generating build matrix
+        id: set-matrix
+        run: |
+          # outputting for debugging purposes
+          python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10"
+          MATRIX=$(python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10")
+          echo "::set-output name=matrix::${MATRIX}"
 
+  run_gigaspeech_2023_10_17_zipformer:
+    if: github.event.label.name == 'zipformer' || github.event.label.name == 'ready' || github.event.label.name == 'run-decode' || github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    needs: generate_build_matrix
+    name: py${{ matrix.python-version }} torch${{ matrix.torch-version }} v${{ matrix.version }}
+    runs-on: ubuntu-latest
+    strategy:
       fail-fast: false
+      matrix:
+        ${{ fromJson(needs.generate_build_matrix.outputs.matrix) }}
 
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: 'pip'
-          cache-dependency-path: '**/requirements-ci.txt'
-
-      - name: Install Python dependencies
-        run: |
-          grep -v '^#' ./requirements-ci.txt  | xargs -n 1 -L 1 pip install
-          pip uninstall -y protobuf
-          pip install --no-binary protobuf protobuf==3.20.*
-
-      - name: Cache kaldifeat
-        id: my-cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/tmp/kaldifeat
-          key: cache-tmp-${{ matrix.python-version }}-2023-05-22
-
-      - name: Install kaldifeat
-        if: steps.my-cache.outputs.cache-hit != 'true'
-        shell: bash
-        run: |
-          .github/scripts/install-kaldifeat.sh
-
       - name: Inference with pre-trained model
-        shell: bash
-        env:
-          GITHUB_EVENT_NAME: ${{ github.event_name }}
-          GITHUB_EVENT_LABEL_NAME: ${{ github.event.label.name }}
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
-        run: |
-          sudo apt-get -qq install git-lfs tree
-          export PYTHONPATH=$PWD:$PYTHONPATH
-          export PYTHONPATH=~/tmp/kaldifeat/kaldifeat/python:$PYTHONPATH
-          export PYTHONPATH=~/tmp/kaldifeat/build/lib:$PYTHONPATH
+        uses: addnab/docker-run-action@v3
+        with:
+            image: ghcr.io/${{ github.repository_owner }}/icefall:cpu-py${{ matrix.python-version }}-torch${{ matrix.torch-version }}-v${{ matrix.version }}
+            options: |
+              --volume ${{ github.workspace }}/:/icefall
+            shell: bash
+            env: |
+              GITHUB_EVENT_NAME: ${{ github.event_name }}
+              GITHUB_EVENT_LABEL_NAME: ${{ github.event.label.name }}
+              HF_TOKEN: ${{ secrets.HF_TOKEN }}
+            run: |
+              export PYTHONPATH=/icefall:$PYTHONPATH
+              cd /icefall
+              git config --global --add safe.directory /icefall
 
-          .github/scripts/run-gigaspeech-zipformer-2023-10-17.sh
+              python3 -m torch.utils.collect_env
+              python3 -m k2.version
+              pip list
+
+              sudo apt-get install -y -q git-lfs tree
+
+              .github/scripts/run-gigaspeech-zipformer-2023-10-17.sh
 
       - name: upload model to https://github.com/k2-fsa/sherpa-onnx
         uses: svenstaro/upload-release-action@v2
@@ -120,17 +104,9 @@ jobs:
           find exp/greedy_search -name "log-*" -exec grep -n --color "best for test-clean" {} + | sort -n -k2
           find exp/greedy_search -name "log-*" -exec grep -n --color "best for test-other" {} + | sort -n -k2
 
-          # echo "===fast_beam_search==="
-          # find exp/fast_beam_search -name "log-*" -exec grep -n --color "best for test-clean" {} + | sort -n -k2
-          # find exp/fast_beam_search -name "log-*" -exec grep -n --color "best for test-other" {} + | sort -n -k2
-          #
-          # echo "===modified beam search==="
-          # find exp/modified_beam_search -name "log-*" -exec grep -n --color "best for test-clean" {} + | sort -n -k2
-          # find exp/modified_beam_search -name "log-*" -exec grep -n --color "best for test-other" {} + | sort -n -k2
-
       - name: Upload decoding results for gigaspeech zipformer
         uses: actions/upload-artifact@v4
         if: github.event_name == 'schedule' || github.event.label.name == 'run-decode' || github.event_name == 'workflow_dispatch'
         with:
-          name: torch-${{ matrix.torch }}-python-${{ matrix.python-version }}-ubuntu-latest-cpu-zipformer-2022-11-11
+          name: torch-${{ matrix.torch-version }}-python-${{ matrix.python-version }}-ubuntu-latest-cpu-zipformer-2022-11-11
           path: egs/gigaspeech/ASR/zipformer/exp/

--- a/.github/workflows/run-gigaspeech-zipformer-2023-10-17.yml
+++ b/.github/workflows/run-gigaspeech-zipformer-2023-10-17.yml
@@ -72,7 +72,8 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
-              python3 -m pip install onnxscript lilcom torchcodec
+              python3 -m pip install onnxscript lilcom
+              python3 -c "import torch; v=torch.__version__.split('.'); exit(0 if (int(v[0]),int(v[1])) >= (2,9) else 1)" && python3 -m pip install torchcodec==0.14.0+cpu -f https://download.pytorch.org/whl/torchcodec || true
 
               python3 -m torch.utils.collect_env
               python3 -m k2.version

--- a/.github/workflows/run-gigaspeech-zipformer-2023-10-17.yml
+++ b/.github/workflows/run-gigaspeech-zipformer-2023-10-17.yml
@@ -72,9 +72,6 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
-              python3 -m pip install onnxscript lilcom
-              python3 -c "import torch; v=torch.__version__.split('.'); exit(0 if (int(v[0]),int(v[1])) >= (2,9) else 1)" && python3 -m pip install torchcodec==0.14.0+cpu -f https://download.pytorch.org/whl/torchcodec || true
-
               python3 -m torch.utils.collect_env
               python3 -m k2.version
               pip list

--- a/.github/workflows/run-gigaspeech-zipformer-2023-10-17.yml
+++ b/.github/workflows/run-gigaspeech-zipformer-2023-10-17.yml
@@ -72,7 +72,7 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
-              python3 -m pip install onnxscript
+              python3 -m pip install onnxscript lilcom
 
               python3 -m torch.utils.collect_env
               python3 -m k2.version

--- a/.github/workflows/run-gigaspeech-zipformer-2023-10-17.yml
+++ b/.github/workflows/run-gigaspeech-zipformer-2023-10-17.yml
@@ -38,8 +38,8 @@ jobs:
         id: set-matrix
         run: |
           # outputting for debugging purposes
-          python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10"
-          MATRIX=$(python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10")
+          python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10" --min-torch-version "2.2.0"
+          MATRIX=$(python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10" --min-torch-version "2.2.0")
           echo "::set-output name=matrix::${MATRIX}"
 
   run_gigaspeech_2023_10_17_zipformer:
@@ -81,6 +81,7 @@ jobs:
               .github/scripts/run-gigaspeech-zipformer-2023-10-17.sh
 
       - name: upload model to https://github.com/k2-fsa/sherpa-onnx
+        if: matrix.torch-version == '2.13.0'
         uses: svenstaro/upload-release-action@v2
         with:
           file_glob: true
@@ -105,7 +106,7 @@ jobs:
 
       - name: Upload decoding results for gigaspeech zipformer
         uses: actions/upload-artifact@v4
-        if: github.event_name == 'schedule' || github.event.label.name == 'run-decode' || github.event_name == 'workflow_dispatch'
+        if: matrix.torch-version == '2.13.0' && (github.event_name == 'schedule' || github.event.label.name == 'run-decode' || github.event_name == 'workflow_dispatch')
         with:
           name: torch-${{ matrix.torch-version }}-python-${{ matrix.python-version }}-ubuntu-latest-cpu-zipformer-2022-11-11
           path: egs/gigaspeech/ASR/zipformer/exp/

--- a/.github/workflows/run-gigaspeech-zipformer-2023-10-17.yml
+++ b/.github/workflows/run-gigaspeech-zipformer-2023-10-17.yml
@@ -72,6 +72,8 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
+              python3 -m pip install onnxscript
+
               python3 -m torch.utils.collect_env
               python3 -m k2.version
               pip list

--- a/.github/workflows/run-librispeech-lstm-transducer-stateless2-2022-09-03.yml
+++ b/.github/workflows/run-librispeech-lstm-transducer-stateless2-2022-09-03.yml
@@ -8,12 +8,6 @@ on:
     types: [labeled]
 
   schedule:
-    # minute (0-59)
-    # hour (0-23)
-    # day of the month (1-31)
-    # month (1-12)
-    # day of the week (0-6)
-    # nightly build at 15:50 UTC time every day
     - cron: "50 15 * * *"
 
   workflow_dispatch:
@@ -23,47 +17,36 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  generate_build_matrix:
+    if: github.repository_owner == 'csukuangfj' || github.repository_owner == 'k2-fsa'
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Generating build matrix
+        id: set-matrix
+        run: |
+          python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10"
+          MATRIX=$(python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10")
+          echo "::set-output name=matrix::${MATRIX}"
+
   run_librispeech_lstm_transducer_stateless2_2022_09_03:
     if: github.event.label.name == 'ready' || github.event.label.name == 'LODR' || github.event.label.name == 'shallow-fusion' || github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    runs-on: ${{ matrix.os }}
+    needs: generate_build_matrix
+    name: py${{ matrix.python-version }} torch${{ matrix.torch-version }} v${{ matrix.version }}
+    runs-on: ubuntu-latest
     strategy:
-      matrix:
-        os: [ubuntu-latest]
-        python-version: [3.8]
-
       fail-fast: false
+      matrix:
+        ${{ fromJson(needs.generate_build_matrix.outputs.matrix) }}
 
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
-      - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: 'pip'
-          cache-dependency-path: '**/requirements-ci.txt'
-
-      - name: Install Python dependencies
-        run: |
-          grep -v '^#' ./requirements-ci.txt  | xargs -n 1 -L 1 pip install
-          pip uninstall -y protobuf
-          pip install --no-binary protobuf protobuf==3.20.*
-
-      - name: Cache kaldifeat
-        id: my-cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/tmp/kaldifeat
-          key: cache-tmp-${{ matrix.python-version }}-2023-05-22
-
-      - name: Install kaldifeat
-        if: steps.my-cache.outputs.cache-hit != 'true'
-        shell: bash
-        run: |
-          .github/scripts/install-kaldifeat.sh
 
       - name: Cache LibriSpeech test-clean and test-other datasets
         id: libri-test-clean-and-test-other-data
@@ -99,21 +82,31 @@ jobs:
           .github/scripts/compute-fbank-librispeech-test-clean-and-test-other.sh
 
       - name: Inference with pre-trained model
-        shell: bash
-        env:
-          GITHUB_EVENT_NAME: ${{ github.event_name }}
-          GITHUB_EVENT_LABEL_NAME: ${{ github.event.label.name }}
-        run: |
-          mkdir -p egs/librispeech/ASR/data
-          ln -sfv ~/tmp/fbank-libri egs/librispeech/ASR/data/fbank
-          ls -lh egs/librispeech/ASR/data/*
+        uses: addnab/docker-run-action@v3
+        with:
+            image: ghcr.io/${{ github.repository_owner }}/icefall:cpu-py${{ matrix.python-version }}-torch${{ matrix.torch-version }}-v${{ matrix.version }}
+            options: |
+              --volume ${{ github.workspace }}/:/icefall
+              --volume ${{ github.home }}/tmp:/root/tmp
+              -e GITHUB_EVENT_NAME=${{ github.event_name }}
+              -e GITHUB_EVENT_LABEL_NAME=${{ github.event.label.name }}
+            shell: bash
+            run: |
+              export PYTHONPATH=/icefall:$PYTHONPATH
+              cd /icefall
+              git config --global --add safe.directory /icefall
 
-          sudo apt-get -qq install git-lfs tree
-          export PYTHONPATH=$PWD:$PYTHONPATH
-          export PYTHONPATH=~/tmp/kaldifeat/kaldifeat/python:$PYTHONPATH
-          export PYTHONPATH=~/tmp/kaldifeat/build/lib:$PYTHONPATH
+              python3 -m torch.utils.collect_env
+              python3 -m k2.version
+              pip list
 
-          .github/scripts/run-librispeech-lstm-transducer-stateless2-2022-09-03.sh
+              mkdir -p egs/librispeech/ASR/data
+              ln -sfv /root/tmp/fbank-libri egs/librispeech/ASR/data/fbank
+              ls -lh egs/librispeech/ASR/data/*
+
+              apt-get install -y -q git-lfs tree
+
+              .github/scripts/run-librispeech-lstm-transducer-stateless2-2022-09-03.sh
 
       - name: Display decoding results for lstm_transducer_stateless2
         if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
@@ -129,10 +122,6 @@ jobs:
           echo "===fast_beam_search==="
           find fast_beam_search -name "log-*" -exec grep -n --color "best for test-clean" {} + | sort -n -k2
           find fast_beam_search -name "log-*" -exec grep -n --color "best for test-other" {} + | sort -n -k2
-
-          # echo "===modified beam search==="
-          # find modified_beam_search -name "log-*" -exec grep -n --color "best for test-clean" {} + | sort -n -k2
-          # find modified_beam_search -name "log-*" -exec grep -n --color "best for test-other" {} + | sort -n -k2
 
       - name: Display decoding results for lstm_transducer_stateless2
         if: github.event.label.name == 'shallow-fusion'
@@ -161,5 +150,5 @@ jobs:
         uses: actions/upload-artifact@v4
         if: github.event_name == 'schedule' || github.event.label.name == 'shallow-fusion' || github.event.label.name == 'LODR' || github.event_name == 'workflow_dispatch'
         with:
-          name: torch-${{ matrix.torch }}-python-${{ matrix.python-version }}-ubuntu-latest-cpu-lstm_transducer_stateless2-2022-09-03
+          name: torch-${{ matrix.torch-version }}-python-${{ matrix.python-version }}-ubuntu-latest-cpu-lstm_transducer_stateless2-2022-09-03
           path: egs/librispeech/ASR/lstm_transducer_stateless2/exp/

--- a/.github/workflows/run-librispeech-lstm-transducer-stateless2-2022-09-03.yml
+++ b/.github/workflows/run-librispeech-lstm-transducer-stateless2-2022-09-03.yml
@@ -96,7 +96,7 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
-              python3 -m pip install onnxscript lilcom
+              python3 -m pip install onnxscript lilcom torchcodec
 
               python3 -m torch.utils.collect_env
               python3 -m k2.version

--- a/.github/workflows/run-librispeech-lstm-transducer-stateless2-2022-09-03.yml
+++ b/.github/workflows/run-librispeech-lstm-transducer-stateless2-2022-09-03.yml
@@ -96,7 +96,8 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
-              python3 -m pip install onnxscript lilcom torchcodec
+              python3 -m pip install onnxscript lilcom
+              python3 -c "import torch; v=torch.__version__.split('.'); exit(0 if (int(v[0]),int(v[1])) >= (2,9) else 1)" && python3 -m pip install torchcodec==0.14.0+cpu -f https://download.pytorch.org/whl/torchcodec || true
 
               python3 -m torch.utils.collect_env
               python3 -m k2.version

--- a/.github/workflows/run-librispeech-lstm-transducer-stateless2-2022-09-03.yml
+++ b/.github/workflows/run-librispeech-lstm-transducer-stateless2-2022-09-03.yml
@@ -29,8 +29,8 @@ jobs:
       - name: Generating build matrix
         id: set-matrix
         run: |
-          python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10"
-          MATRIX=$(python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10")
+          python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10" --min-torch-version "2.2.0"
+          MATRIX=$(python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10" --min-torch-version "2.2.0")
           echo "::set-output name=matrix::${MATRIX}"
 
   run_librispeech_lstm_transducer_stateless2_2022_09_03:
@@ -148,7 +148,7 @@ jobs:
 
       - name: Upload decoding results for lstm_transducer_stateless2
         uses: actions/upload-artifact@v4
-        if: github.event_name == 'schedule' || github.event.label.name == 'shallow-fusion' || github.event.label.name == 'LODR' || github.event_name == 'workflow_dispatch'
+        if: matrix.torch-version == '2.13.0' && (github.event_name == 'schedule' || github.event.label.name == 'shallow-fusion' || github.event.label.name == 'LODR' || github.event_name == 'workflow_dispatch')
         with:
           name: torch-${{ matrix.torch-version }}-python-${{ matrix.python-version }}-ubuntu-latest-cpu-lstm_transducer_stateless2-2022-09-03
           path: egs/librispeech/ASR/lstm_transducer_stateless2/exp/

--- a/.github/workflows/run-librispeech-lstm-transducer-stateless2-2022-09-03.yml
+++ b/.github/workflows/run-librispeech-lstm-transducer-stateless2-2022-09-03.yml
@@ -96,9 +96,6 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
-              python3 -m pip install onnxscript lilcom
-              python3 -c "import torch; v=torch.__version__.split('.'); exit(0 if (int(v[0]),int(v[1])) >= (2,9) else 1)" && python3 -m pip install torchcodec==0.14.0+cpu -f https://download.pytorch.org/whl/torchcodec || true
-
               python3 -m torch.utils.collect_env
               python3 -m k2.version
               pip list

--- a/.github/workflows/run-librispeech-lstm-transducer-stateless2-2022-09-03.yml
+++ b/.github/workflows/run-librispeech-lstm-transducer-stateless2-2022-09-03.yml
@@ -34,12 +34,12 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
@@ -53,7 +53,7 @@ jobs:
 
       - name: Cache kaldifeat
         id: my-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/tmp/kaldifeat
@@ -67,7 +67,7 @@ jobs:
 
       - name: Cache LibriSpeech test-clean and test-other datasets
         id: libri-test-clean-and-test-other-data
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/tmp/download
@@ -86,7 +86,7 @@ jobs:
 
       - name: Cache LibriSpeech test-clean and test-other fbank features
         id: libri-test-clean-and-test-other-fbank
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/tmp/fbank-libri

--- a/.github/workflows/run-librispeech-lstm-transducer-stateless2-2022-09-03.yml
+++ b/.github/workflows/run-librispeech-lstm-transducer-stateless2-2022-09-03.yml
@@ -96,6 +96,8 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
+              python3 -m pip install onnxscript lilcom
+
               python3 -m torch.utils.collect_env
               python3 -m k2.version
               pip list

--- a/.github/workflows/run-librispeech-lstm-transducer-stateless2-2022-09-03.yml
+++ b/.github/workflows/run-librispeech-lstm-transducer-stateless2-2022-09-03.yml
@@ -87,6 +87,7 @@ jobs:
             image: ghcr.io/${{ github.repository_owner }}/icefall:cpu-py${{ matrix.python-version }}-torch${{ matrix.torch-version }}-v${{ matrix.version }}
             options: |
               --volume ${{ github.workspace }}/:/icefall
+              -e TORCHAUDIO_USE_BACKEND=soundfile
               --volume ${{ github.home }}/tmp:/root/tmp
               -e GITHUB_EVENT_NAME=${{ github.event_name }}
               -e GITHUB_EVENT_LABEL_NAME=${{ github.event.label.name }}

--- a/.github/workflows/run-multi-corpora-zipformer.yml
+++ b/.github/workflows/run-multi-corpora-zipformer.yml
@@ -59,7 +59,8 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
-              python3 -m pip install onnxscript lilcom torchcodec
+              python3 -m pip install onnxscript lilcom
+              python3 -c "import torch; v=torch.__version__.split('.'); exit(0 if (int(v[0]),int(v[1])) >= (2,9) else 1)" && python3 -m pip install torchcodec==0.14.0+cpu -f https://download.pytorch.org/whl/torchcodec || true
 
               python3 -m torch.utils.collect_env
               python3 -m k2.version

--- a/.github/workflows/run-multi-corpora-zipformer.yml
+++ b/.github/workflows/run-multi-corpora-zipformer.yml
@@ -59,9 +59,6 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
-              python3 -m pip install onnxscript lilcom
-              python3 -c "import torch; v=torch.__version__.split('.'); exit(0 if (int(v[0]),int(v[1])) >= (2,9) else 1)" && python3 -m pip install torchcodec==0.14.0+cpu -f https://download.pytorch.org/whl/torchcodec || true
-
               python3 -m torch.utils.collect_env
               python3 -m k2.version
               pip list

--- a/.github/workflows/run-multi-corpora-zipformer.yml
+++ b/.github/workflows/run-multi-corpora-zipformer.yml
@@ -59,6 +59,8 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
+              python3 -m pip install onnxscript lilcom
+
               python3 -m torch.utils.collect_env
               python3 -m k2.version
               pip list

--- a/.github/workflows/run-multi-corpora-zipformer.yml
+++ b/.github/workflows/run-multi-corpora-zipformer.yml
@@ -59,7 +59,7 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
-              python3 -m pip install onnxscript lilcom
+              python3 -m pip install onnxscript lilcom torchcodec
 
               python3 -m torch.utils.collect_env
               python3 -m k2.version

--- a/.github/workflows/run-multi-corpora-zipformer.yml
+++ b/.github/workflows/run-multi-corpora-zipformer.yml
@@ -26,8 +26,8 @@ jobs:
       - name: Generating build matrix
         id: set-matrix
         run: |
-          python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10"
-          MATRIX=$(python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10")
+          python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10" --min-torch-version "2.2.0"
+          MATRIX=$(python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10" --min-torch-version "2.2.0")
           echo "::set-output name=matrix::${MATRIX}"
 
   run_multi_corpora_zipformer:

--- a/.github/workflows/run-multi-corpora-zipformer.yml
+++ b/.github/workflows/run-multi-corpora-zipformer.yml
@@ -1,19 +1,3 @@
-# Copyright      2023   Xiaomi Corp.    (author: Zengrui Jin)
-
-# See ../../LICENSE for clarification regarding multiple authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 name: run-multi-corpora-zipformer
 
 on:
@@ -30,57 +14,55 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  run_multi-corpora_zipformer:
-    if: github.event.label.name == 'onnx' || github.event.label.name == 'ready' || github.event_name == 'push' || github.event.label.name == 'multi-zh_hans' || github.event.label.name == 'zipformer' || github.event.label.name == 'multi-corpora'
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        python-version: [3.8]
+  generate_build_matrix:
+    if: github.repository_owner == 'csukuangfj' || github.repository_owner == 'k2-fsa'
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Generating build matrix
+        id: set-matrix
+        run: |
+          python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10"
+          MATRIX=$(python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10")
+          echo "::set-output name=matrix::${MATRIX}"
 
+  run_multi_corpora_zipformer:
+    if: github.event.label.name == 'onnx' || github.event.label.name == 'ready' || github.event_name == 'push' || github.event.label.name == 'multi-zh_hans' || github.event.label.name == 'zipformer' || github.event.label.name == 'multi-corpora'
+    needs: generate_build_matrix
+    name: py${{ matrix.python-version }} torch${{ matrix.torch-version }} v${{ matrix.version }}
+    runs-on: ubuntu-latest
+    strategy:
       fail-fast: false
+      matrix:
+        ${{ fromJson(needs.generate_build_matrix.outputs.matrix) }}
 
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: 'pip'
-          cache-dependency-path: '**/requirements-ci.txt'
-
-      - name: Install Python dependencies
-        run: |
-          grep -v '^#' ./requirements-ci.txt  | xargs -n 1 -L 1 pip install
-          pip uninstall -y protobuf
-          pip install --no-binary protobuf protobuf==3.20.*
-
-      - name: Cache kaldifeat
-        id: my-cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/tmp/kaldifeat
-          key: cache-tmp-${{ matrix.python-version }}-2023-05-22
-
-      - name: Install kaldifeat
-        if: steps.my-cache.outputs.cache-hit != 'true'
-        shell: bash
-        run: |
-          .github/scripts/install-kaldifeat.sh
-
       - name: Inference with pre-trained model
-        shell: bash
-        env:
-          GITHUB_EVENT_NAME: ${{ github.event_name }}
-          GITHUB_EVENT_LABEL_NAME: ${{ github.event.label.name }}
-        run: |
-          sudo apt-get -qq install git-lfs tree
-          export PYTHONPATH=$PWD:$PYTHONPATH
-          export PYTHONPATH=~/tmp/kaldifeat/kaldifeat/python:$PYTHONPATH
-          export PYTHONPATH=~/tmp/kaldifeat/build/lib:$PYTHONPATH
+        uses: addnab/docker-run-action@v3
+        with:
+            image: ghcr.io/${{ github.repository_owner }}/icefall:cpu-py${{ matrix.python-version }}-torch${{ matrix.torch-version }}-v${{ matrix.version }}
+            options: |
+              --volume ${{ github.workspace }}/:/icefall
+              -e GITHUB_EVENT_NAME=${{ github.event_name }}
+              -e GITHUB_EVENT_LABEL_NAME=${{ github.event.label.name }}
+            shell: bash
+            run: |
+              export PYTHONPATH=/icefall:$PYTHONPATH
+              cd /icefall
+              git config --global --add safe.directory /icefall
 
-          .github/scripts/run-multi-corpora-zipformer.sh
+              python3 -m torch.utils.collect_env
+              python3 -m k2.version
+              pip list
+
+              apt-get install -y -q git-lfs tree
+
+              .github/scripts/run-multi-corpora-zipformer.sh

--- a/.github/workflows/run-multi-corpora-zipformer.yml
+++ b/.github/workflows/run-multi-corpora-zipformer.yml
@@ -41,12 +41,12 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
@@ -60,7 +60,7 @@ jobs:
 
       - name: Cache kaldifeat
         id: my-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/tmp/kaldifeat

--- a/.github/workflows/run-multi-corpora-zipformer.yml
+++ b/.github/workflows/run-multi-corpora-zipformer.yml
@@ -51,6 +51,7 @@ jobs:
             image: ghcr.io/${{ github.repository_owner }}/icefall:cpu-py${{ matrix.python-version }}-torch${{ matrix.torch-version }}-v${{ matrix.version }}
             options: |
               --volume ${{ github.workspace }}/:/icefall
+              -e TORCHAUDIO_USE_BACKEND=soundfile
               -e GITHUB_EVENT_NAME=${{ github.event_name }}
               -e GITHUB_EVENT_LABEL_NAME=${{ github.event.label.name }}
             shell: bash

--- a/.github/workflows/run-ptb-rnn-lm.yml
+++ b/.github/workflows/run-ptb-rnn-lm.yml
@@ -34,12 +34,12 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'

--- a/.github/workflows/run-ptb-rnn-lm.yml
+++ b/.github/workflows/run-ptb-rnn-lm.yml
@@ -60,9 +60,6 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
-              python3 -m pip install onnxscript lilcom
-              python3 -c "import torch; v=torch.__version__.split('.'); exit(0 if (int(v[0]),int(v[1])) >= (2,9) else 1)" && python3 -m pip install torchcodec==0.14.0+cpu -f https://download.pytorch.org/whl/torchcodec || true
-
               python3 -m torch.utils.collect_env
               python3 -m k2.version
               pip list
@@ -81,9 +78,6 @@ jobs:
               export PYTHONPATH=/icefall:$PYTHONPATH
               cd /icefall
               git config --global --add safe.directory /icefall
-
-              python3 -m pip install onnxscript lilcom
-              python3 -c "import torch; v=torch.__version__.split('.'); exit(0 if (int(v[0]),int(v[1])) >= (2,9) else 1)" && python3 -m pip install torchcodec==0.14.0+cpu -f https://download.pytorch.org/whl/torchcodec || true
 
               cd egs/ptb/LM
               ./train-rnn-lm.sh --world-size 1 --num-epochs 5 --use-epoch 4 --use-avg 2

--- a/.github/workflows/run-ptb-rnn-lm.yml
+++ b/.github/workflows/run-ptb-rnn-lm.yml
@@ -60,7 +60,7 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
-              python3 -m pip install onnxscript lilcom
+              python3 -m pip install onnxscript lilcom torchcodec
 
               python3 -m torch.utils.collect_env
               python3 -m k2.version
@@ -81,7 +81,7 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
-              python3 -m pip install onnxscript lilcom
+              python3 -m pip install onnxscript lilcom torchcodec
 
               cd egs/ptb/LM
               ./train-rnn-lm.sh --world-size 1 --num-epochs 5 --use-epoch 4 --use-avg 2

--- a/.github/workflows/run-ptb-rnn-lm.yml
+++ b/.github/workflows/run-ptb-rnn-lm.yml
@@ -60,6 +60,8 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
+              python3 -m pip install onnxscript lilcom
+
               python3 -m torch.utils.collect_env
               python3 -m k2.version
               pip list
@@ -78,6 +80,8 @@ jobs:
               export PYTHONPATH=/icefall:$PYTHONPATH
               cd /icefall
               git config --global --add safe.directory /icefall
+
+              python3 -m pip install onnxscript lilcom
 
               cd egs/ptb/LM
               ./train-rnn-lm.sh --world-size 1 --num-epochs 5 --use-epoch 4 --use-avg 2

--- a/.github/workflows/run-ptb-rnn-lm.yml
+++ b/.github/workflows/run-ptb-rnn-lm.yml
@@ -8,12 +8,6 @@ on:
     types: [labeled]
 
   schedule:
-    # minute (0-59)
-    # hour (0-23)
-    # day of the month (1-31)
-    # month (1-12)
-    # day of the week (0-6)
-    # nightly build at 15:50 UTC time every day
     - cron: "50 15 * * *"
 
   workflow_dispatch:
@@ -23,47 +17,70 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  generate_build_matrix:
+    if: github.repository_owner == 'csukuangfj' || github.repository_owner == 'k2-fsa'
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Generating build matrix
+        id: set-matrix
+        run: |
+          python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10"
+          MATRIX=$(python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10")
+          echo "::set-output name=matrix::${MATRIX}"
+
   run_ptb_rnn_lm_training:
     if: github.event.label.name == 'ready' || github.event.label.name == 'rnnlm' || github.event_name == 'push' || github.event_name == 'schedule'
-    runs-on: ${{ matrix.os }}
+    needs: generate_build_matrix
+    name: py${{ matrix.python-version }} torch${{ matrix.torch-version }} v${{ matrix.version }}
+    runs-on: ubuntu-latest
     strategy:
-      matrix:
-        os: [ubuntu-latest]
-        python-version: ["3.8"]
-
       fail-fast: false
+      matrix:
+        ${{ fromJson(needs.generate_build_matrix.outputs.matrix) }}
 
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: 'pip'
-          cache-dependency-path: '**/requirements-ci.txt'
-
-      - name: Install Python dependencies
-        run: |
-          grep -v '^#' ./requirements-ci.txt  | grep -v kaldifst | xargs -n 1 -L 1 pip install
-          pip uninstall -y protobuf
-          pip install --no-binary protobuf protobuf==3.20.*
-
       - name: Prepare data
-        shell: bash
-        run: |
-          export PYTHONPATH=$PWD:$PYTHONPATH
-          cd egs/ptb/LM
-          ./prepare.sh
+        uses: addnab/docker-run-action@v3
+        with:
+            image: ghcr.io/${{ github.repository_owner }}/icefall:cpu-py${{ matrix.python-version }}-torch${{ matrix.torch-version }}-v${{ matrix.version }}
+            options: |
+              --volume ${{ github.workspace }}/:/icefall
+            shell: bash
+            run: |
+              export PYTHONPATH=/icefall:$PYTHONPATH
+              cd /icefall
+              git config --global --add safe.directory /icefall
+
+              python3 -m torch.utils.collect_env
+              python3 -m k2.version
+              pip list
+
+              cd egs/ptb/LM
+              ./prepare.sh
 
       - name: Run training
-        shell: bash
-        run: |
-          export PYTHONPATH=$PWD:$PYTHONPATH
-          cd egs/ptb/LM
-          ./train-rnn-lm.sh --world-size 1 --num-epochs 5 --use-epoch 4 --use-avg 2
+        uses: addnab/docker-run-action@v3
+        with:
+            image: ghcr.io/${{ github.repository_owner }}/icefall:cpu-py${{ matrix.python-version }}-torch${{ matrix.torch-version }}-v${{ matrix.version }}
+            options: |
+              --volume ${{ github.workspace }}/:/icefall
+            shell: bash
+            run: |
+              export PYTHONPATH=/icefall:$PYTHONPATH
+              cd /icefall
+              git config --global --add safe.directory /icefall
+
+              cd egs/ptb/LM
+              ./train-rnn-lm.sh --world-size 1 --num-epochs 5 --use-epoch 4 --use-avg 2
 
       - name: Upload pretrained models
         uses: actions/upload-artifact@v4

--- a/.github/workflows/run-ptb-rnn-lm.yml
+++ b/.github/workflows/run-ptb-rnn-lm.yml
@@ -29,8 +29,8 @@ jobs:
       - name: Generating build matrix
         id: set-matrix
         run: |
-          python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10"
-          MATRIX=$(python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10")
+          python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10" --min-torch-version "2.2.0"
+          MATRIX=$(python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10" --min-torch-version "2.2.0")
           echo "::set-output name=matrix::${MATRIX}"
 
   run_ptb_rnn_lm_training:
@@ -84,7 +84,7 @@ jobs:
 
       - name: Upload pretrained models
         uses: actions/upload-artifact@v4
-        if: github.event.label.name == 'ready' || github.event.label.name == 'rnnlm' || github.event_name == 'push' || github.event_name == 'schedule'
+        if: matrix.torch-version == '2.13.0' && (github.event.label.name == 'ready' || github.event.label.name == 'rnnlm' || github.event_name == 'push' || github.event_name == 'schedule')
         with:
           name: python-${{ matrix.python-version }}-ubuntu-rnn-lm-ptb
           path: egs/ptb/LM/my-rnnlm-exp/

--- a/.github/workflows/run-ptb-rnn-lm.yml
+++ b/.github/workflows/run-ptb-rnn-lm.yml
@@ -54,6 +54,7 @@ jobs:
             image: ghcr.io/${{ github.repository_owner }}/icefall:cpu-py${{ matrix.python-version }}-torch${{ matrix.torch-version }}-v${{ matrix.version }}
             options: |
               --volume ${{ github.workspace }}/:/icefall
+              -e TORCHAUDIO_USE_BACKEND=soundfile
             shell: bash
             run: |
               export PYTHONPATH=/icefall:$PYTHONPATH
@@ -73,6 +74,7 @@ jobs:
             image: ghcr.io/${{ github.repository_owner }}/icefall:cpu-py${{ matrix.python-version }}-torch${{ matrix.torch-version }}-v${{ matrix.version }}
             options: |
               --volume ${{ github.workspace }}/:/icefall
+              -e TORCHAUDIO_USE_BACKEND=soundfile
             shell: bash
             run: |
               export PYTHONPATH=/icefall:$PYTHONPATH

--- a/.github/workflows/run-ptb-rnn-lm.yml
+++ b/.github/workflows/run-ptb-rnn-lm.yml
@@ -60,7 +60,8 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
-              python3 -m pip install onnxscript lilcom torchcodec
+              python3 -m pip install onnxscript lilcom
+              python3 -c "import torch; v=torch.__version__.split('.'); exit(0 if (int(v[0]),int(v[1])) >= (2,9) else 1)" && python3 -m pip install torchcodec==0.14.0+cpu -f https://download.pytorch.org/whl/torchcodec || true
 
               python3 -m torch.utils.collect_env
               python3 -m k2.version
@@ -81,7 +82,8 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
-              python3 -m pip install onnxscript lilcom torchcodec
+              python3 -m pip install onnxscript lilcom
+              python3 -c "import torch; v=torch.__version__.split('.'); exit(0 if (int(v[0]),int(v[1])) >= (2,9) else 1)" && python3 -m pip install torchcodec==0.14.0+cpu -f https://download.pytorch.org/whl/torchcodec || true
 
               cd egs/ptb/LM
               ./train-rnn-lm.sh --world-size 1 --num-epochs 5 --use-epoch 4 --use-avg 2

--- a/.github/workflows/run-swbd-conformer-ctc.yml
+++ b/.github/workflows/run-swbd-conformer-ctc.yml
@@ -59,7 +59,8 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
-              python3 -m pip install onnxscript lilcom torchcodec
+              python3 -m pip install onnxscript lilcom
+              python3 -c "import torch; v=torch.__version__.split('.'); exit(0 if (int(v[0]),int(v[1])) >= (2,9) else 1)" && python3 -m pip install torchcodec==0.14.0+cpu -f https://download.pytorch.org/whl/torchcodec || true
 
               python3 -m torch.utils.collect_env
               python3 -m k2.version

--- a/.github/workflows/run-swbd-conformer-ctc.yml
+++ b/.github/workflows/run-swbd-conformer-ctc.yml
@@ -59,9 +59,6 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
-              python3 -m pip install onnxscript lilcom
-              python3 -c "import torch; v=torch.__version__.split('.'); exit(0 if (int(v[0]),int(v[1])) >= (2,9) else 1)" && python3 -m pip install torchcodec==0.14.0+cpu -f https://download.pytorch.org/whl/torchcodec || true
-
               python3 -m torch.utils.collect_env
               python3 -m k2.version
               pip list

--- a/.github/workflows/run-swbd-conformer-ctc.yml
+++ b/.github/workflows/run-swbd-conformer-ctc.yml
@@ -59,6 +59,8 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
+              python3 -m pip install onnxscript lilcom
+
               python3 -m torch.utils.collect_env
               python3 -m k2.version
               pip list

--- a/.github/workflows/run-swbd-conformer-ctc.yml
+++ b/.github/workflows/run-swbd-conformer-ctc.yml
@@ -59,7 +59,7 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
-              python3 -m pip install onnxscript lilcom
+              python3 -m pip install onnxscript lilcom torchcodec
 
               python3 -m torch.utils.collect_env
               python3 -m k2.version

--- a/.github/workflows/run-swbd-conformer-ctc.yml
+++ b/.github/workflows/run-swbd-conformer-ctc.yml
@@ -26,8 +26,8 @@ jobs:
       - name: Generating build matrix
         id: set-matrix
         run: |
-          python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10"
-          MATRIX=$(python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10")
+          python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10" --min-torch-version "2.2.0"
+          MATRIX=$(python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10" --min-torch-version "2.2.0")
           echo "::set-output name=matrix::${MATRIX}"
 
   run_swbd_conformer_ctc:

--- a/.github/workflows/run-swbd-conformer-ctc.yml
+++ b/.github/workflows/run-swbd-conformer-ctc.yml
@@ -41,12 +41,12 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
@@ -60,7 +60,7 @@ jobs:
 
       - name: Cache kaldifeat
         id: my-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/tmp/kaldifeat

--- a/.github/workflows/run-swbd-conformer-ctc.yml
+++ b/.github/workflows/run-swbd-conformer-ctc.yml
@@ -1,19 +1,3 @@
-# Copyright      2023   Xiaomi Corp.    (author: Zengrui Jin)
-
-# See ../../LICENSE for clarification regarding multiple authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 name: run-swbd-conformer_ctc
 
 on:
@@ -30,57 +14,55 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  run-swbd-conformer_ctc:
-    if: github.event.label.name == 'onnx' || github.event.label.name == 'ready' || github.event_name == 'push' || github.event.label.name == 'swbd'
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        python-version: [3.8]
+  generate_build_matrix:
+    if: github.repository_owner == 'csukuangfj' || github.repository_owner == 'k2-fsa'
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Generating build matrix
+        id: set-matrix
+        run: |
+          python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10"
+          MATRIX=$(python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10")
+          echo "::set-output name=matrix::${MATRIX}"
 
+  run_swbd_conformer_ctc:
+    if: github.event.label.name == 'onnx' || github.event.label.name == 'ready' || github.event_name == 'push' || github.event.label.name == 'swbd'
+    needs: generate_build_matrix
+    name: py${{ matrix.python-version }} torch${{ matrix.torch-version }} v${{ matrix.version }}
+    runs-on: ubuntu-latest
+    strategy:
       fail-fast: false
+      matrix:
+        ${{ fromJson(needs.generate_build_matrix.outputs.matrix) }}
 
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: 'pip'
-          cache-dependency-path: '**/requirements-ci.txt'
-
-      - name: Install Python dependencies
-        run: |
-          grep -v '^#' ./requirements-ci.txt  | xargs -n 1 -L 1 pip install
-          pip uninstall -y protobuf
-          pip install --no-binary protobuf protobuf==3.20.*
-
-      - name: Cache kaldifeat
-        id: my-cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/tmp/kaldifeat
-          key: cache-tmp-${{ matrix.python-version }}-2023-05-22
-
-      - name: Install kaldifeat
-        if: steps.my-cache.outputs.cache-hit != 'true'
-        shell: bash
-        run: |
-          .github/scripts/install-kaldifeat.sh
-
       - name: Inference with pre-trained model
-        shell: bash
-        env:
-          GITHUB_EVENT_NAME: ${{ github.event_name }}
-          GITHUB_EVENT_LABEL_NAME: ${{ github.event.label.name }}
-        run: |
-          sudo apt-get -qq install git-lfs tree
-          export PYTHONPATH=$PWD:$PYTHONPATH
-          export PYTHONPATH=~/tmp/kaldifeat/kaldifeat/python:$PYTHONPATH
-          export PYTHONPATH=~/tmp/kaldifeat/build/lib:$PYTHONPATH
+        uses: addnab/docker-run-action@v3
+        with:
+            image: ghcr.io/${{ github.repository_owner }}/icefall:cpu-py${{ matrix.python-version }}-torch${{ matrix.torch-version }}-v${{ matrix.version }}
+            options: |
+              --volume ${{ github.workspace }}/:/icefall
+              -e GITHUB_EVENT_NAME=${{ github.event_name }}
+              -e GITHUB_EVENT_LABEL_NAME=${{ github.event.label.name }}
+            shell: bash
+            run: |
+              export PYTHONPATH=/icefall:$PYTHONPATH
+              cd /icefall
+              git config --global --add safe.directory /icefall
 
-          .github/scripts/run-swbd-conformer-ctc-2023-08-26.sh
+              python3 -m torch.utils.collect_env
+              python3 -m k2.version
+              pip list
+
+              apt-get install -y -q git-lfs tree
+
+              .github/scripts/run-swbd-conformer-ctc-2023-08-26.sh

--- a/.github/workflows/run-swbd-conformer-ctc.yml
+++ b/.github/workflows/run-swbd-conformer-ctc.yml
@@ -51,6 +51,7 @@ jobs:
             image: ghcr.io/${{ github.repository_owner }}/icefall:cpu-py${{ matrix.python-version }}-torch${{ matrix.torch-version }}-v${{ matrix.version }}
             options: |
               --volume ${{ github.workspace }}/:/icefall
+              -e TORCHAUDIO_USE_BACKEND=soundfile
               -e GITHUB_EVENT_NAME=${{ github.event_name }}
               -e GITHUB_EVENT_LABEL_NAME=${{ github.event.label.name }}
             shell: bash

--- a/.github/workflows/run-wenetspeech-pruned-transducer-stateless2.yml
+++ b/.github/workflows/run-wenetspeech-pruned-transducer-stateless2.yml
@@ -1,19 +1,3 @@
-# Copyright      2021  Fangjun Kuang (csukuangfj@gmail.com)
-
-# See ../../LICENSE for clarification regarding multiple authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 name: run-wenetspeech-pruned-transducer-stateless2
 
 on:
@@ -30,57 +14,55 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  generate_build_matrix:
+    if: github.repository_owner == 'csukuangfj' || github.repository_owner == 'k2-fsa'
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Generating build matrix
+        id: set-matrix
+        run: |
+          python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10"
+          MATRIX=$(python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10")
+          echo "::set-output name=matrix::${MATRIX}"
+
   run_wenetspeech_pruned_transducer_stateless2:
     if: github.event.label.name == 'onnx' || github.event.label.name == 'ready' || github.event_name == 'push' || github.event.label.name == 'wenetspeech'
-    runs-on: ${{ matrix.os }}
+    needs: generate_build_matrix
+    name: py${{ matrix.python-version }} torch${{ matrix.torch-version }} v${{ matrix.version }}
+    runs-on: ubuntu-latest
     strategy:
-      matrix:
-        os: [ubuntu-latest]
-        python-version: [3.8]
-
       fail-fast: false
+      matrix:
+        ${{ fromJson(needs.generate_build_matrix.outputs.matrix) }}
 
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: 'pip'
-          cache-dependency-path: '**/requirements-ci.txt'
-
-      - name: Install Python dependencies
-        run: |
-          grep -v '^#' ./requirements-ci.txt  | xargs -n 1 -L 1 pip install
-          pip uninstall -y protobuf
-          pip install --no-binary protobuf protobuf==3.20.*
-
-      - name: Cache kaldifeat
-        id: my-cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/tmp/kaldifeat
-          key: cache-tmp-${{ matrix.python-version }}-2023-05-22
-
-      - name: Install kaldifeat
-        if: steps.my-cache.outputs.cache-hit != 'true'
-        shell: bash
-        run: |
-          .github/scripts/install-kaldifeat.sh
-
       - name: Inference with pre-trained model
-        shell: bash
-        env:
-          GITHUB_EVENT_NAME: ${{ github.event_name }}
-          GITHUB_EVENT_LABEL_NAME: ${{ github.event.label.name }}
-        run: |
-          sudo apt-get -qq install git-lfs tree
-          export PYTHONPATH=$PWD:$PYTHONPATH
-          export PYTHONPATH=~/tmp/kaldifeat/kaldifeat/python:$PYTHONPATH
-          export PYTHONPATH=~/tmp/kaldifeat/build/lib:$PYTHONPATH
+        uses: addnab/docker-run-action@v3
+        with:
+            image: ghcr.io/${{ github.repository_owner }}/icefall:cpu-py${{ matrix.python-version }}-torch${{ matrix.torch-version }}-v${{ matrix.version }}
+            options: |
+              --volume ${{ github.workspace }}/:/icefall
+              -e GITHUB_EVENT_NAME=${{ github.event_name }}
+              -e GITHUB_EVENT_LABEL_NAME=${{ github.event.label.name }}
+            shell: bash
+            run: |
+              export PYTHONPATH=/icefall:$PYTHONPATH
+              cd /icefall
+              git config --global --add safe.directory /icefall
 
-          .github/scripts/run-wenetspeech-pruned-transducer-stateless2.sh
+              python3 -m torch.utils.collect_env
+              python3 -m k2.version
+              pip list
+
+              apt-get install -y -q git-lfs tree
+
+              .github/scripts/run-wenetspeech-pruned-transducer-stateless2.sh

--- a/.github/workflows/run-wenetspeech-pruned-transducer-stateless2.yml
+++ b/.github/workflows/run-wenetspeech-pruned-transducer-stateless2.yml
@@ -59,7 +59,8 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
-              python3 -m pip install onnxscript lilcom torchcodec
+              python3 -m pip install onnxscript lilcom
+              python3 -c "import torch; v=torch.__version__.split('.'); exit(0 if (int(v[0]),int(v[1])) >= (2,9) else 1)" && python3 -m pip install torchcodec==0.14.0+cpu -f https://download.pytorch.org/whl/torchcodec || true
 
               python3 -m torch.utils.collect_env
               python3 -m k2.version

--- a/.github/workflows/run-wenetspeech-pruned-transducer-stateless2.yml
+++ b/.github/workflows/run-wenetspeech-pruned-transducer-stateless2.yml
@@ -59,9 +59,6 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
-              python3 -m pip install onnxscript lilcom
-              python3 -c "import torch; v=torch.__version__.split('.'); exit(0 if (int(v[0]),int(v[1])) >= (2,9) else 1)" && python3 -m pip install torchcodec==0.14.0+cpu -f https://download.pytorch.org/whl/torchcodec || true
-
               python3 -m torch.utils.collect_env
               python3 -m k2.version
               pip list

--- a/.github/workflows/run-wenetspeech-pruned-transducer-stateless2.yml
+++ b/.github/workflows/run-wenetspeech-pruned-transducer-stateless2.yml
@@ -59,6 +59,8 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
+              python3 -m pip install onnxscript lilcom
+
               python3 -m torch.utils.collect_env
               python3 -m k2.version
               pip list

--- a/.github/workflows/run-wenetspeech-pruned-transducer-stateless2.yml
+++ b/.github/workflows/run-wenetspeech-pruned-transducer-stateless2.yml
@@ -59,7 +59,7 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
-              python3 -m pip install onnxscript lilcom
+              python3 -m pip install onnxscript lilcom torchcodec
 
               python3 -m torch.utils.collect_env
               python3 -m k2.version

--- a/.github/workflows/run-wenetspeech-pruned-transducer-stateless2.yml
+++ b/.github/workflows/run-wenetspeech-pruned-transducer-stateless2.yml
@@ -26,8 +26,8 @@ jobs:
       - name: Generating build matrix
         id: set-matrix
         run: |
-          python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10"
-          MATRIX=$(python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10")
+          python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10" --min-torch-version "2.2.0"
+          MATRIX=$(python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10" --min-torch-version "2.2.0")
           echo "::set-output name=matrix::${MATRIX}"
 
   run_wenetspeech_pruned_transducer_stateless2:

--- a/.github/workflows/run-wenetspeech-pruned-transducer-stateless2.yml
+++ b/.github/workflows/run-wenetspeech-pruned-transducer-stateless2.yml
@@ -41,12 +41,12 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
@@ -60,7 +60,7 @@ jobs:
 
       - name: Cache kaldifeat
         id: my-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/tmp/kaldifeat

--- a/.github/workflows/run-wenetspeech-pruned-transducer-stateless2.yml
+++ b/.github/workflows/run-wenetspeech-pruned-transducer-stateless2.yml
@@ -51,6 +51,7 @@ jobs:
             image: ghcr.io/${{ github.repository_owner }}/icefall:cpu-py${{ matrix.python-version }}-torch${{ matrix.torch-version }}-v${{ matrix.version }}
             options: |
               --volume ${{ github.workspace }}/:/icefall
+              -e TORCHAUDIO_USE_BACKEND=soundfile
               -e GITHUB_EVENT_NAME=${{ github.event_name }}
               -e GITHUB_EVENT_LABEL_NAME=${{ github.event.label.name }}
             shell: bash

--- a/.github/workflows/style_check.yml
+++ b/.github/workflows/style_check.yml
@@ -40,12 +40,12 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/style_check.yml
+++ b/.github/workflows/style_check.yml
@@ -56,9 +56,6 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
-              python3 -m pip install onnxscript lilcom
-              python3 -c "import torch; v=torch.__version__.split('.'); exit(0 if (int(v[0]),int(v[1])) >= (2,9) else 1)" && python3 -m pip install torchcodec==0.14.0+cpu -f https://download.pytorch.org/whl/torchcodec || true
-
               python3 -m pip install --upgrade pip black==22.3.0 flake8==5.0.4 click==8.1.0 isort==5.10.1
 
       - name: Run flake8
@@ -72,9 +69,6 @@ jobs:
             run: |
               cd /icefall
               git config --global --add safe.directory /icefall
-
-              python3 -m pip install onnxscript lilcom
-              python3 -c "import torch; v=torch.__version__.split('.'); exit(0 if (int(v[0]),int(v[1])) >= (2,9) else 1)" && python3 -m pip install torchcodec==0.14.0+cpu -f https://download.pytorch.org/whl/torchcodec || true
 
               python3 -m pip install --upgrade black==22.3.0 flake8==5.0.4 click==8.1.0 isort==5.10.1
 
@@ -96,9 +90,6 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
-              python3 -m pip install onnxscript lilcom
-              python3 -c "import torch; v=torch.__version__.split('.'); exit(0 if (int(v[0]),int(v[1])) >= (2,9) else 1)" && python3 -m pip install torchcodec==0.14.0+cpu -f https://download.pytorch.org/whl/torchcodec || true
-
               python3 -m pip install --upgrade black==22.3.0 click==8.1.0
               black --check --diff .
 
@@ -113,9 +104,6 @@ jobs:
             run: |
               cd /icefall
               git config --global --add safe.directory /icefall
-
-              python3 -m pip install onnxscript lilcom
-              python3 -c "import torch; v=torch.__version__.split('.'); exit(0 if (int(v[0]),int(v[1])) >= (2,9) else 1)" && python3 -m pip install torchcodec==0.14.0+cpu -f https://download.pytorch.org/whl/torchcodec || true
 
               python3 -m pip install --upgrade isort==5.10.1
               isort --check --diff .

--- a/.github/workflows/style_check.yml
+++ b/.github/workflows/style_check.yml
@@ -1,19 +1,3 @@
-# Copyright      2021  Fangjun Kuang (csukuangfj@gmail.com)
-
-# See ../../LICENSE for clarification regarding multiple authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 name: style_check
 
 on:
@@ -31,47 +15,95 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  generate_build_matrix:
+    if: github.repository_owner == 'csukuangfj' || github.repository_owner == 'k2-fsa'
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Generating build matrix
+        id: set-matrix
+        run: |
+          python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10"
+          MATRIX=$(python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10")
+          echo "::set-output name=matrix::${MATRIX}"
+
   style_check:
-    runs-on: ${{ matrix.os }}
+    needs: generate_build_matrix
+    name: py${{ matrix.python-version }} torch${{ matrix.torch-version }} v${{ matrix.version }}
+    runs-on: ubuntu-latest
     strategy:
-      matrix:
-        os: [ubuntu-latest]
-        python-version: ["3.10"]
       fail-fast: false
+      matrix:
+        ${{ fromJson(needs.generate_build_matrix.outputs.matrix) }}
 
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+      - name: Install linting tools
+        uses: addnab/docker-run-action@v3
         with:
-          python-version: ${{ matrix.python-version }}
+            image: ghcr.io/${{ github.repository_owner }}/icefall:cpu-py${{ matrix.python-version }}-torch${{ matrix.torch-version }}-v${{ matrix.version }}
+            options: |
+              --volume ${{ github.workspace }}/:/icefall
+            shell: bash
+            run: |
+              cd /icefall
+              git config --global --add safe.directory /icefall
 
-      - name: Install Python dependencies
-        run: |
-          python3 -m pip install --upgrade pip black==22.3.0 flake8==5.0.4 click==8.1.0 isort==5.10.1
-          # Click issue fixed in https://github.com/psf/black/pull/2966
+              python3 -m pip install --upgrade pip black==22.3.0 flake8==5.0.4 click==8.1.0 isort==5.10.1
 
       - name: Run flake8
-        shell: bash
-        working-directory: ${{github.workspace}}
-        run: |
-          # stop the build if there are Python syntax errors or undefined names
-          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 \
-            --statistics --extend-ignore=E203,E266,E501,F401,E402,F403,F841,W503
+        uses: addnab/docker-run-action@v3
+        with:
+            image: ghcr.io/${{ github.repository_owner }}/icefall:cpu-py${{ matrix.python-version }}-torch${{ matrix.torch-version }}-v${{ matrix.version }}
+            options: |
+              --volume ${{ github.workspace }}/:/icefall
+            shell: bash
+            working-directory: /icefall
+            run: |
+              cd /icefall
+              git config --global --add safe.directory /icefall
+
+              python3 -m pip install --upgrade black==22.3.0 flake8==5.0.4 click==8.1.0 isort==5.10.1
+
+              # stop the build if there are Python syntax errors or undefined names
+              flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+              # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+              flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 \
+                --statistics --extend-ignore=E203,E266,E501,F401,E402,F403,F841,W503
 
       - name: Run black
-        shell: bash
-        working-directory: ${{github.workspace}}
-        run: |
-          black --check --diff .
+        uses: addnab/docker-run-action@v3
+        with:
+            image: ghcr.io/${{ github.repository_owner }}/icefall:cpu-py${{ matrix.python-version }}-torch${{ matrix.torch-version }}-v${{ matrix.version }}
+            options: |
+              --volume ${{ github.workspace }}/:/icefall
+            shell: bash
+            working-directory: /icefall
+            run: |
+              cd /icefall
+              git config --global --add safe.directory /icefall
+
+              python3 -m pip install --upgrade black==22.3.0 click==8.1.0
+              black --check --diff .
 
       - name: Run isort
-        shell: bash
-        working-directory: ${{github.workspace}}
-        run: |
-          isort --check --diff .
+        uses: addnab/docker-run-action@v3
+        with:
+            image: ghcr.io/${{ github.repository_owner }}/icefall:cpu-py${{ matrix.python-version }}-torch${{ matrix.torch-version }}-v${{ matrix.version }}
+            options: |
+              --volume ${{ github.workspace }}/:/icefall
+            shell: bash
+            working-directory: /icefall
+            run: |
+              cd /icefall
+              git config --global --add safe.directory /icefall
+
+              python3 -m pip install --upgrade isort==5.10.1
+              isort --check --diff .

--- a/.github/workflows/style_check.yml
+++ b/.github/workflows/style_check.yml
@@ -56,7 +56,8 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
-              python3 -m pip install onnxscript lilcom torchcodec
+              python3 -m pip install onnxscript lilcom
+              python3 -c "import torch; v=torch.__version__.split('.'); exit(0 if (int(v[0]),int(v[1])) >= (2,9) else 1)" && python3 -m pip install torchcodec==0.14.0+cpu -f https://download.pytorch.org/whl/torchcodec || true
 
               python3 -m pip install --upgrade pip black==22.3.0 flake8==5.0.4 click==8.1.0 isort==5.10.1
 
@@ -72,7 +73,8 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
-              python3 -m pip install onnxscript lilcom torchcodec
+              python3 -m pip install onnxscript lilcom
+              python3 -c "import torch; v=torch.__version__.split('.'); exit(0 if (int(v[0]),int(v[1])) >= (2,9) else 1)" && python3 -m pip install torchcodec==0.14.0+cpu -f https://download.pytorch.org/whl/torchcodec || true
 
               python3 -m pip install --upgrade black==22.3.0 flake8==5.0.4 click==8.1.0 isort==5.10.1
 
@@ -94,7 +96,8 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
-              python3 -m pip install onnxscript lilcom torchcodec
+              python3 -m pip install onnxscript lilcom
+              python3 -c "import torch; v=torch.__version__.split('.'); exit(0 if (int(v[0]),int(v[1])) >= (2,9) else 1)" && python3 -m pip install torchcodec==0.14.0+cpu -f https://download.pytorch.org/whl/torchcodec || true
 
               python3 -m pip install --upgrade black==22.3.0 click==8.1.0
               black --check --diff .
@@ -111,7 +114,8 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
-              python3 -m pip install onnxscript lilcom torchcodec
+              python3 -m pip install onnxscript lilcom
+              python3 -c "import torch; v=torch.__version__.split('.'); exit(0 if (int(v[0]),int(v[1])) >= (2,9) else 1)" && python3 -m pip install torchcodec==0.14.0+cpu -f https://download.pytorch.org/whl/torchcodec || true
 
               python3 -m pip install --upgrade isort==5.10.1
               isort --check --diff .

--- a/.github/workflows/style_check.yml
+++ b/.github/workflows/style_check.yml
@@ -56,6 +56,8 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
+              python3 -m pip install onnxscript lilcom
+
               python3 -m pip install --upgrade pip black==22.3.0 flake8==5.0.4 click==8.1.0 isort==5.10.1
 
       - name: Run flake8
@@ -69,6 +71,8 @@ jobs:
             run: |
               cd /icefall
               git config --global --add safe.directory /icefall
+
+              python3 -m pip install onnxscript lilcom
 
               python3 -m pip install --upgrade black==22.3.0 flake8==5.0.4 click==8.1.0 isort==5.10.1
 
@@ -90,6 +94,8 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
+              python3 -m pip install onnxscript lilcom
+
               python3 -m pip install --upgrade black==22.3.0 click==8.1.0
               black --check --diff .
 
@@ -104,6 +110,8 @@ jobs:
             run: |
               cd /icefall
               git config --global --add safe.directory /icefall
+
+              python3 -m pip install onnxscript lilcom
 
               python3 -m pip install --upgrade isort==5.10.1
               isort --check --diff .

--- a/.github/workflows/style_check.yml
+++ b/.github/workflows/style_check.yml
@@ -51,6 +51,7 @@ jobs:
             image: ghcr.io/${{ github.repository_owner }}/icefall:cpu-py${{ matrix.python-version }}-torch${{ matrix.torch-version }}-v${{ matrix.version }}
             options: |
               --volume ${{ github.workspace }}/:/icefall
+              -e TORCHAUDIO_USE_BACKEND=soundfile
             shell: bash
             run: |
               cd /icefall
@@ -64,6 +65,7 @@ jobs:
             image: ghcr.io/${{ github.repository_owner }}/icefall:cpu-py${{ matrix.python-version }}-torch${{ matrix.torch-version }}-v${{ matrix.version }}
             options: |
               --volume ${{ github.workspace }}/:/icefall
+              -e TORCHAUDIO_USE_BACKEND=soundfile
             shell: bash
             working-directory: /icefall
             run: |
@@ -84,6 +86,7 @@ jobs:
             image: ghcr.io/${{ github.repository_owner }}/icefall:cpu-py${{ matrix.python-version }}-torch${{ matrix.torch-version }}-v${{ matrix.version }}
             options: |
               --volume ${{ github.workspace }}/:/icefall
+              -e TORCHAUDIO_USE_BACKEND=soundfile
             shell: bash
             working-directory: /icefall
             run: |
@@ -99,6 +102,7 @@ jobs:
             image: ghcr.io/${{ github.repository_owner }}/icefall:cpu-py${{ matrix.python-version }}-torch${{ matrix.torch-version }}-v${{ matrix.version }}
             options: |
               --volume ${{ github.workspace }}/:/icefall
+              -e TORCHAUDIO_USE_BACKEND=soundfile
             shell: bash
             working-directory: /icefall
             run: |

--- a/.github/workflows/style_check.yml
+++ b/.github/workflows/style_check.yml
@@ -56,7 +56,7 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
-              python3 -m pip install onnxscript lilcom
+              python3 -m pip install onnxscript lilcom torchcodec
 
               python3 -m pip install --upgrade pip black==22.3.0 flake8==5.0.4 click==8.1.0 isort==5.10.1
 
@@ -72,7 +72,7 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
-              python3 -m pip install onnxscript lilcom
+              python3 -m pip install onnxscript lilcom torchcodec
 
               python3 -m pip install --upgrade black==22.3.0 flake8==5.0.4 click==8.1.0 isort==5.10.1
 
@@ -94,7 +94,7 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
-              python3 -m pip install onnxscript lilcom
+              python3 -m pip install onnxscript lilcom torchcodec
 
               python3 -m pip install --upgrade black==22.3.0 click==8.1.0
               black --check --diff .
@@ -111,7 +111,7 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
-              python3 -m pip install onnxscript lilcom
+              python3 -m pip install onnxscript lilcom torchcodec
 
               python3 -m pip install --upgrade isort==5.10.1
               isort --check --diff .

--- a/.github/workflows/style_check.yml
+++ b/.github/workflows/style_check.yml
@@ -27,8 +27,8 @@ jobs:
       - name: Generating build matrix
         id: set-matrix
         run: |
-          python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10"
-          MATRIX=$(python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10")
+          python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10" --min-torch-version "2.2.0"
+          MATRIX=$(python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10" --min-torch-version "2.2.0")
           echo "::set-output name=matrix::${MATRIX}"
 
   style_check:

--- a/.github/workflows/test-ncnn-export.yml
+++ b/.github/workflows/test-ncnn-export.yml
@@ -54,6 +54,7 @@ jobs:
             image: ghcr.io/${{ github.repository_owner }}/icefall:cpu-py${{ matrix.python-version }}-torch${{ matrix.torch-version }}-v${{ matrix.version }}
             options: |
               --volume ${{ github.workspace }}/:/icefall
+              -e TORCHAUDIO_USE_BACKEND=soundfile
               -e GITHUB_EVENT_NAME=${{ github.event_name }}
               -e GITHUB_EVENT_LABEL_NAME=${{ github.event.label.name }}
             shell: bash

--- a/.github/workflows/test-ncnn-export.yml
+++ b/.github/workflows/test-ncnn-export.yml
@@ -62,9 +62,6 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
-              python3 -m pip install onnxscript lilcom
-              python3 -c "import torch; v=torch.__version__.split('.'); exit(0 if (int(v[0]),int(v[1])) >= (2,9) else 1)" && python3 -m pip install torchcodec==0.14.0+cpu -f https://download.pytorch.org/whl/torchcodec || true
-
               python3 -m torch.utils.collect_env
               python3 -m k2.version
               pip list

--- a/.github/workflows/test-ncnn-export.yml
+++ b/.github/workflows/test-ncnn-export.yml
@@ -62,7 +62,8 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
-              python3 -m pip install onnxscript lilcom torchcodec
+              python3 -m pip install onnxscript lilcom
+              python3 -c "import torch; v=torch.__version__.split('.'); exit(0 if (int(v[0]),int(v[1])) >= (2,9) else 1)" && python3 -m pip install torchcodec==0.14.0+cpu -f https://download.pytorch.org/whl/torchcodec || true
 
               python3 -m torch.utils.collect_env
               python3 -m k2.version

--- a/.github/workflows/test-ncnn-export.yml
+++ b/.github/workflows/test-ncnn-export.yml
@@ -8,12 +8,6 @@ on:
     types: [labeled]
 
   schedule:
-    # minute (0-59)
-    # hour (0-23)
-    # day of the month (1-31)
-    # month (1-12)
-    # day of the week (0-6)
-    # nightly build at 15:50 UTC time every day
     - cron: "50 15 * * *"
 
   workflow_dispatch:
@@ -23,55 +17,53 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  generate_build_matrix:
+    if: github.repository_owner == 'csukuangfj' || github.repository_owner == 'k2-fsa'
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Generating build matrix
+        id: set-matrix
+        run: |
+          python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10"
+          MATRIX=$(python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10")
+          echo "::set-output name=matrix::${MATRIX}"
+
   test_ncnn_export:
     if: github.event.label.name == 'ready' || github.event.label.name == 'ncnn' || github.event_name == 'push' || github.event_name == 'schedule'
-    runs-on: ${{ matrix.os }}
+    needs: generate_build_matrix
+    name: py${{ matrix.python-version }} torch${{ matrix.torch-version }} v${{ matrix.version }}
+    runs-on: ubuntu-latest
     strategy:
-      matrix:
-        os: [ubuntu-latest]
-        python-version: [3.8]
       fail-fast: false
+      matrix:
+        ${{ fromJson(needs.generate_build_matrix.outputs.matrix) }}
 
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: 'pip'
-          cache-dependency-path: '**/requirements-ci.txt'
-
-      - name: Install Python dependencies
-        run: |
-          grep -v '^#' ./requirements-ci.txt  | xargs -n 1 -L 1 pip install
-          pip uninstall -y protobuf
-          pip install --no-binary protobuf protobuf==3.20.*
-
-      - name: Cache kaldifeat
-        id: my-cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/tmp/kaldifeat
-          key: cache-tmp-${{ matrix.python-version }}-2023-05-22
-
-      - name: Install kaldifeat
-        if: steps.my-cache.outputs.cache-hit != 'true'
-        shell: bash
-        run: |
-          .github/scripts/install-kaldifeat.sh
-
       - name: Test ncnn export
-        shell: bash
-        env:
-          GITHUB_EVENT_NAME: ${{ github.event_name }}
-          GITHUB_EVENT_LABEL_NAME: ${{ github.event.label.name }}
-        run: |
-          export PYTHONPATH=$PWD:$PYTHONPATH
-          export PYTHONPATH=~/tmp/kaldifeat/kaldifeat/python:$PYTHONPATH
-          export PYTHONPATH=~/tmp/kaldifeat/build/lib:$PYTHONPATH
+        uses: addnab/docker-run-action@v3
+        with:
+            image: ghcr.io/${{ github.repository_owner }}/icefall:cpu-py${{ matrix.python-version }}-torch${{ matrix.torch-version }}-v${{ matrix.version }}
+            options: |
+              --volume ${{ github.workspace }}/:/icefall
+              -e GITHUB_EVENT_NAME=${{ github.event_name }}
+              -e GITHUB_EVENT_LABEL_NAME=${{ github.event.label.name }}
+            shell: bash
+            run: |
+              export PYTHONPATH=/icefall:$PYTHONPATH
+              cd /icefall
+              git config --global --add safe.directory /icefall
 
-          .github/scripts/test-ncnn-export.sh
+              python3 -m torch.utils.collect_env
+              python3 -m k2.version
+              pip list
+
+              .github/scripts/test-ncnn-export.sh

--- a/.github/workflows/test-ncnn-export.yml
+++ b/.github/workflows/test-ncnn-export.yml
@@ -33,12 +33,12 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
@@ -52,7 +52,7 @@ jobs:
 
       - name: Cache kaldifeat
         id: my-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/tmp/kaldifeat

--- a/.github/workflows/test-ncnn-export.yml
+++ b/.github/workflows/test-ncnn-export.yml
@@ -29,8 +29,8 @@ jobs:
       - name: Generating build matrix
         id: set-matrix
         run: |
-          python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10"
-          MATRIX=$(python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10")
+          python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10" --min-torch-version "2.2.0"
+          MATRIX=$(python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10" --min-torch-version "2.2.0")
           echo "::set-output name=matrix::${MATRIX}"
 
   test_ncnn_export:

--- a/.github/workflows/test-ncnn-export.yml
+++ b/.github/workflows/test-ncnn-export.yml
@@ -62,6 +62,8 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
+              python3 -m pip install onnxscript lilcom
+
               python3 -m torch.utils.collect_env
               python3 -m k2.version
               pip list

--- a/.github/workflows/test-ncnn-export.yml
+++ b/.github/workflows/test-ncnn-export.yml
@@ -62,7 +62,7 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
-              python3 -m pip install onnxscript lilcom
+              python3 -m pip install onnxscript lilcom torchcodec
 
               python3 -m torch.utils.collect_env
               python3 -m k2.version

--- a/.github/workflows/test-onnx-export.yml
+++ b/.github/workflows/test-onnx-export.yml
@@ -54,6 +54,7 @@ jobs:
             image: ghcr.io/${{ github.repository_owner }}/icefall:cpu-py${{ matrix.python-version }}-torch${{ matrix.torch-version }}-v${{ matrix.version }}
             options: |
               --volume ${{ github.workspace }}/:/icefall
+              -e TORCHAUDIO_USE_BACKEND=soundfile
               -e GITHUB_EVENT_NAME=${{ github.event_name }}
               -e GITHUB_EVENT_LABEL_NAME=${{ github.event.label.name }}
             shell: bash

--- a/.github/workflows/test-onnx-export.yml
+++ b/.github/workflows/test-onnx-export.yml
@@ -62,9 +62,6 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
-              python3 -m pip install onnxscript lilcom
-              python3 -c "import torch; v=torch.__version__.split('.'); exit(0 if (int(v[0]),int(v[1])) >= (2,9) else 1)" && python3 -m pip install torchcodec==0.14.0+cpu -f https://download.pytorch.org/whl/torchcodec || true
-
               python3 -m torch.utils.collect_env
               python3 -m k2.version
               pip list

--- a/.github/workflows/test-onnx-export.yml
+++ b/.github/workflows/test-onnx-export.yml
@@ -29,8 +29,8 @@ jobs:
       - name: Generating build matrix
         id: set-matrix
         run: |
-          python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10"
-          MATRIX=$(python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10")
+          python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10" --min-torch-version "2.2.0"
+          MATRIX=$(python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10" --min-torch-version "2.2.0")
           echo "::set-output name=matrix::${MATRIX}"
 
   test_onnx_export:

--- a/.github/workflows/test-onnx-export.yml
+++ b/.github/workflows/test-onnx-export.yml
@@ -62,7 +62,8 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
-              python3 -m pip install onnxscript lilcom torchcodec
+              python3 -m pip install onnxscript lilcom
+              python3 -c "import torch; v=torch.__version__.split('.'); exit(0 if (int(v[0]),int(v[1])) >= (2,9) else 1)" && python3 -m pip install torchcodec==0.14.0+cpu -f https://download.pytorch.org/whl/torchcodec || true
 
               python3 -m torch.utils.collect_env
               python3 -m k2.version

--- a/.github/workflows/test-onnx-export.yml
+++ b/.github/workflows/test-onnx-export.yml
@@ -33,12 +33,12 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
@@ -52,7 +52,7 @@ jobs:
 
       - name: Cache kaldifeat
         id: my-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/tmp/kaldifeat

--- a/.github/workflows/test-onnx-export.yml
+++ b/.github/workflows/test-onnx-export.yml
@@ -62,6 +62,8 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
+              python3 -m pip install onnxscript lilcom
+
               python3 -m torch.utils.collect_env
               python3 -m k2.version
               pip list

--- a/.github/workflows/test-onnx-export.yml
+++ b/.github/workflows/test-onnx-export.yml
@@ -62,7 +62,7 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
-              python3 -m pip install onnxscript lilcom
+              python3 -m pip install onnxscript lilcom torchcodec
 
               python3 -m torch.utils.collect_env
               python3 -m k2.version

--- a/.github/workflows/test-onnx-export.yml
+++ b/.github/workflows/test-onnx-export.yml
@@ -8,12 +8,6 @@ on:
     types: [labeled]
 
   schedule:
-    # minute (0-59)
-    # hour (0-23)
-    # day of the month (1-31)
-    # month (1-12)
-    # day of the week (0-6)
-    # nightly build at 15:50 UTC time every day
     - cron: "50 15 * * *"
 
   workflow_dispatch:
@@ -23,55 +17,53 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  generate_build_matrix:
+    if: github.repository_owner == 'csukuangfj' || github.repository_owner == 'k2-fsa'
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Generating build matrix
+        id: set-matrix
+        run: |
+          python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10"
+          MATRIX=$(python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10")
+          echo "::set-output name=matrix::${MATRIX}"
+
   test_onnx_export:
     if: github.event.label.name == 'ready' || github.event.label.name == 'onnx' || github.event_name == 'push' || github.event_name == 'schedule'
-    runs-on: ${{ matrix.os }}
+    needs: generate_build_matrix
+    name: py${{ matrix.python-version }} torch${{ matrix.torch-version }} v${{ matrix.version }}
+    runs-on: ubuntu-latest
     strategy:
-      matrix:
-        os: [ubuntu-latest]
-        python-version: [3.8]
       fail-fast: false
+      matrix:
+        ${{ fromJson(needs.generate_build_matrix.outputs.matrix) }}
 
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: 'pip'
-          cache-dependency-path: '**/requirements-ci.txt'
-
-      - name: Install Python dependencies
-        run: |
-          grep -v '^#' ./requirements-ci.txt  | xargs -n 1 -L 1 pip install
-          pip uninstall -y protobuf
-          pip install --no-binary protobuf protobuf==3.20.*
-
-      - name: Cache kaldifeat
-        id: my-cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/tmp/kaldifeat
-          key: cache-tmp-${{ matrix.python-version }}-2023-05-22
-
-      - name: Install kaldifeat
-        if: steps.my-cache.outputs.cache-hit != 'true'
-        shell: bash
-        run: |
-          .github/scripts/install-kaldifeat.sh
-
       - name: Test ONNX export
-        shell: bash
-        env:
-          GITHUB_EVENT_NAME: ${{ github.event_name }}
-          GITHUB_EVENT_LABEL_NAME: ${{ github.event.label.name }}
-        run: |
-          export PYTHONPATH=$PWD:$PYTHONPATH
-          export PYTHONPATH=~/tmp/kaldifeat/kaldifeat/python:$PYTHONPATH
-          export PYTHONPATH=~/tmp/kaldifeat/build/lib:$PYTHONPATH
+        uses: addnab/docker-run-action@v3
+        with:
+            image: ghcr.io/${{ github.repository_owner }}/icefall:cpu-py${{ matrix.python-version }}-torch${{ matrix.torch-version }}-v${{ matrix.version }}
+            options: |
+              --volume ${{ github.workspace }}/:/icefall
+              -e GITHUB_EVENT_NAME=${{ github.event_name }}
+              -e GITHUB_EVENT_LABEL_NAME=${{ github.event.label.name }}
+            shell: bash
+            run: |
+              export PYTHONPATH=/icefall:$PYTHONPATH
+              cd /icefall
+              git config --global --add safe.directory /icefall
 
-          .github/scripts/test-onnx-export.sh
+              python3 -m torch.utils.collect_env
+              python3 -m k2.version
+              pip list
+
+              .github/scripts/test-onnx-export.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,6 +62,7 @@ jobs:
             image: ghcr.io/${{ github.repository_owner }}/icefall:cpu-py${{ matrix.python-version }}-torch${{ matrix.torch-version }}-v${{ matrix.version }}
             options: |
               --volume ${{ github.workspace }}/:/icefall
+              -e TORCHAUDIO_USE_BACKEND=soundfile
             shell: bash
             run: |
               export PYTHONPATH=/icefall:$PYTHONPATH

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,7 +68,7 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
-              python3 -m pip install onnxscript lilcom
+              python3 -m pip install onnxscript lilcom torchcodec
 
               pytest -v -s ./test
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,7 +68,8 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
-              python3 -m pip install onnxscript lilcom torchcodec
+              python3 -m pip install onnxscript lilcom
+              python3 -c "import torch; v=torch.__version__.split('.'); exit(0 if (int(v[0]),int(v[1])) >= (2,9) else 1)" && python3 -m pip install torchcodec==0.14.0+cpu -f https://download.pytorch.org/whl/torchcodec || true
 
               pytest -v -s ./test
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,9 +68,6 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
-              python3 -m pip install onnxscript lilcom
-              python3 -c "import torch; v=torch.__version__.split('.'); exit(0 if (int(v[0]),int(v[1])) >= (2,9) else 1)" && python3 -m pip install torchcodec==0.14.0+cpu -f https://download.pytorch.org/whl/torchcodec || true
-
               pytest -v -s ./test
 
               # runt tests for conformer ctc

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,8 +30,8 @@ jobs:
         id: set-matrix
         run: |
           # outputting for debugging purposes
-          python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10"
-          MATRIX=$(python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10")
+          python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10" --min-torch-version "2.2.0"
+          MATRIX=$(python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10" --min-torch-version "2.2.0")
           echo "::set-output name=matrix::${MATRIX}"
   test:
     needs: generate_build_matrix
@@ -106,6 +106,7 @@ jobs:
               pytest -v -s
 
       - uses: actions/upload-artifact@v4
+        if: matrix.torch-version == '2.13.0'
         with:
           path: egs/librispeech/ASR/zipformer/swoosh.pdf
           name: swoosh-${{ matrix.python-version }}-${{ matrix.torch-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,6 +68,8 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
+              python3 -m pip install onnxscript lilcom
+
               pytest -v -s ./test
 
               # runt tests for conformer ctc

--- a/.github/workflows/yesno.yml
+++ b/.github/workflows/yesno.yml
@@ -60,9 +60,6 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
-              python3 -m pip install onnxscript lilcom
-              python3 -c "import torch; v=torch.__version__.split('.'); exit(0 if (int(v[0]),int(v[1])) >= (2,9) else 1)" && python3 -m pip install torchcodec==0.14.0+cpu -f https://download.pytorch.org/whl/torchcodec || true
-
               python3 -m torch.utils.collect_env
               python3 -m k2.version
               pip list

--- a/.github/workflows/yesno.yml
+++ b/.github/workflows/yesno.yml
@@ -54,6 +54,7 @@ jobs:
             image: ghcr.io/${{ github.repository_owner }}/icefall:cpu-py${{ matrix.python-version }}-torch${{ matrix.torch-version }}-v${{ matrix.version }}
             options: |
               --volume ${{ github.workspace }}/:/icefall
+              -e TORCHAUDIO_USE_BACKEND=soundfile
             shell: bash
             run: |
               export PYTHONPATH=/icefall:$PYTHONPATH

--- a/.github/workflows/yesno.yml
+++ b/.github/workflows/yesno.yml
@@ -30,9 +30,9 @@ jobs:
         id: set-matrix
         run: |
           # outputting for debugging purposes
-          python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10"
-          MATRIX=$(python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10")
-          # MATRIX=$(python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10" --min-torch-version "2.5.0")
+          python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10" --min-torch-version "2.2.0"
+          MATRIX=$(python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10" --min-torch-version "2.2.0")
+          # MATRIX=$(python ./.github/scripts/docker/generate_build_matrix.py --python-version "3.10" --min-torch-version "2.2.0" --min-torch-version "2.5.0")
           echo "::set-output name=matrix::${MATRIX}"
   yesno:
     needs: generate_build_matrix

--- a/.github/workflows/yesno.yml
+++ b/.github/workflows/yesno.yml
@@ -60,7 +60,7 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
-              python3 -m pip install onnxscript lilcom
+              python3 -m pip install onnxscript lilcom torchcodec
 
               python3 -m torch.utils.collect_env
               python3 -m k2.version

--- a/.github/workflows/yesno.yml
+++ b/.github/workflows/yesno.yml
@@ -60,7 +60,8 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
-              python3 -m pip install onnxscript lilcom torchcodec
+              python3 -m pip install onnxscript lilcom
+              python3 -c "import torch; v=torch.__version__.split('.'); exit(0 if (int(v[0]),int(v[1])) >= (2,9) else 1)" && python3 -m pip install torchcodec==0.14.0+cpu -f https://download.pytorch.org/whl/torchcodec || true
 
               python3 -m torch.utils.collect_env
               python3 -m k2.version

--- a/.github/workflows/yesno.yml
+++ b/.github/workflows/yesno.yml
@@ -60,6 +60,8 @@ jobs:
               cd /icefall
               git config --global --add safe.directory /icefall
 
+              python3 -m pip install onnxscript lilcom
+
               python3 -m torch.utils.collect_env
               python3 -m k2.version
               pip list

--- a/egs/aidatatang_200zh/ASR/pruned_transducer_stateless2/pretrained.py
+++ b/egs/aidatatang_200zh/ASR/pruned_transducer_stateless2/pretrained.py
@@ -62,7 +62,7 @@ from typing import List
 import k2
 import kaldifeat
 import torch
-import torchaudio
+import soundfile as sf
 from beam_search import (
     beam_search,
     fast_beam_search_one_best,
@@ -113,7 +113,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -191,7 +191,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/aishell/ASR/conformer_ctc/pretrained.py
+++ b/egs/aishell/ASR/conformer_ctc/pretrained.py
@@ -25,7 +25,7 @@ from typing import List
 import k2
 import kaldifeat
 import torch
-import torchaudio
+import soundfile as sf
 from conformer import Conformer
 from torch.nn.utils.rnn import pad_sequence
 
@@ -164,7 +164,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -209,7 +209,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/aishell/ASR/pruned_transducer_stateless2/pretrained.py
+++ b/egs/aishell/ASR/pruned_transducer_stateless2/pretrained.py
@@ -64,7 +64,7 @@ from typing import List
 import k2
 import kaldifeat
 import torch
-import torchaudio
+import soundfile as sf
 from beam_search import (
     beam_search,
     fast_beam_search_one_best,
@@ -116,7 +116,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -194,7 +194,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/aishell/ASR/pruned_transducer_stateless3/pretrained.py
+++ b/egs/aishell/ASR/pruned_transducer_stateless3/pretrained.py
@@ -64,7 +64,7 @@ from typing import List
 import k2
 import kaldifeat
 import torch
-import torchaudio
+import soundfile as sf
 from beam_search import (
     beam_search,
     fast_beam_search_one_best,
@@ -116,7 +116,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -194,7 +194,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/aishell/ASR/pruned_transducer_stateless7/export-onnx.py
+++ b/egs/aishell/ASR/pruned_transducer_stateless7/export-onnx.py
@@ -66,6 +66,7 @@ from icefall.checkpoint import (
     load_checkpoint,
 )
 from icefall.utils import num_tokens, setup_logger, str2bool
+from icefall.utils import get_onnx_export_kwargs
 
 
 def get_parser():
@@ -288,7 +289,8 @@ def export_encoder_model_onnx(
             "x_lens": {0: "N"},
             "encoder_out": {0: "N", 1: "T"},
             "encoder_out_lens": {0: "N"},
-        },
+        },,
+        **get_onnx_export_kwargs(),
     )
 
 
@@ -332,7 +334,7 @@ def export_decoder_model_onnx(
             "y": {0: "N"},
             "decoder_out": {0: "N"},
         },
-    )
+    , **get_onnx_export_kwargs())
 
     meta_data = {
         "context_size": str(context_size),
@@ -377,7 +379,8 @@ def export_joiner_model_onnx(
             "encoder_out": {0: "N"},
             "decoder_out": {0: "N"},
             "logit": {0: "N"},
-        },
+        },,
+        **get_onnx_export_kwargs(),
     )
     meta_data = {
         "joiner_dim": str(joiner_dim),

--- a/egs/aishell/ASR/pruned_transducer_stateless7/export-onnx.py
+++ b/egs/aishell/ASR/pruned_transducer_stateless7/export-onnx.py
@@ -289,9 +289,9 @@ def export_encoder_model_onnx(
             "x_lens": {0: "N"},
             "encoder_out": {0: "N", 1: "T"},
             "encoder_out_lens": {0: "N"},
-        }
+        },
         **get_onnx_export_kwargs(),
-    )
+)
 
 
 def export_decoder_model_onnx(
@@ -334,7 +334,8 @@ def export_decoder_model_onnx(
             "y": {0: "N"},
             "decoder_out": {0: "N"},
         },
-    , **get_onnx_export_kwargs())
+        **get_onnx_export_kwargs(),
+)
 
     meta_data = {
         "context_size": str(context_size),
@@ -379,9 +380,9 @@ def export_joiner_model_onnx(
             "encoder_out": {0: "N"},
             "decoder_out": {0: "N"},
             "logit": {0: "N"},
-        }
+        },
         **get_onnx_export_kwargs(),
-    )
+)
     meta_data = {
         "joiner_dim": str(joiner_dim),
     }

--- a/egs/aishell/ASR/pruned_transducer_stateless7/export-onnx.py
+++ b/egs/aishell/ASR/pruned_transducer_stateless7/export-onnx.py
@@ -289,7 +289,7 @@ def export_encoder_model_onnx(
             "x_lens": {0: "N"},
             "encoder_out": {0: "N", 1: "T"},
             "encoder_out_lens": {0: "N"},
-        },,
+        }
         **get_onnx_export_kwargs(),
     )
 
@@ -379,7 +379,7 @@ def export_joiner_model_onnx(
             "encoder_out": {0: "N"},
             "decoder_out": {0: "N"},
             "logit": {0: "N"},
-        },,
+        }
         **get_onnx_export_kwargs(),
     )
     meta_data = {

--- a/egs/aishell/ASR/pruned_transducer_stateless7/jit_pretrained.py
+++ b/egs/aishell/ASR/pruned_transducer_stateless7/jit_pretrained.py
@@ -43,7 +43,7 @@ from typing import List
 import kaldifeat
 import sentencepiece as spm
 import torch
-import torchaudio
+import soundfile as sf
 from torch.nn.utils.rnn import pad_sequence
 
 from icefall.lexicon import Lexicon
@@ -75,7 +75,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -97,7 +97,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/aishell/ASR/pruned_transducer_stateless7/onnx_pretrained.py
+++ b/egs/aishell/ASR/pruned_transducer_stateless7/onnx_pretrained.py
@@ -74,7 +74,7 @@ import kaldifeat
 import numpy as np
 import onnxruntime as ort
 import torch
-import torchaudio
+import soundfile as sf
 from torch.nn.utils.rnn import pad_sequence
 
 
@@ -115,7 +115,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -260,7 +260,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/aishell/ASR/pruned_transducer_stateless7_bbpe/jit_pretrained.py
+++ b/egs/aishell/ASR/pruned_transducer_stateless7_bbpe/jit_pretrained.py
@@ -43,7 +43,7 @@ from typing import List
 import kaldifeat
 import sentencepiece as spm
 import torch
-import torchaudio
+import soundfile as sf
 from torch.nn.utils.rnn import pad_sequence
 
 from icefall import smart_byte_decode
@@ -72,7 +72,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -94,7 +94,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/aishell/ASR/pruned_transducer_stateless7_bbpe/pretrained.py
+++ b/egs/aishell/ASR/pruned_transducer_stateless7_bbpe/pretrained.py
@@ -66,7 +66,7 @@ import k2
 import kaldifeat
 import sentencepiece as spm
 import torch
-import torchaudio
+import soundfile as sf
 from beam_search import (
     beam_search,
     fast_beam_search_one_best,
@@ -118,7 +118,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -197,7 +197,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/aishell/ASR/tdnn_lstm_ctc/pretrained.py
+++ b/egs/aishell/ASR/tdnn_lstm_ctc/pretrained.py
@@ -24,7 +24,7 @@ from typing import List
 import k2
 import kaldifeat
 import torch
-import torchaudio
+import soundfile as sf
 from model import TdnnLstm
 from torch.nn.utils.rnn import pad_sequence
 
@@ -70,7 +70,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -109,7 +109,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/aishell/ASR/transducer_stateless/pretrained.py
+++ b/egs/aishell/ASR/transducer_stateless/pretrained.py
@@ -49,8 +49,8 @@ from typing import List
 
 import kaldifeat
 import torch
+import soundfile as sf
 import torch.nn as nn
-import torchaudio
 from beam_search import beam_search, greedy_search
 from conformer import Conformer
 from decoder import Decoder
@@ -101,7 +101,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -209,7 +209,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/aishell/ASR/transducer_stateless_modified-2/pretrained.py
+++ b/egs/aishell/ASR/transducer_stateless_modified-2/pretrained.py
@@ -64,7 +64,7 @@ from typing import List
 import k2
 import kaldifeat
 import torch
-import torchaudio
+import soundfile as sf
 from beam_search import (
     beam_search,
     fast_beam_search_one_best,
@@ -116,7 +116,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -192,7 +192,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/aishell/ASR/transducer_stateless_modified/pretrained.py
+++ b/egs/aishell/ASR/transducer_stateless_modified/pretrained.py
@@ -64,7 +64,7 @@ from typing import List
 import k2
 import kaldifeat
 import torch
-import torchaudio
+import soundfile as sf
 from beam_search import (
     beam_search,
     fast_beam_search_one_best,
@@ -116,7 +116,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -192,7 +192,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/aishell/ASR/zipformer/jit_pretrained_bbpe.py
+++ b/egs/aishell/ASR/zipformer/jit_pretrained_bbpe.py
@@ -45,7 +45,7 @@ from typing import List
 import kaldifeat
 import sentencepiece as spm
 import torch
-import torchaudio
+import soundfile as sf
 from torch.nn.utils.rnn import pad_sequence
 
 from icefall import smart_byte_decode
@@ -75,7 +75,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -97,7 +97,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/aishell/ASR/zipformer/pretrained_bbpe.py
+++ b/egs/aishell/ASR/zipformer/pretrained_bbpe.py
@@ -119,7 +119,7 @@ import k2
 import kaldifeat
 import sentencepiece as spm
 import torch
-import torchaudio
+import soundfile as sf
 from beam_search import (
     beam_search,
     fast_beam_search_one_best,
@@ -170,7 +170,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -250,7 +250,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/aishell2/ASR/pruned_transducer_stateless5/pretrained.py
+++ b/egs/aishell2/ASR/pruned_transducer_stateless5/pretrained.py
@@ -58,7 +58,7 @@ from typing import List
 import k2
 import kaldifeat
 import torch
-import torchaudio
+import soundfile as sf
 from beam_search import (
     beam_search,
     fast_beam_search_one_best,
@@ -110,7 +110,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -189,7 +189,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/aishell4/ASR/pruned_transducer_stateless5/pretrained.py
+++ b/egs/aishell4/ASR/pruned_transducer_stateless5/pretrained.py
@@ -71,7 +71,7 @@ from typing import List
 import k2
 import kaldifeat
 import torch
-import torchaudio
+import soundfile as sf
 from beam_search import (
     beam_search,
     fast_beam_search_one_best,
@@ -123,7 +123,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -202,7 +202,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/alimeeting/ASR/pruned_transducer_stateless2/pretrained.py
+++ b/egs/alimeeting/ASR/pruned_transducer_stateless2/pretrained.py
@@ -62,7 +62,7 @@ from typing import List
 import k2
 import kaldifeat
 import torch
-import torchaudio
+import soundfile as sf
 from beam_search import (
     beam_search,
     fast_beam_search_one_best,
@@ -113,7 +113,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -191,7 +191,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/audioset/AT/zipformer/export-onnx.py
+++ b/egs/audioset/AT/zipformer/export-onnx.py
@@ -222,7 +222,7 @@ def export_audio_tagging_model_onnx(
             "x": {0: "N", 1: "T"},
             "x_lens": {0: "N"},
             "probs": {0: "N"},
-        },,
+        }
         **get_onnx_export_kwargs(),
     )
 

--- a/egs/audioset/AT/zipformer/export-onnx.py
+++ b/egs/audioset/AT/zipformer/export-onnx.py
@@ -222,9 +222,9 @@ def export_audio_tagging_model_onnx(
             "x": {0: "N", 1: "T"},
             "x_lens": {0: "N"},
             "probs": {0: "N"},
-        }
+        },
         **get_onnx_export_kwargs(),
-    )
+)
 
     meta_data = {
         "model_type": "zipformer2",

--- a/egs/audioset/AT/zipformer/export-onnx.py
+++ b/egs/audioset/AT/zipformer/export-onnx.py
@@ -53,6 +53,7 @@ from icefall.checkpoint import (
     load_checkpoint,
 )
 from icefall.utils import make_pad_mask, str2bool
+from icefall.utils import get_onnx_export_kwargs
 
 
 def get_parser():
@@ -221,7 +222,8 @@ def export_audio_tagging_model_onnx(
             "x": {0: "N", 1: "T"},
             "x_lens": {0: "N"},
             "probs": {0: "N"},
-        },
+        },,
+        **get_onnx_export_kwargs(),
     )
 
     meta_data = {

--- a/egs/audioset/AT/zipformer/jit_pretrained.py
+++ b/egs/audioset/AT/zipformer/jit_pretrained.py
@@ -52,7 +52,7 @@ from typing import List
 
 import kaldifeat
 import torch
-import torchaudio
+import soundfile as sf
 from torch.nn.utils.rnn import pad_sequence
 
 
@@ -79,7 +79,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -101,7 +101,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/audioset/AT/zipformer/onnx_pretrained.py
+++ b/egs/audioset/AT/zipformer/onnx_pretrained.py
@@ -47,7 +47,7 @@ from typing import List
 import kaldifeat
 import onnxruntime as ort
 import torch
-import torchaudio
+import soundfile as sf
 from torch.nn.utils.rnn import pad_sequence
 
 
@@ -74,7 +74,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -152,7 +152,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/audioset/AT/zipformer/pretrained.py
+++ b/egs/audioset/AT/zipformer/pretrained.py
@@ -48,7 +48,7 @@ from typing import List
 
 import kaldifeat
 import torch
-import torchaudio
+import soundfile as sf
 from torch.nn.utils.rnn import pad_sequence
 from train import add_model_arguments, get_model, get_params
 
@@ -78,7 +78,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -109,7 +109,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/baker_zh/TTS/matcha/export_onnx.py
+++ b/egs/baker_zh/TTS/matcha/export_onnx.py
@@ -177,7 +177,7 @@ def main():
                 "x": {0: "N", 1: "L"},
                 "x_length": {0: "N"},
                 "mel": {0: "N", 2: "L"},
-            },,
+            }
         **get_onnx_export_kwargs(),
     )
 

--- a/egs/baker_zh/TTS/matcha/export_onnx.py
+++ b/egs/baker_zh/TTS/matcha/export_onnx.py
@@ -26,6 +26,7 @@ from tokenizer import Tokenizer
 from train import get_model, get_params
 
 from icefall.checkpoint import load_checkpoint
+from icefall.utils import get_onnx_export_kwargs
 
 
 def get_parser():
@@ -176,8 +177,9 @@ def main():
                 "x": {0: "N", 1: "L"},
                 "x_length": {0: "N"},
                 "mel": {0: "N", 2: "L"},
-            },
-        )
+            },,
+        **get_onnx_export_kwargs(),
+    )
 
         meta_data = {
             "model_type": "matcha-tts",

--- a/egs/baker_zh/TTS/matcha/export_onnx.py
+++ b/egs/baker_zh/TTS/matcha/export_onnx.py
@@ -177,9 +177,9 @@ def main():
                 "x": {0: "N", 1: "L"},
                 "x_length": {0: "N"},
                 "mel": {0: "N", 2: "L"},
-            }
-        **get_onnx_export_kwargs(),
-    )
+            },
+            **get_onnx_export_kwargs(),
+)
 
         meta_data = {
             "model_type": "matcha-tts",

--- a/egs/commonvoice/ASR/pruned_transducer_stateless7/export-onnx.py
+++ b/egs/commonvoice/ASR/pruned_transducer_stateless7/export-onnx.py
@@ -67,6 +67,7 @@ from icefall.checkpoint import (
     load_checkpoint,
 )
 from icefall.utils import setup_logger, str2bool
+from icefall.utils import get_onnx_export_kwargs
 
 
 def get_parser():
@@ -289,7 +290,8 @@ def export_encoder_model_onnx(
             "x_lens": {0: "N"},
             "encoder_out": {0: "N", 1: "T"},
             "encoder_out_lens": {0: "N"},
-        },
+        },,
+        **get_onnx_export_kwargs(),
     )
 
     meta_data = {
@@ -343,7 +345,7 @@ def export_decoder_model_onnx(
             "y": {0: "N"},
             "decoder_out": {0: "N"},
         },
-    )
+    , **get_onnx_export_kwargs())
 
     meta_data = {
         "context_size": str(context_size),
@@ -388,7 +390,8 @@ def export_joiner_model_onnx(
             "encoder_out": {0: "N"},
             "decoder_out": {0: "N"},
             "logit": {0: "N"},
-        },
+        },,
+        **get_onnx_export_kwargs(),
     )
     meta_data = {
         "joiner_dim": str(joiner_dim),

--- a/egs/commonvoice/ASR/pruned_transducer_stateless7/export-onnx.py
+++ b/egs/commonvoice/ASR/pruned_transducer_stateless7/export-onnx.py
@@ -290,9 +290,9 @@ def export_encoder_model_onnx(
             "x_lens": {0: "N"},
             "encoder_out": {0: "N", 1: "T"},
             "encoder_out_lens": {0: "N"},
-        }
+        },
         **get_onnx_export_kwargs(),
-    )
+)
 
     meta_data = {
         "model_type": "zipformer",
@@ -345,7 +345,8 @@ def export_decoder_model_onnx(
             "y": {0: "N"},
             "decoder_out": {0: "N"},
         },
-    , **get_onnx_export_kwargs())
+        **get_onnx_export_kwargs(),
+)
 
     meta_data = {
         "context_size": str(context_size),
@@ -390,9 +391,9 @@ def export_joiner_model_onnx(
             "encoder_out": {0: "N"},
             "decoder_out": {0: "N"},
             "logit": {0: "N"},
-        }
+        },
         **get_onnx_export_kwargs(),
-    )
+)
     meta_data = {
         "joiner_dim": str(joiner_dim),
     }

--- a/egs/commonvoice/ASR/pruned_transducer_stateless7/export-onnx.py
+++ b/egs/commonvoice/ASR/pruned_transducer_stateless7/export-onnx.py
@@ -290,7 +290,7 @@ def export_encoder_model_onnx(
             "x_lens": {0: "N"},
             "encoder_out": {0: "N", 1: "T"},
             "encoder_out_lens": {0: "N"},
-        },,
+        }
         **get_onnx_export_kwargs(),
     )
 
@@ -390,7 +390,7 @@ def export_joiner_model_onnx(
             "encoder_out": {0: "N"},
             "decoder_out": {0: "N"},
             "logit": {0: "N"},
-        },,
+        }
         **get_onnx_export_kwargs(),
     )
     meta_data = {

--- a/egs/commonvoice/ASR/pruned_transducer_stateless7/onnx_pretrained.py
+++ b/egs/commonvoice/ASR/pruned_transducer_stateless7/onnx_pretrained.py
@@ -75,7 +75,7 @@ import kaldifeat
 import numpy as np
 import onnxruntime as ort
 import torch
-import torchaudio
+import soundfile as sf
 from torch.nn.utils.rnn import pad_sequence
 
 
@@ -116,7 +116,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -261,7 +261,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/commonvoice/ASR/pruned_transducer_stateless7/pretrained.py
+++ b/egs/commonvoice/ASR/pruned_transducer_stateless7/pretrained.py
@@ -77,7 +77,7 @@ import k2
 import kaldifeat
 import sentencepiece as spm
 import torch
-import torchaudio
+import soundfile as sf
 from beam_search import (
     beam_search,
     fast_beam_search_one_best,
@@ -128,7 +128,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -207,7 +207,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/csj/ASR/pruned_transducer_stateless7_streaming/jit_trace_pretrained.py
+++ b/egs/csj/ASR/pruned_transducer_stateless7_streaming/jit_trace_pretrained.py
@@ -44,7 +44,7 @@ import logging
 from typing import List, Optional
 
 import torch
-import torchaudio
+import soundfile as sf
 from kaldifeat import FbankOptions, OnlineFbank, OnlineFeature
 from tokenizer import Tokenizer
 
@@ -93,7 +93,7 @@ def get_parser():
         "sound_file",
         type=str,
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -115,7 +115,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/csj/ASR/pruned_transducer_stateless7_streaming/pretrained.py
+++ b/egs/csj/ASR/pruned_transducer_stateless7_streaming/pretrained.py
@@ -76,7 +76,7 @@ from typing import List
 import k2
 import kaldifeat
 import torch
-import torchaudio
+import soundfile as sf
 from beam_search import (
     beam_search,
     fast_beam_search_one_best,
@@ -120,7 +120,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -199,7 +199,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/gigaspeech/ASR/zipformer/export-onnx.py
+++ b/egs/gigaspeech/ASR/zipformer/export-onnx.py
@@ -315,7 +315,7 @@ def export_encoder_model_onnx(
             "encoder_out_lens": {0: "N"},
         },
         **get_onnx_export_kwargs(),
-    )
+)
 
     meta_data = {
         "model_type": "zipformer2",
@@ -369,7 +369,7 @@ def export_decoder_model_onnx(
             "decoder_out": {0: "N"},
         },
         **get_onnx_export_kwargs(),
-    )
+)
 
     meta_data = {
         "context_size": str(context_size),
@@ -414,9 +414,9 @@ def export_joiner_model_onnx(
             "encoder_out": {0: "N"},
             "decoder_out": {0: "N"},
             "logit": {0: "N"},
-        }
+        },
         **get_onnx_export_kwargs(),
-    )
+)
     meta_data = {
         "joiner_dim": str(joiner_dim),
     }

--- a/egs/gigaspeech/ASR/zipformer/export-onnx.py
+++ b/egs/gigaspeech/ASR/zipformer/export-onnx.py
@@ -414,7 +414,7 @@ def export_joiner_model_onnx(
             "encoder_out": {0: "N"},
             "decoder_out": {0: "N"},
             "logit": {0: "N"},
-        },,
+        }
         **get_onnx_export_kwargs(),
     )
     meta_data = {

--- a/egs/gigaspeech/ASR/zipformer/export-onnx.py
+++ b/egs/gigaspeech/ASR/zipformer/export-onnx.py
@@ -82,6 +82,7 @@ from icefall.checkpoint import (
     load_checkpoint,
 )
 from icefall.utils import make_pad_mask, num_tokens, str2bool
+from icefall.utils import get_onnx_export_kwargs
 
 
 def get_parser():
@@ -313,6 +314,7 @@ def export_encoder_model_onnx(
             "encoder_out": {0: "N", 1: "T"},
             "encoder_out_lens": {0: "N"},
         },
+        **get_onnx_export_kwargs(),
     )
 
     meta_data = {
@@ -366,6 +368,7 @@ def export_decoder_model_onnx(
             "y": {0: "N"},
             "decoder_out": {0: "N"},
         },
+        **get_onnx_export_kwargs(),
     )
 
     meta_data = {
@@ -411,7 +414,8 @@ def export_joiner_model_onnx(
             "encoder_out": {0: "N"},
             "decoder_out": {0: "N"},
             "logit": {0: "N"},
-        },
+        },,
+        **get_onnx_export_kwargs(),
     )
     meta_data = {
         "joiner_dim": str(joiner_dim),

--- a/egs/iwslt22_ta/ASR/pruned_transducer_stateless5/pretrained.py
+++ b/egs/iwslt22_ta/ASR/pruned_transducer_stateless5/pretrained.py
@@ -68,7 +68,7 @@ import k2
 import kaldifeat
 import sentencepiece as spm
 import torch
-import torchaudio
+import soundfile as sf
 from beam_search import (
     beam_search,
     fast_beam_search_one_best,
@@ -117,7 +117,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -196,7 +196,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert sample_rate == expected_sample_rate, (
             f"expected sample rate: {expected_sample_rate}. " f"Given: {sample_rate}"
         )

--- a/egs/iwslt22_ta/ST/pruned_transducer_stateless5/pretrained.py
+++ b/egs/iwslt22_ta/ST/pruned_transducer_stateless5/pretrained.py
@@ -68,7 +68,7 @@ import k2
 import kaldifeat
 import sentencepiece as spm
 import torch
-import torchaudio
+import soundfile as sf
 from beam_search import (
     beam_search,
     fast_beam_search_one_best,
@@ -117,7 +117,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -196,7 +196,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert sample_rate == expected_sample_rate, (
             f"expected sample rate: {expected_sample_rate}. " f"Given: {sample_rate}"
         )

--- a/egs/iwslt22_ta/ST/zipformer/jit_pretrained.py
+++ b/egs/iwslt22_ta/ST/zipformer/jit_pretrained.py
@@ -43,7 +43,7 @@ from typing import List
 import kaldifeat
 import sentencepiece as spm
 import torch
-import torchaudio
+import soundfile as sf
 from torch.nn.utils.rnn import pad_sequence
 
 
@@ -70,7 +70,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -92,7 +92,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/iwslt22_ta/ST/zipformer/jit_pretrained_streaming.py
+++ b/egs/iwslt22_ta/ST/zipformer/jit_pretrained_streaming.py
@@ -46,7 +46,7 @@ from typing import List, Optional
 import kaldifeat
 import sentencepiece as spm
 import torch
-import torchaudio
+import soundfile as sf
 from kaldifeat import FbankOptions, OnlineFbank, OnlineFeature
 from torch.nn.utils.rnn import pad_sequence
 
@@ -80,7 +80,7 @@ def get_parser():
         "sound_file",
         type=str,
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -102,7 +102,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/iwslt22_ta/ST/zipformer/pretrained.py
+++ b/egs/iwslt22_ta/ST/zipformer/pretrained.py
@@ -114,7 +114,7 @@ import k2
 import kaldifeat
 import sentencepiece as spm
 import torch
-import torchaudio
+import soundfile as sf
 from beam_search import (
     fast_beam_search_one_best,
     greedy_search_batch,
@@ -162,7 +162,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -242,7 +242,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/libricss/SURT/dprnn_zipformer/pretrained.py
+++ b/egs/libricss/SURT/dprnn_zipformer/pretrained.py
@@ -22,7 +22,7 @@ from typing import List
 import k2
 import kaldifeat
 import torch
-import torchaudio
+import soundfile as sf
 from beam_search import (
     beam_search,
     greedy_search,
@@ -72,7 +72,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -139,7 +139,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/libriheavy/ASR/zipformer_prompt_asr/pretrained.py
+++ b/egs/libriheavy/ASR/zipformer_prompt_asr/pretrained.py
@@ -61,7 +61,7 @@ import k2
 import kaldifeat
 import sentencepiece as spm
 import torch
-import torchaudio
+import soundfile as sf
 from beam_search import greedy_search_batch, modified_beam_search
 from text_normalization import _apply_style_transform, train_text_normalization
 from torch.nn.utils.rnn import pad_sequence
@@ -113,7 +113,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -203,7 +203,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/librispeech/ASR/conformer_ctc/jit_pretrained_decode_with_H.py
+++ b/egs/librispeech/ASR/conformer_ctc/jit_pretrained_decode_with_H.py
@@ -39,6 +39,7 @@ from typing import Dict, List
 import kaldifeat
 import kaldifst
 import torch
+import soundfile as sf
 import torchaudio
 from kaldi_decoder import DecodableCtc, FasterDecoder, FasterDecoderOptions
 from torch.nn.utils.rnn import pad_sequence
@@ -73,7 +74,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. ",
     )
 
@@ -104,7 +105,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         if sample_rate != expected_sample_rate:
             wave = torchaudio.functional.resample(
                 wave,

--- a/egs/librispeech/ASR/conformer_ctc/jit_pretrained_decode_with_HL.py
+++ b/egs/librispeech/ASR/conformer_ctc/jit_pretrained_decode_with_HL.py
@@ -39,6 +39,7 @@ from typing import Dict, List
 import kaldifeat
 import kaldifst
 import torch
+import soundfile as sf
 import torchaudio
 from kaldi_decoder import DecodableCtc, FasterDecoder, FasterDecoderOptions
 from torch.nn.utils.rnn import pad_sequence
@@ -73,7 +74,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. ",
     )
 
@@ -104,7 +105,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         if sample_rate != expected_sample_rate:
             wave = torchaudio.functional.resample(
                 wave,

--- a/egs/librispeech/ASR/conformer_ctc/jit_pretrained_decode_with_HLG.py
+++ b/egs/librispeech/ASR/conformer_ctc/jit_pretrained_decode_with_HLG.py
@@ -38,6 +38,7 @@ from typing import Dict, List
 import kaldifeat
 import kaldifst
 import torch
+import soundfile as sf
 import torchaudio
 from kaldi_decoder import DecodableCtc, FasterDecoder, FasterDecoderOptions
 from torch.nn.utils.rnn import pad_sequence
@@ -72,7 +73,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. ",
     )
 
@@ -103,7 +104,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         if sample_rate != expected_sample_rate:
             wave = torchaudio.functional.resample(
                 wave,

--- a/egs/librispeech/ASR/conformer_ctc/pretrained.py
+++ b/egs/librispeech/ASR/conformer_ctc/pretrained.py
@@ -25,7 +25,7 @@ from typing import List
 import k2
 import kaldifeat
 import torch
-import torchaudio
+import soundfile as sf
 from conformer import Conformer
 from torch.nn.utils.rnn import pad_sequence
 
@@ -186,7 +186,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -231,7 +231,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/librispeech/ASR/conformer_ctc3/jit_pretrained.py
+++ b/egs/librispeech/ASR/conformer_ctc3/jit_pretrained.py
@@ -73,7 +73,7 @@ import k2
 import kaldifeat
 import sentencepiece as spm
 import torch
-import torchaudio
+import soundfile as sf
 from decode import get_decoding_params
 from torch.nn.utils.rnn import pad_sequence
 from train import add_model_arguments, get_params
@@ -211,7 +211,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -235,7 +235,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert sample_rate == expected_sample_rate, (
             f"expected sample rate: {expected_sample_rate}. " f"Given: {sample_rate}"
         )

--- a/egs/librispeech/ASR/conformer_ctc3/pretrained.py
+++ b/egs/librispeech/ASR/conformer_ctc3/pretrained.py
@@ -68,7 +68,7 @@ from typing import List
 import k2
 import kaldifeat
 import torch
-import torchaudio
+import soundfile as sf
 from decode import get_decoding_params
 from torch.nn.utils.rnn import pad_sequence
 from train import add_model_arguments, get_ctc_model, get_params
@@ -228,7 +228,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -252,7 +252,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert sample_rate == expected_sample_rate, (
             f"expected sample rate: {expected_sample_rate}. " f"Given: {sample_rate}"
         )

--- a/egs/librispeech/ASR/conv_emformer_transducer_stateless2/export-onnx.py
+++ b/egs/librispeech/ASR/conv_emformer_transducer_stateless2/export-onnx.py
@@ -70,6 +70,7 @@ from icefall.checkpoint import (
     load_checkpoint,
 )
 from icefall.utils import num_tokens, setup_logger, str2bool
+from icefall.utils import get_onnx_export_kwargs
 
 
 def get_parser():
@@ -368,7 +369,8 @@ def export_encoder_model_onnx(
             "encoder_out": {0: "N"},
             **inputs,
             **outputs,
-        },
+        },,
+        **get_onnx_export_kwargs(),
     )
 
     add_meta_data(filename=encoder_filename, meta_data=meta_data)
@@ -414,7 +416,7 @@ def export_decoder_model_onnx(
             "y": {0: "N"},
             "decoder_out": {0: "N"},
         },
-    )
+    , **get_onnx_export_kwargs())
 
     meta_data = {
         "context_size": str(context_size),
@@ -459,7 +461,8 @@ def export_joiner_model_onnx(
             "encoder_out": {0: "N"},
             "decoder_out": {0: "N"},
             "logit": {0: "N"},
-        },
+        },,
+        **get_onnx_export_kwargs(),
     )
     meta_data = {
         "joiner_dim": str(joiner_dim),

--- a/egs/librispeech/ASR/conv_emformer_transducer_stateless2/export-onnx.py
+++ b/egs/librispeech/ASR/conv_emformer_transducer_stateless2/export-onnx.py
@@ -369,7 +369,7 @@ def export_encoder_model_onnx(
             "encoder_out": {0: "N"},
             **inputs,
             **outputs,
-        },,
+        }
         **get_onnx_export_kwargs(),
     )
 
@@ -461,7 +461,7 @@ def export_joiner_model_onnx(
             "encoder_out": {0: "N"},
             "decoder_out": {0: "N"},
             "logit": {0: "N"},
-        },,
+        }
         **get_onnx_export_kwargs(),
     )
     meta_data = {

--- a/egs/librispeech/ASR/conv_emformer_transducer_stateless2/export-onnx.py
+++ b/egs/librispeech/ASR/conv_emformer_transducer_stateless2/export-onnx.py
@@ -369,9 +369,9 @@ def export_encoder_model_onnx(
             "encoder_out": {0: "N"},
             **inputs,
             **outputs,
-        }
+        },
         **get_onnx_export_kwargs(),
-    )
+)
 
     add_meta_data(filename=encoder_filename, meta_data=meta_data)
 
@@ -416,7 +416,8 @@ def export_decoder_model_onnx(
             "y": {0: "N"},
             "decoder_out": {0: "N"},
         },
-    , **get_onnx_export_kwargs())
+        **get_onnx_export_kwargs(),
+)
 
     meta_data = {
         "context_size": str(context_size),
@@ -461,9 +462,9 @@ def export_joiner_model_onnx(
             "encoder_out": {0: "N"},
             "decoder_out": {0: "N"},
             "logit": {0: "N"},
-        }
+        },
         **get_onnx_export_kwargs(),
-    )
+)
     meta_data = {
         "joiner_dim": str(joiner_dim),
     }

--- a/egs/librispeech/ASR/conv_emformer_transducer_stateless2/jit_pretrained.py
+++ b/egs/librispeech/ASR/conv_emformer_transducer_stateless2/jit_pretrained.py
@@ -44,7 +44,7 @@ from typing import List, Optional
 import kaldifeat
 import sentencepiece as spm
 import torch
-import torchaudio
+import soundfile as sf
 from kaldifeat import FbankOptions, OnlineFbank, OnlineFeature
 from torch.nn.utils.rnn import pad_sequence
 
@@ -85,7 +85,7 @@ def get_parser():
         "sound_file",
         type=str,
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -121,7 +121,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/librispeech/ASR/conv_emformer_transducer_stateless2/onnx_pretrained.py
+++ b/egs/librispeech/ASR/conv_emformer_transducer_stateless2/onnx_pretrained.py
@@ -67,7 +67,7 @@ import k2
 import numpy as np
 import onnxruntime as ort
 import torch
-import torchaudio
+import soundfile as sf
 from kaldifeat import FbankOptions, OnlineFbank, OnlineFeature
 
 
@@ -107,7 +107,7 @@ def get_parser():
         "sound_file",
         type=str,
         help="The input sound file to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -301,7 +301,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/librispeech/ASR/conv_emformer_transducer_stateless2/streaming-ncnn-decode.py
+++ b/egs/librispeech/ASR/conv_emformer_transducer_stateless2/streaming-ncnn-decode.py
@@ -39,6 +39,7 @@ from typing import List, Optional, Tuple
 import k2
 import ncnn
 import torch
+import soundfile as sf
 import torchaudio
 from kaldifeat import FbankOptions, OnlineFbank, OnlineFeature
 
@@ -251,7 +252,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/librispeech/ASR/lstm_transducer_stateless/jit_pretrained.py
+++ b/egs/librispeech/ASR/lstm_transducer_stateless/jit_pretrained.py
@@ -45,7 +45,7 @@ from typing import List
 import kaldifeat
 import sentencepiece as spm
 import torch
-import torchaudio
+import soundfile as sf
 from torch.nn.utils.rnn import pad_sequence
 
 
@@ -86,7 +86,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -122,7 +122,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/librispeech/ASR/lstm_transducer_stateless/pretrained.py
+++ b/egs/librispeech/ASR/lstm_transducer_stateless/pretrained.py
@@ -67,7 +67,7 @@ from typing import List
 import k2
 import kaldifeat
 import torch
-import torchaudio
+import soundfile as sf
 from beam_search import (
     beam_search,
     fast_beam_search_one_best,
@@ -118,7 +118,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -197,7 +197,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/librispeech/ASR/lstm_transducer_stateless2/export-onnx-zh.py
+++ b/egs/librispeech/ASR/lstm_transducer_stateless2/export-onnx-zh.py
@@ -72,6 +72,7 @@ from icefall.checkpoint import (
     load_checkpoint,
 )
 from icefall.utils import num_tokens, setup_logger, str2bool
+from icefall.utils import get_onnx_export_kwargs
 
 
 def get_parser():
@@ -314,7 +315,8 @@ def export_encoder_model_onnx(
             "encoder_out": {0: "N"},
             "new_state0": {1: "N"},
             "new_state1": {1: "N"},
-        },
+        },,
+        **get_onnx_export_kwargs(),
     )
 
     meta_data = {
@@ -372,7 +374,7 @@ def export_decoder_model_onnx(
             "y": {0: "N"},
             "decoder_out": {0: "N"},
         },
-    )
+    , **get_onnx_export_kwargs())
 
     meta_data = {
         "context_size": str(context_size),
@@ -417,7 +419,8 @@ def export_joiner_model_onnx(
             "encoder_out": {0: "N"},
             "decoder_out": {0: "N"},
             "logit": {0: "N"},
-        },
+        },,
+        **get_onnx_export_kwargs(),
     )
     meta_data = {
         "joiner_dim": str(joiner_dim),

--- a/egs/librispeech/ASR/lstm_transducer_stateless2/export-onnx-zh.py
+++ b/egs/librispeech/ASR/lstm_transducer_stateless2/export-onnx-zh.py
@@ -315,7 +315,7 @@ def export_encoder_model_onnx(
             "encoder_out": {0: "N"},
             "new_state0": {1: "N"},
             "new_state1": {1: "N"},
-        },,
+        }
         **get_onnx_export_kwargs(),
     )
 
@@ -419,7 +419,7 @@ def export_joiner_model_onnx(
             "encoder_out": {0: "N"},
             "decoder_out": {0: "N"},
             "logit": {0: "N"},
-        },,
+        }
         **get_onnx_export_kwargs(),
     )
     meta_data = {

--- a/egs/librispeech/ASR/lstm_transducer_stateless2/export-onnx-zh.py
+++ b/egs/librispeech/ASR/lstm_transducer_stateless2/export-onnx-zh.py
@@ -315,9 +315,9 @@ def export_encoder_model_onnx(
             "encoder_out": {0: "N"},
             "new_state0": {1: "N"},
             "new_state1": {1: "N"},
-        }
+        },
         **get_onnx_export_kwargs(),
-    )
+)
 
     meta_data = {
         "model_type": "lstm",
@@ -374,7 +374,8 @@ def export_decoder_model_onnx(
             "y": {0: "N"},
             "decoder_out": {0: "N"},
         },
-    , **get_onnx_export_kwargs())
+        **get_onnx_export_kwargs(),
+)
 
     meta_data = {
         "context_size": str(context_size),
@@ -419,9 +420,9 @@ def export_joiner_model_onnx(
             "encoder_out": {0: "N"},
             "decoder_out": {0: "N"},
             "logit": {0: "N"},
-        }
+        },
         **get_onnx_export_kwargs(),
-    )
+)
     meta_data = {
         "joiner_dim": str(joiner_dim),
     }

--- a/egs/librispeech/ASR/lstm_transducer_stateless2/export-onnx.py
+++ b/egs/librispeech/ASR/lstm_transducer_stateless2/export-onnx.py
@@ -312,7 +312,7 @@ def export_encoder_model_onnx(
             "encoder_out": {0: "N"},
             "new_state0": {1: "N"},
             "new_state1": {1: "N"},
-        },,
+        }
         **get_onnx_export_kwargs(),
     )
 
@@ -416,7 +416,7 @@ def export_joiner_model_onnx(
             "encoder_out": {0: "N"},
             "decoder_out": {0: "N"},
             "logit": {0: "N"},
-        },,
+        }
         **get_onnx_export_kwargs(),
     )
     meta_data = {

--- a/egs/librispeech/ASR/lstm_transducer_stateless2/export-onnx.py
+++ b/egs/librispeech/ASR/lstm_transducer_stateless2/export-onnx.py
@@ -69,6 +69,7 @@ from icefall.checkpoint import (
     load_checkpoint,
 )
 from icefall.utils import num_tokens, setup_logger, str2bool
+from icefall.utils import get_onnx_export_kwargs
 
 
 def get_parser():
@@ -311,7 +312,8 @@ def export_encoder_model_onnx(
             "encoder_out": {0: "N"},
             "new_state0": {1: "N"},
             "new_state1": {1: "N"},
-        },
+        },,
+        **get_onnx_export_kwargs(),
     )
 
     meta_data = {
@@ -369,7 +371,7 @@ def export_decoder_model_onnx(
             "y": {0: "N"},
             "decoder_out": {0: "N"},
         },
-    )
+    , **get_onnx_export_kwargs())
 
     meta_data = {
         "context_size": str(context_size),
@@ -414,7 +416,8 @@ def export_joiner_model_onnx(
             "encoder_out": {0: "N"},
             "decoder_out": {0: "N"},
             "logit": {0: "N"},
-        },
+        },,
+        **get_onnx_export_kwargs(),
     )
     meta_data = {
         "joiner_dim": str(joiner_dim),

--- a/egs/librispeech/ASR/lstm_transducer_stateless2/export-onnx.py
+++ b/egs/librispeech/ASR/lstm_transducer_stateless2/export-onnx.py
@@ -312,9 +312,9 @@ def export_encoder_model_onnx(
             "encoder_out": {0: "N"},
             "new_state0": {1: "N"},
             "new_state1": {1: "N"},
-        }
+        },
         **get_onnx_export_kwargs(),
-    )
+)
 
     meta_data = {
         "model_type": "lstm",
@@ -371,7 +371,8 @@ def export_decoder_model_onnx(
             "y": {0: "N"},
             "decoder_out": {0: "N"},
         },
-    , **get_onnx_export_kwargs())
+        **get_onnx_export_kwargs(),
+)
 
     meta_data = {
         "context_size": str(context_size),
@@ -416,9 +417,9 @@ def export_joiner_model_onnx(
             "encoder_out": {0: "N"},
             "decoder_out": {0: "N"},
             "logit": {0: "N"},
-        }
+        },
         **get_onnx_export_kwargs(),
-    )
+)
     meta_data = {
         "joiner_dim": str(joiner_dim),
     }

--- a/egs/librispeech/ASR/lstm_transducer_stateless2/jit_pretrained.py
+++ b/egs/librispeech/ASR/lstm_transducer_stateless2/jit_pretrained.py
@@ -46,7 +46,7 @@ from typing import List
 import kaldifeat
 import sentencepiece as spm
 import torch
-import torchaudio
+import soundfile as sf
 from torch.nn.utils.rnn import pad_sequence
 
 
@@ -87,7 +87,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -123,7 +123,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/librispeech/ASR/lstm_transducer_stateless2/ncnn-decode.py
+++ b/egs/librispeech/ASR/lstm_transducer_stateless2/ncnn-decode.py
@@ -41,6 +41,7 @@ import k2
 import kaldifeat
 import ncnn
 import torch
+import soundfile as sf
 import torchaudio
 
 
@@ -203,7 +204,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/librispeech/ASR/lstm_transducer_stateless2/onnx_pretrained.py
+++ b/egs/librispeech/ASR/lstm_transducer_stateless2/onnx_pretrained.py
@@ -60,7 +60,7 @@ import k2
 import numpy as np
 import onnxruntime as ort
 import torch
-import torchaudio
+import soundfile as sf
 from kaldifeat import FbankOptions, OnlineFbank, OnlineFeature
 
 
@@ -100,7 +100,7 @@ def get_parser():
         "sound_file",
         type=str,
         help="The input sound file to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -273,7 +273,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/librispeech/ASR/lstm_transducer_stateless2/pretrained.py
+++ b/egs/librispeech/ASR/lstm_transducer_stateless2/pretrained.py
@@ -70,7 +70,7 @@ from typing import List
 import k2
 import kaldifeat
 import torch
-import torchaudio
+import soundfile as sf
 from beam_search import (
     beam_search,
     fast_beam_search_one_best,
@@ -121,7 +121,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -200,7 +200,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/librispeech/ASR/lstm_transducer_stateless2/streaming-ncnn-decode.py
+++ b/egs/librispeech/ASR/lstm_transducer_stateless2/streaming-ncnn-decode.py
@@ -29,6 +29,7 @@ from typing import List, Optional
 import k2
 import ncnn
 import torch
+import soundfile as sf
 import torchaudio
 from kaldifeat import FbankOptions, OnlineFbank, OnlineFeature
 
@@ -192,7 +193,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/librispeech/ASR/lstm_transducer_stateless2/streaming-onnx-decode.py
+++ b/egs/librispeech/ASR/lstm_transducer_stateless2/streaming-onnx-decode.py
@@ -50,6 +50,7 @@ if not is_module_available("onnxruntime"):
 import onnxruntime as ort
 import sentencepiece as spm
 import torch
+import soundfile as sf
 import torchaudio
 from kaldifeat import FbankOptions, OnlineFbank, OnlineFeature
 
@@ -110,7 +111,7 @@ def get_args():
         "sound_filename",
         type=str,
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -146,7 +147,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/librispeech/ASR/lstm_transducer_stateless3/jit_pretrained.py
+++ b/egs/librispeech/ASR/lstm_transducer_stateless3/jit_pretrained.py
@@ -45,7 +45,7 @@ from typing import List
 import kaldifeat
 import sentencepiece as spm
 import torch
-import torchaudio
+import soundfile as sf
 from torch.nn.utils.rnn import pad_sequence
 
 
@@ -86,7 +86,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -122,7 +122,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/librispeech/ASR/lstm_transducer_stateless3/pretrained.py
+++ b/egs/librispeech/ASR/lstm_transducer_stateless3/pretrained.py
@@ -68,7 +68,7 @@ import k2
 import kaldifeat
 import sentencepiece as spm
 import torch
-import torchaudio
+import soundfile as sf
 from beam_search import (
     beam_search,
     fast_beam_search_one_best,
@@ -119,7 +119,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -198,7 +198,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/librispeech/ASR/pruned_transducer_stateless/export-onnx.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless/export-onnx.py
@@ -59,6 +59,7 @@ from train import add_model_arguments, get_params, get_transducer_model
 
 from icefall.checkpoint import average_checkpoints, find_checkpoints, load_checkpoint
 from icefall.utils import setup_logger
+from icefall.utils import get_onnx_export_kwargs
 
 
 def get_parser():
@@ -266,7 +267,8 @@ def export_encoder_model_onnx(
             "x_lens": {0: "N"},
             "encoder_out": {0: "N", 1: "T"},
             "encoder_out_lens": {0: "N"},
-        },
+        },,
+        **get_onnx_export_kwargs(),
     )
 
     meta_data = {
@@ -320,7 +322,7 @@ def export_decoder_model_onnx(
             "y": {0: "N"},
             "decoder_out": {0: "N"},
         },
-    )
+    , **get_onnx_export_kwargs())
 
     meta_data = {
         "context_size": str(context_size),
@@ -365,7 +367,8 @@ def export_joiner_model_onnx(
             "encoder_out": {0: "N"},
             "decoder_out": {0: "N"},
             "logit": {0: "N"},
-        },
+        },,
+        **get_onnx_export_kwargs(),
     )
     meta_data = {
         "joiner_dim": str(joiner_dim),

--- a/egs/librispeech/ASR/pruned_transducer_stateless/export-onnx.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless/export-onnx.py
@@ -267,9 +267,9 @@ def export_encoder_model_onnx(
             "x_lens": {0: "N"},
             "encoder_out": {0: "N", 1: "T"},
             "encoder_out_lens": {0: "N"},
-        }
+        },
         **get_onnx_export_kwargs(),
-    )
+)
 
     meta_data = {
         "model_type": "conformer",
@@ -322,7 +322,8 @@ def export_decoder_model_onnx(
             "y": {0: "N"},
             "decoder_out": {0: "N"},
         },
-    , **get_onnx_export_kwargs())
+        **get_onnx_export_kwargs(),
+)
 
     meta_data = {
         "context_size": str(context_size),
@@ -367,9 +368,9 @@ def export_joiner_model_onnx(
             "encoder_out": {0: "N"},
             "decoder_out": {0: "N"},
             "logit": {0: "N"},
-        }
+        },
         **get_onnx_export_kwargs(),
-    )
+)
     meta_data = {
         "joiner_dim": str(joiner_dim),
     }

--- a/egs/librispeech/ASR/pruned_transducer_stateless/export-onnx.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless/export-onnx.py
@@ -267,7 +267,7 @@ def export_encoder_model_onnx(
             "x_lens": {0: "N"},
             "encoder_out": {0: "N", 1: "T"},
             "encoder_out_lens": {0: "N"},
-        },,
+        }
         **get_onnx_export_kwargs(),
     )
 
@@ -367,7 +367,7 @@ def export_joiner_model_onnx(
             "encoder_out": {0: "N"},
             "decoder_out": {0: "N"},
             "logit": {0: "N"},
-        },,
+        }
         **get_onnx_export_kwargs(),
     )
     meta_data = {

--- a/egs/librispeech/ASR/pruned_transducer_stateless/pretrained.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless/pretrained.py
@@ -67,7 +67,7 @@ from typing import List
 import k2
 import kaldifeat
 import torch
-import torchaudio
+import soundfile as sf
 from beam_search import (
     beam_search,
     fast_beam_search_one_best,
@@ -118,7 +118,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -218,7 +218,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/librispeech/ASR/pruned_transducer_stateless2/pretrained.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless2/pretrained.py
@@ -67,7 +67,7 @@ from typing import List
 import k2
 import kaldifeat
 import torch
-import torchaudio
+import soundfile as sf
 from beam_search import (
     beam_search,
     fast_beam_search_one_best,
@@ -118,7 +118,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -219,7 +219,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/librispeech/ASR/pruned_transducer_stateless3/export-onnx.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless3/export-onnx.py
@@ -272,9 +272,9 @@ def export_encoder_model_onnx(
             "x_lens": {0: "N"},
             "encoder_out": {0: "N", 1: "T"},
             "encoder_out_lens": {0: "N"},
-        }
+        },
         **get_onnx_export_kwargs(),
-    )
+)
 
     meta_data = {
         "model_type": "conformer",
@@ -327,7 +327,8 @@ def export_decoder_model_onnx(
             "y": {0: "N"},
             "decoder_out": {0: "N"},
         },
-    , **get_onnx_export_kwargs())
+        **get_onnx_export_kwargs(),
+)
 
     meta_data = {
         "context_size": str(context_size),
@@ -372,9 +373,9 @@ def export_joiner_model_onnx(
             "encoder_out": {0: "N"},
             "decoder_out": {0: "N"},
             "logit": {0: "N"},
-        }
+        },
         **get_onnx_export_kwargs(),
-    )
+)
     meta_data = {
         "joiner_dim": str(joiner_dim),
     }

--- a/egs/librispeech/ASR/pruned_transducer_stateless3/export-onnx.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless3/export-onnx.py
@@ -60,6 +60,7 @@ from train import add_model_arguments, get_params, get_transducer_model
 
 from icefall.checkpoint import average_checkpoints, find_checkpoints, load_checkpoint
 from icefall.utils import num_tokens, setup_logger
+from icefall.utils import get_onnx_export_kwargs
 
 
 def get_parser():
@@ -271,7 +272,8 @@ def export_encoder_model_onnx(
             "x_lens": {0: "N"},
             "encoder_out": {0: "N", 1: "T"},
             "encoder_out_lens": {0: "N"},
-        },
+        },,
+        **get_onnx_export_kwargs(),
     )
 
     meta_data = {
@@ -325,7 +327,7 @@ def export_decoder_model_onnx(
             "y": {0: "N"},
             "decoder_out": {0: "N"},
         },
-    )
+    , **get_onnx_export_kwargs())
 
     meta_data = {
         "context_size": str(context_size),
@@ -370,7 +372,8 @@ def export_joiner_model_onnx(
             "encoder_out": {0: "N"},
             "decoder_out": {0: "N"},
             "logit": {0: "N"},
-        },
+        },,
+        **get_onnx_export_kwargs(),
     )
     meta_data = {
         "joiner_dim": str(joiner_dim),

--- a/egs/librispeech/ASR/pruned_transducer_stateless3/export-onnx.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless3/export-onnx.py
@@ -272,7 +272,7 @@ def export_encoder_model_onnx(
             "x_lens": {0: "N"},
             "encoder_out": {0: "N", 1: "T"},
             "encoder_out_lens": {0: "N"},
-        },,
+        }
         **get_onnx_export_kwargs(),
     )
 
@@ -372,7 +372,7 @@ def export_joiner_model_onnx(
             "encoder_out": {0: "N"},
             "decoder_out": {0: "N"},
             "logit": {0: "N"},
-        },,
+        }
         **get_onnx_export_kwargs(),
     )
     meta_data = {

--- a/egs/librispeech/ASR/pruned_transducer_stateless3/jit_pretrained.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless3/jit_pretrained.py
@@ -64,7 +64,7 @@ from typing import List
 import kaldifeat
 import sentencepiece as spm
 import torch
-import torchaudio
+import soundfile as sf
 from torch.nn.utils.rnn import pad_sequence
 
 
@@ -105,7 +105,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -141,7 +141,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/librispeech/ASR/pruned_transducer_stateless3/onnx_pretrained.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless3/onnx_pretrained.py
@@ -73,7 +73,7 @@ import k2
 import kaldifeat
 import onnxruntime as ort
 import torch
-import torchaudio
+import soundfile as sf
 from torch.nn.utils.rnn import pad_sequence
 
 
@@ -114,7 +114,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -259,7 +259,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/librispeech/ASR/pruned_transducer_stateless3/pretrained.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless3/pretrained.py
@@ -76,7 +76,7 @@ from typing import List
 import k2
 import kaldifeat
 import torch
-import torchaudio
+import soundfile as sf
 from beam_search import (
     beam_search,
     fast_beam_search_one_best,
@@ -127,7 +127,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -228,7 +228,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/librispeech/ASR/pruned_transducer_stateless3/test_onnx.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless3/test_onnx.py
@@ -124,7 +124,7 @@ def test_rel_pos():
             "x": {0: "N", 1: "T"},
             "y": {0: "N", 1: "T"},
             "pos_emb": {0: "N", 1: "T"},
-        },,
+        }
         **get_onnx_export_kwargs(),
     )
 
@@ -213,7 +213,7 @@ def test_conformer_encoder_layer():
             "pos_emb": {0: "N", 1: "T"},
             "src_key_padding_mask": {0: "N", 1: "T"},
             "y": {0: "T", 1: "N"},
-        },,
+        }
         **get_onnx_export_kwargs(),
     )
 
@@ -299,7 +299,7 @@ def test_conformer_encoder():
             "pos_emb": {0: "N", 1: "T"},
             "src_key_padding_mask": {0: "N", 1: "T"},
             "y": {0: "T", 1: "N"},
-        },,
+        }
         **get_onnx_export_kwargs(),
     )
 
@@ -357,7 +357,7 @@ def test_conformer():
             "x_lens": {0: "N"},
             "y": {0: "N", 1: "T"},
             "y_lens": {0: "N"},
-        },,
+        }
         **get_onnx_export_kwargs(),
     )
     options = ort.SessionOptions()

--- a/egs/librispeech/ASR/pruned_transducer_stateless3/test_onnx.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless3/test_onnx.py
@@ -20,7 +20,6 @@
 This file is to test that models can be exported to onnx.
 """
 import os
-
 from icefall import is_module_available
 
 if not is_module_available("onnxruntime"):
@@ -38,6 +37,7 @@ from conformer import (
 from scaling_converter import convert_scaled_to_non_scaled
 
 from icefall.utils import make_pad_mask
+from icefall.utils import get_onnx_export_kwargs
 
 ort.set_default_logger_severity(3)
 
@@ -69,7 +69,7 @@ def test_conv2d_subsampling():
             "x": {0: "N", 1: "T"},
             "y": {0: "N", 1: "T"},
         },
-    )
+    , **get_onnx_export_kwargs())
 
     options = ort.SessionOptions()
     options.inter_op_num_threads = 1
@@ -124,7 +124,8 @@ def test_rel_pos():
             "x": {0: "N", 1: "T"},
             "y": {0: "N", 1: "T"},
             "pos_emb": {0: "N", 1: "T"},
-        },
+        },,
+        **get_onnx_export_kwargs(),
     )
 
     options = ort.SessionOptions()
@@ -212,7 +213,8 @@ def test_conformer_encoder_layer():
             "pos_emb": {0: "N", 1: "T"},
             "src_key_padding_mask": {0: "N", 1: "T"},
             "y": {0: "T", 1: "N"},
-        },
+        },,
+        **get_onnx_export_kwargs(),
     )
 
     options = ort.SessionOptions()
@@ -297,7 +299,8 @@ def test_conformer_encoder():
             "pos_emb": {0: "N", 1: "T"},
             "src_key_padding_mask": {0: "N", 1: "T"},
             "y": {0: "T", 1: "N"},
-        },
+        },,
+        **get_onnx_export_kwargs(),
     )
 
     options = ort.SessionOptions()
@@ -354,7 +357,8 @@ def test_conformer():
             "x_lens": {0: "N"},
             "y": {0: "N", 1: "T"},
             "y_lens": {0: "N"},
-        },
+        },,
+        **get_onnx_export_kwargs(),
     )
     options = ort.SessionOptions()
     options.inter_op_num_threads = 1

--- a/egs/librispeech/ASR/pruned_transducer_stateless3/test_onnx.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless3/test_onnx.py
@@ -20,6 +20,7 @@
 This file is to test that models can be exported to onnx.
 """
 import os
+
 from icefall import is_module_available
 
 if not is_module_available("onnxruntime"):
@@ -69,7 +70,8 @@ def test_conv2d_subsampling():
             "x": {0: "N", 1: "T"},
             "y": {0: "N", 1: "T"},
         },
-    , **get_onnx_export_kwargs())
+        **get_onnx_export_kwargs(),
+)
 
     options = ort.SessionOptions()
     options.inter_op_num_threads = 1
@@ -124,9 +126,9 @@ def test_rel_pos():
             "x": {0: "N", 1: "T"},
             "y": {0: "N", 1: "T"},
             "pos_emb": {0: "N", 1: "T"},
-        }
+        },
         **get_onnx_export_kwargs(),
-    )
+)
 
     options = ort.SessionOptions()
     options.inter_op_num_threads = 1
@@ -213,9 +215,9 @@ def test_conformer_encoder_layer():
             "pos_emb": {0: "N", 1: "T"},
             "src_key_padding_mask": {0: "N", 1: "T"},
             "y": {0: "T", 1: "N"},
-        }
+        },
         **get_onnx_export_kwargs(),
-    )
+)
 
     options = ort.SessionOptions()
     options.inter_op_num_threads = 1
@@ -299,9 +301,9 @@ def test_conformer_encoder():
             "pos_emb": {0: "N", 1: "T"},
             "src_key_padding_mask": {0: "N", 1: "T"},
             "y": {0: "T", 1: "N"},
-        }
+        },
         **get_onnx_export_kwargs(),
-    )
+)
 
     options = ort.SessionOptions()
     options.inter_op_num_threads = 1
@@ -357,9 +359,9 @@ def test_conformer():
             "x_lens": {0: "N"},
             "y": {0: "N", 1: "T"},
             "y_lens": {0: "N"},
-        }
+        },
         **get_onnx_export_kwargs(),
-    )
+)
     options = ort.SessionOptions()
     options.inter_op_num_threads = 1
     options.intra_op_num_threads = 1

--- a/egs/librispeech/ASR/pruned_transducer_stateless5/export-onnx-streaming.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless5/export-onnx-streaming.py
@@ -355,9 +355,9 @@ def export_encoder_model_onnx(
             "encoder_out": {0: "N"},
             "new_cached_attn": {2: "N"},
             "new_cached_conv": {2: "N"},
-        }
+        },
         **get_onnx_export_kwargs(),
-    )
+)
 
     meta_data = {
         "model_type": "conformer",
@@ -419,7 +419,8 @@ def export_decoder_model_onnx(
             "y": {0: "N"},
             "decoder_out": {0: "N"},
         },
-    , **get_onnx_export_kwargs())
+        **get_onnx_export_kwargs(),
+)
 
     meta_data = {
         "context_size": str(context_size),
@@ -464,9 +465,9 @@ def export_joiner_model_onnx(
             "encoder_out": {0: "N"},
             "decoder_out": {0: "N"},
             "logit": {0: "N"},
-        }
+        },
         **get_onnx_export_kwargs(),
-    )
+)
     meta_data = {
         "joiner_dim": str(joiner_dim),
     }

--- a/egs/librispeech/ASR/pruned_transducer_stateless5/export-onnx-streaming.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless5/export-onnx-streaming.py
@@ -355,7 +355,7 @@ def export_encoder_model_onnx(
             "encoder_out": {0: "N"},
             "new_cached_attn": {2: "N"},
             "new_cached_conv": {2: "N"},
-        },,
+        }
         **get_onnx_export_kwargs(),
     )
 
@@ -464,7 +464,7 @@ def export_joiner_model_onnx(
             "encoder_out": {0: "N"},
             "decoder_out": {0: "N"},
             "logit": {0: "N"},
-        },,
+        }
         **get_onnx_export_kwargs(),
     )
     meta_data = {

--- a/egs/librispeech/ASR/pruned_transducer_stateless5/export-onnx-streaming.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless5/export-onnx-streaming.py
@@ -75,6 +75,7 @@ from icefall.checkpoint import (
     load_checkpoint,
 )
 from icefall.utils import num_tokens, setup_logger, str2bool
+from icefall.utils import get_onnx_export_kwargs
 
 
 def get_parser():
@@ -354,7 +355,8 @@ def export_encoder_model_onnx(
             "encoder_out": {0: "N"},
             "new_cached_attn": {2: "N"},
             "new_cached_conv": {2: "N"},
-        },
+        },,
+        **get_onnx_export_kwargs(),
     )
 
     meta_data = {
@@ -417,7 +419,7 @@ def export_decoder_model_onnx(
             "y": {0: "N"},
             "decoder_out": {0: "N"},
         },
-    )
+    , **get_onnx_export_kwargs())
 
     meta_data = {
         "context_size": str(context_size),
@@ -462,7 +464,8 @@ def export_joiner_model_onnx(
             "encoder_out": {0: "N"},
             "decoder_out": {0: "N"},
             "logit": {0: "N"},
-        },
+        },,
+        **get_onnx_export_kwargs(),
     )
     meta_data = {
         "joiner_dim": str(joiner_dim),

--- a/egs/librispeech/ASR/pruned_transducer_stateless5/export-onnx.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless5/export-onnx.py
@@ -295,7 +295,7 @@ def export_encoder_model_onnx(
             "x_lens": {0: "N"},
             "encoder_out": {0: "N", 1: "T"},
             "encoder_out_lens": {0: "N"},
-        },,
+        }
         **get_onnx_export_kwargs(),
     )
 
@@ -395,7 +395,7 @@ def export_joiner_model_onnx(
             "encoder_out": {0: "N"},
             "decoder_out": {0: "N"},
             "logit": {0: "N"},
-        },,
+        }
         **get_onnx_export_kwargs(),
     )
     meta_data = {

--- a/egs/librispeech/ASR/pruned_transducer_stateless5/export-onnx.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless5/export-onnx.py
@@ -295,9 +295,9 @@ def export_encoder_model_onnx(
             "x_lens": {0: "N"},
             "encoder_out": {0: "N", 1: "T"},
             "encoder_out_lens": {0: "N"},
-        }
+        },
         **get_onnx_export_kwargs(),
-    )
+)
 
     meta_data = {
         "model_type": "conformer",
@@ -350,7 +350,8 @@ def export_decoder_model_onnx(
             "y": {0: "N"},
             "decoder_out": {0: "N"},
         },
-    , **get_onnx_export_kwargs())
+        **get_onnx_export_kwargs(),
+)
 
     meta_data = {
         "context_size": str(context_size),
@@ -395,9 +396,9 @@ def export_joiner_model_onnx(
             "encoder_out": {0: "N"},
             "decoder_out": {0: "N"},
             "logit": {0: "N"},
-        }
+        },
         **get_onnx_export_kwargs(),
-    )
+)
     meta_data = {
         "joiner_dim": str(joiner_dim),
     }

--- a/egs/librispeech/ASR/pruned_transducer_stateless5/export-onnx.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless5/export-onnx.py
@@ -72,6 +72,7 @@ from icefall.checkpoint import (
     load_checkpoint,
 )
 from icefall.utils import num_tokens, setup_logger, str2bool
+from icefall.utils import get_onnx_export_kwargs
 
 
 def get_parser():
@@ -294,7 +295,8 @@ def export_encoder_model_onnx(
             "x_lens": {0: "N"},
             "encoder_out": {0: "N", 1: "T"},
             "encoder_out_lens": {0: "N"},
-        },
+        },,
+        **get_onnx_export_kwargs(),
     )
 
     meta_data = {
@@ -348,7 +350,7 @@ def export_decoder_model_onnx(
             "y": {0: "N"},
             "decoder_out": {0: "N"},
         },
-    )
+    , **get_onnx_export_kwargs())
 
     meta_data = {
         "context_size": str(context_size),
@@ -393,7 +395,8 @@ def export_joiner_model_onnx(
             "encoder_out": {0: "N"},
             "decoder_out": {0: "N"},
             "logit": {0: "N"},
-        },
+        },,
+        **get_onnx_export_kwargs(),
     )
     meta_data = {
         "joiner_dim": str(joiner_dim),

--- a/egs/librispeech/ASR/pruned_transducer_stateless5/onnx_pretrained-streaming.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless5/onnx_pretrained-streaming.py
@@ -69,7 +69,7 @@ import k2
 import numpy as np
 import onnxruntime as ort
 import torch
-import torchaudio
+import soundfile as sf
 from kaldifeat import FbankOptions, OnlineFbank, OnlineFeature
 
 
@@ -109,7 +109,7 @@ def get_parser():
         "sound_file",
         type=str,
         help="The input sound file to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -301,7 +301,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/librispeech/ASR/pruned_transducer_stateless5/pretrained.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless5/pretrained.py
@@ -67,7 +67,7 @@ from typing import List
 import k2
 import kaldifeat
 import torch
-import torchaudio
+import soundfile as sf
 from beam_search import (
     beam_search,
     fast_beam_search_one_best,
@@ -118,7 +118,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -197,7 +197,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/librispeech/ASR/pruned_transducer_stateless7/export-onnx.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless7/export-onnx.py
@@ -67,6 +67,7 @@ from icefall.checkpoint import (
     load_checkpoint,
 )
 from icefall.utils import num_tokens, setup_logger, str2bool
+from icefall.utils import get_onnx_export_kwargs
 
 
 def get_parser():
@@ -288,7 +289,8 @@ def export_encoder_model_onnx(
             "x_lens": {0: "N"},
             "encoder_out": {0: "N", 1: "T"},
             "encoder_out_lens": {0: "N"},
-        },
+        },,
+        **get_onnx_export_kwargs(),
     )
 
     meta_data = {
@@ -342,7 +344,7 @@ def export_decoder_model_onnx(
             "y": {0: "N"},
             "decoder_out": {0: "N"},
         },
-    )
+    , **get_onnx_export_kwargs())
 
     meta_data = {
         "context_size": str(context_size),
@@ -387,7 +389,8 @@ def export_joiner_model_onnx(
             "encoder_out": {0: "N"},
             "decoder_out": {0: "N"},
             "logit": {0: "N"},
-        },
+        },,
+        **get_onnx_export_kwargs(),
     )
     meta_data = {
         "joiner_dim": str(joiner_dim),

--- a/egs/librispeech/ASR/pruned_transducer_stateless7/export-onnx.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless7/export-onnx.py
@@ -289,7 +289,7 @@ def export_encoder_model_onnx(
             "x_lens": {0: "N"},
             "encoder_out": {0: "N", 1: "T"},
             "encoder_out_lens": {0: "N"},
-        },,
+        }
         **get_onnx_export_kwargs(),
     )
 
@@ -389,7 +389,7 @@ def export_joiner_model_onnx(
             "encoder_out": {0: "N"},
             "decoder_out": {0: "N"},
             "logit": {0: "N"},
-        },,
+        }
         **get_onnx_export_kwargs(),
     )
     meta_data = {

--- a/egs/librispeech/ASR/pruned_transducer_stateless7/export-onnx.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless7/export-onnx.py
@@ -289,9 +289,9 @@ def export_encoder_model_onnx(
             "x_lens": {0: "N"},
             "encoder_out": {0: "N", 1: "T"},
             "encoder_out_lens": {0: "N"},
-        }
+        },
         **get_onnx_export_kwargs(),
-    )
+)
 
     meta_data = {
         "model_type": "zipformer",
@@ -344,7 +344,8 @@ def export_decoder_model_onnx(
             "y": {0: "N"},
             "decoder_out": {0: "N"},
         },
-    , **get_onnx_export_kwargs())
+        **get_onnx_export_kwargs(),
+)
 
     meta_data = {
         "context_size": str(context_size),
@@ -389,9 +390,9 @@ def export_joiner_model_onnx(
             "encoder_out": {0: "N"},
             "decoder_out": {0: "N"},
             "logit": {0: "N"},
-        }
+        },
         **get_onnx_export_kwargs(),
-    )
+)
     meta_data = {
         "joiner_dim": str(joiner_dim),
     }

--- a/egs/librispeech/ASR/pruned_transducer_stateless7/jit_pretrained.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless7/jit_pretrained.py
@@ -43,7 +43,7 @@ from typing import List
 import kaldifeat
 import sentencepiece as spm
 import torch
-import torchaudio
+import soundfile as sf
 from torch.nn.utils.rnn import pad_sequence
 
 
@@ -70,7 +70,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -92,7 +92,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/librispeech/ASR/pruned_transducer_stateless7/pretrained.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless7/pretrained.py
@@ -77,7 +77,7 @@ from typing import List
 import k2
 import kaldifeat
 import torch
-import torchaudio
+import soundfile as sf
 from beam_search import (
     beam_search,
     fast_beam_search_one_best,
@@ -128,7 +128,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -207,7 +207,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/librispeech/ASR/pruned_transducer_stateless7/test_onnx.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless7/test_onnx.py
@@ -196,7 +196,7 @@ def test_zipformer_encoder_layer():
             "x": {0: "T", 1: "N"},
             "pos_emb": {0: "N", 1: "T"},
             "y": {0: "T", 1: "N"},
-        },,
+        }
         **get_onnx_export_kwargs(),
     )
 
@@ -278,7 +278,7 @@ def test_zipformer_encoder():
         dynamic_axes={
             "x": {0: "T", 1: "N"},
             "y": {0: "T", 1: "N"},
-        },,
+        }
         **get_onnx_export_kwargs(),
     )
 
@@ -335,7 +335,7 @@ def test_zipformer():
             "x_lens": {0: "N"},
             "y": {0: "N", 1: "T"},
             "y_lens": {0: "N"},
-        },,
+        }
         **get_onnx_export_kwargs(),
     )
     options = ort.SessionOptions()

--- a/egs/librispeech/ASR/pruned_transducer_stateless7/test_onnx.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless7/test_onnx.py
@@ -20,6 +20,7 @@
 This file is to test that models can be exported to onnx.
 """
 import os
+
 from icefall import is_module_available
 from icefall.utils import get_onnx_export_kwargs
 
@@ -65,7 +66,8 @@ def test_conv2d_subsampling():
             "x": {0: "N", 1: "T"},
             "y": {0: "N", 1: "T"},
         },
-    , **get_onnx_export_kwargs())
+        **get_onnx_export_kwargs(),
+)
 
     options = ort.SessionOptions()
     options.inter_op_num_threads = 1
@@ -120,7 +122,8 @@ def test_rel_pos():
             "x": {0: "N", 1: "T"},
             "pos_emb": {0: "N", 1: "T"},
         },
-    , **get_onnx_export_kwargs())
+        **get_onnx_export_kwargs(),
+)
 
     options = ort.SessionOptions()
     options.inter_op_num_threads = 1
@@ -196,9 +199,9 @@ def test_zipformer_encoder_layer():
             "x": {0: "T", 1: "N"},
             "pos_emb": {0: "N", 1: "T"},
             "y": {0: "T", 1: "N"},
-        }
+        },
         **get_onnx_export_kwargs(),
-    )
+)
 
     options = ort.SessionOptions()
     options.inter_op_num_threads = 1
@@ -278,9 +281,9 @@ def test_zipformer_encoder():
         dynamic_axes={
             "x": {0: "T", 1: "N"},
             "y": {0: "T", 1: "N"},
-        }
+        },
         **get_onnx_export_kwargs(),
-    )
+)
 
     options = ort.SessionOptions()
     options.inter_op_num_threads = 1
@@ -335,9 +338,9 @@ def test_zipformer():
             "x_lens": {0: "N"},
             "y": {0: "N", 1: "T"},
             "y_lens": {0: "N"},
-        }
+        },
         **get_onnx_export_kwargs(),
-    )
+)
     options = ort.SessionOptions()
     options.inter_op_num_threads = 1
     options.intra_op_num_threads = 1

--- a/egs/librispeech/ASR/pruned_transducer_stateless7/test_onnx.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless7/test_onnx.py
@@ -20,8 +20,8 @@
 This file is to test that models can be exported to onnx.
 """
 import os
-
 from icefall import is_module_available
+from icefall.utils import get_onnx_export_kwargs
 
 if not is_module_available("onnxruntime"):
     raise ValueError("Please 'pip install onnxruntime' first.")
@@ -65,7 +65,7 @@ def test_conv2d_subsampling():
             "x": {0: "N", 1: "T"},
             "y": {0: "N", 1: "T"},
         },
-    )
+    , **get_onnx_export_kwargs())
 
     options = ort.SessionOptions()
     options.inter_op_num_threads = 1
@@ -120,7 +120,7 @@ def test_rel_pos():
             "x": {0: "N", 1: "T"},
             "pos_emb": {0: "N", 1: "T"},
         },
-    )
+    , **get_onnx_export_kwargs())
 
     options = ort.SessionOptions()
     options.inter_op_num_threads = 1
@@ -196,7 +196,8 @@ def test_zipformer_encoder_layer():
             "x": {0: "T", 1: "N"},
             "pos_emb": {0: "N", 1: "T"},
             "y": {0: "T", 1: "N"},
-        },
+        },,
+        **get_onnx_export_kwargs(),
     )
 
     options = ort.SessionOptions()
@@ -277,7 +278,8 @@ def test_zipformer_encoder():
         dynamic_axes={
             "x": {0: "T", 1: "N"},
             "y": {0: "T", 1: "N"},
-        },
+        },,
+        **get_onnx_export_kwargs(),
     )
 
     options = ort.SessionOptions()
@@ -333,7 +335,8 @@ def test_zipformer():
             "x_lens": {0: "N"},
             "y": {0: "N", 1: "T"},
             "y_lens": {0: "N"},
-        },
+        },,
+        **get_onnx_export_kwargs(),
     )
     options = ort.SessionOptions()
     options.inter_op_num_threads = 1

--- a/egs/librispeech/ASR/pruned_transducer_stateless7_ctc/jit_pretrained.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless7_ctc/jit_pretrained.py
@@ -42,7 +42,7 @@ from typing import List
 import kaldifeat
 import sentencepiece as spm
 import torch
-import torchaudio
+import soundfile as sf
 from torch.nn.utils.rnn import pad_sequence
 
 
@@ -69,7 +69,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -91,7 +91,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"Expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/librispeech/ASR/pruned_transducer_stateless7_ctc/jit_pretrained_ctc.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless7_ctc/jit_pretrained_ctc.py
@@ -82,7 +82,7 @@ import k2
 import kaldifeat
 import sentencepiece as spm
 import torch
-import torchaudio
+import soundfile as sf
 from ctc_decode import get_decoding_params
 from torch.nn.utils.rnn import pad_sequence
 from train import get_params
@@ -220,7 +220,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -242,7 +242,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"Expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/librispeech/ASR/pruned_transducer_stateless7_ctc/pretrained.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless7_ctc/pretrained.py
@@ -76,7 +76,7 @@ from typing import List
 import k2
 import kaldifeat
 import torch
-import torchaudio
+import soundfile as sf
 from beam_search import (
     beam_search,
     fast_beam_search_one_best,
@@ -127,7 +127,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -206,7 +206,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"Expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/librispeech/ASR/pruned_transducer_stateless7_ctc/pretrained_ctc.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless7_ctc/pretrained_ctc.py
@@ -80,7 +80,7 @@ import k2
 import kaldifeat
 import sentencepiece as spm
 import torch
-import torchaudio
+import soundfile as sf
 from ctc_decode import get_decoding_params
 from torch.nn.utils.rnn import pad_sequence
 from train import add_model_arguments, get_params, get_transducer_model
@@ -227,7 +227,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -251,7 +251,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert sample_rate == expected_sample_rate, (
             f"expected sample rate: {expected_sample_rate}. " f"Given: {sample_rate}"
         )

--- a/egs/librispeech/ASR/pruned_transducer_stateless7_ctc_bs/export_onnx.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless7_ctc_bs/export_onnx.py
@@ -267,7 +267,7 @@ def export_encoder_model_onnx(
             "x_lens": {0: "N"},
             "encoder_out": {0: "N", 1: "T"},
             "encoder_out_lens": {0: "N"},
-        },,
+        }
         **get_onnx_export_kwargs(),
     )
     logging.info(f"Saved to {encoder_filename}")
@@ -313,7 +313,7 @@ def export_decoder_model_onnx(
         dynamic_axes={
             "y": {0: "N"},
             "decoder_out": {0: "N"},
-        },,
+        }
         **get_onnx_export_kwargs(),
     )
     logging.info(f"Saved to {decoder_filename}")
@@ -352,7 +352,7 @@ def export_decoder_model_onnx_triton(
         dynamic_axes={
             "y": {0: "N"},
             "decoder_out": {0: "N"},
-        },,
+        }
         **get_onnx_export_kwargs(),
     )
     logging.info(f"Saved to {decoder_filename}")
@@ -417,7 +417,7 @@ def export_joiner_model_onnx(
             "encoder_out": {0: "N"},
             "decoder_out": {0: "N"},
             "logit": {0: "N"},
-        },,
+        }
         **get_onnx_export_kwargs(),
     )
     logging.info(f"Saved to {joiner_filename}")
@@ -503,7 +503,7 @@ def export_joiner_model_onnx_triton(
             "encoder_out": {0: "N"},
             "decoder_out": {0: "N"},
             "logit": {0: "N"},
-        },,
+        }
         **get_onnx_export_kwargs(),
     )
     logging.info(f"Saved to {joiner_filename}")
@@ -580,7 +580,7 @@ def export_lconv_onnx(
             "lconv_input": {0: "N", 1: "T"},
             "src_key_padding_mask": {0: "N", 1: "T"},
             "lconv_out": {0: "N", 1: "T"},
-        },,
+        }
         **get_onnx_export_kwargs(),
     )
     logging.info(f"Saved to {lconv_filename}")
@@ -627,7 +627,7 @@ def export_lconv_onnx_triton(
             "lconv_input": {0: "N", 1: "T"},
             "lconv_input_lens": {0: "N"},
             "lconv_out": {0: "N", 1: "T"},
-        },,
+        }
         **get_onnx_export_kwargs(),
     )
     logging.info(f"Saved to {lconv_filename}")
@@ -678,7 +678,7 @@ def export_frame_reducer_onnx(
             "ctc_output": {0: "N", 1: "T"},
             "out": {0: "N", 1: "T"},
             "out_lens": {0: "N"},
-        },,
+        }
         **get_onnx_export_kwargs(),
     )
     logging.info(f"Saved to {frame_reducer_filename}")
@@ -720,7 +720,7 @@ def export_ctc_output_onnx(
         dynamic_axes={
             "encoder_out": {0: "N", 1: "T"},
             "ctc_output": {0: "N", 1: "T"},
-        },,
+        }
         **get_onnx_export_kwargs(),
     )
     logging.info(f"Saved to {ctc_output_filename}")

--- a/egs/librispeech/ASR/pruned_transducer_stateless7_ctc_bs/export_onnx.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless7_ctc_bs/export_onnx.py
@@ -100,7 +100,6 @@ from icefall.checkpoint import (
     load_checkpoint,
 )
 from icefall.utils import num_tokens, str2bool
-from icefall.utils import get_onnx_export_kwargs
 
 
 def get_parser():
@@ -250,9 +249,7 @@ def export_encoder_model_onnx(
     # submit a pull request on PyTorch GitHub.
     #
     # I cannot find which statement causes the above error.
-    # torch.onnx.export(,
-        **get_onnx_export_kwargs(),
-    ) will use torch.jit.trace() internally, which
+    # torch.onnx.export() will use torch.jit.trace() internally, which
     # works well for the current reworked model
     torch.onnx.export(
         encoder_model,
@@ -267,8 +264,7 @@ def export_encoder_model_onnx(
             "x_lens": {0: "N"},
             "encoder_out": {0: "N", 1: "T"},
             "encoder_out_lens": {0: "N"},
-        }
-        **get_onnx_export_kwargs(),
+        },
     )
     logging.info(f"Saved to {encoder_filename}")
 
@@ -313,8 +309,7 @@ def export_decoder_model_onnx(
         dynamic_axes={
             "y": {0: "N"},
             "decoder_out": {0: "N"},
-        }
-        **get_onnx_export_kwargs(),
+        },
     )
     logging.info(f"Saved to {decoder_filename}")
 
@@ -352,8 +347,7 @@ def export_decoder_model_onnx_triton(
         dynamic_axes={
             "y": {0: "N"},
             "decoder_out": {0: "N"},
-        }
-        **get_onnx_export_kwargs(),
+        },
     )
     logging.info(f"Saved to {decoder_filename}")
 
@@ -417,8 +411,7 @@ def export_joiner_model_onnx(
             "encoder_out": {0: "N"},
             "decoder_out": {0: "N"},
             "logit": {0: "N"},
-        }
-        **get_onnx_export_kwargs(),
+        },
     )
     logging.info(f"Saved to {joiner_filename}")
 
@@ -435,7 +428,7 @@ def export_joiner_model_onnx(
             "encoder_out": {0: "N"},
             "projected_encoder_out": {0: "N"},
         },
-    , **get_onnx_export_kwargs())
+    )
     logging.info(f"Saved to {encoder_proj_filename}")
 
     decoder_out = torch.rand(1, decoder_out_dim, dtype=torch.float32)
@@ -451,7 +444,7 @@ def export_joiner_model_onnx(
             "decoder_out": {0: "N"},
             "projected_decoder_out": {0: "N"},
         },
-    , **get_onnx_export_kwargs())
+    )
     logging.info(f"Saved to {decoder_proj_filename}")
 
 
@@ -503,8 +496,7 @@ def export_joiner_model_onnx_triton(
             "encoder_out": {0: "N"},
             "decoder_out": {0: "N"},
             "logit": {0: "N"},
-        }
-        **get_onnx_export_kwargs(),
+        },
     )
     logging.info(f"Saved to {joiner_filename}")
 
@@ -521,7 +513,7 @@ def export_joiner_model_onnx_triton(
             "encoder_out": {0: "N"},
             "projected_encoder_out": {0: "N"},
         },
-    , **get_onnx_export_kwargs())
+    )
     logging.info(f"Saved to {encoder_proj_filename}")
 
     decoder_out = torch.rand(1, decoder_out_dim, dtype=torch.float32)
@@ -537,7 +529,7 @@ def export_joiner_model_onnx_triton(
             "decoder_out": {0: "N"},
             "projected_decoder_out": {0: "N"},
         },
-    , **get_onnx_export_kwargs())
+    )
     logging.info(f"Saved to {decoder_proj_filename}")
 
 
@@ -580,8 +572,7 @@ def export_lconv_onnx(
             "lconv_input": {0: "N", 1: "T"},
             "src_key_padding_mask": {0: "N", 1: "T"},
             "lconv_out": {0: "N", 1: "T"},
-        }
-        **get_onnx_export_kwargs(),
+        },
     )
     logging.info(f"Saved to {lconv_filename}")
 
@@ -627,8 +618,7 @@ def export_lconv_onnx_triton(
             "lconv_input": {0: "N", 1: "T"},
             "lconv_input_lens": {0: "N"},
             "lconv_out": {0: "N", 1: "T"},
-        }
-        **get_onnx_export_kwargs(),
+        },
     )
     logging.info(f"Saved to {lconv_filename}")
 
@@ -678,8 +668,7 @@ def export_frame_reducer_onnx(
             "ctc_output": {0: "N", 1: "T"},
             "out": {0: "N", 1: "T"},
             "out_lens": {0: "N"},
-        }
-        **get_onnx_export_kwargs(),
+        },
     )
     logging.info(f"Saved to {frame_reducer_filename}")
 
@@ -720,8 +709,7 @@ def export_ctc_output_onnx(
         dynamic_axes={
             "encoder_out": {0: "N", 1: "T"},
             "ctc_output": {0: "N", 1: "T"},
-        }
-        **get_onnx_export_kwargs(),
+        },
     )
     logging.info(f"Saved to {ctc_output_filename}")
 

--- a/egs/librispeech/ASR/pruned_transducer_stateless7_ctc_bs/export_onnx.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless7_ctc_bs/export_onnx.py
@@ -100,6 +100,7 @@ from icefall.checkpoint import (
     load_checkpoint,
 )
 from icefall.utils import num_tokens, str2bool
+from icefall.utils import get_onnx_export_kwargs
 
 
 def get_parser():
@@ -249,7 +250,9 @@ def export_encoder_model_onnx(
     # submit a pull request on PyTorch GitHub.
     #
     # I cannot find which statement causes the above error.
-    # torch.onnx.export() will use torch.jit.trace() internally, which
+    # torch.onnx.export(,
+        **get_onnx_export_kwargs(),
+    ) will use torch.jit.trace() internally, which
     # works well for the current reworked model
     torch.onnx.export(
         encoder_model,
@@ -264,7 +267,8 @@ def export_encoder_model_onnx(
             "x_lens": {0: "N"},
             "encoder_out": {0: "N", 1: "T"},
             "encoder_out_lens": {0: "N"},
-        },
+        },,
+        **get_onnx_export_kwargs(),
     )
     logging.info(f"Saved to {encoder_filename}")
 
@@ -309,7 +313,8 @@ def export_decoder_model_onnx(
         dynamic_axes={
             "y": {0: "N"},
             "decoder_out": {0: "N"},
-        },
+        },,
+        **get_onnx_export_kwargs(),
     )
     logging.info(f"Saved to {decoder_filename}")
 
@@ -347,7 +352,8 @@ def export_decoder_model_onnx_triton(
         dynamic_axes={
             "y": {0: "N"},
             "decoder_out": {0: "N"},
-        },
+        },,
+        **get_onnx_export_kwargs(),
     )
     logging.info(f"Saved to {decoder_filename}")
 
@@ -411,7 +417,8 @@ def export_joiner_model_onnx(
             "encoder_out": {0: "N"},
             "decoder_out": {0: "N"},
             "logit": {0: "N"},
-        },
+        },,
+        **get_onnx_export_kwargs(),
     )
     logging.info(f"Saved to {joiner_filename}")
 
@@ -428,7 +435,7 @@ def export_joiner_model_onnx(
             "encoder_out": {0: "N"},
             "projected_encoder_out": {0: "N"},
         },
-    )
+    , **get_onnx_export_kwargs())
     logging.info(f"Saved to {encoder_proj_filename}")
 
     decoder_out = torch.rand(1, decoder_out_dim, dtype=torch.float32)
@@ -444,7 +451,7 @@ def export_joiner_model_onnx(
             "decoder_out": {0: "N"},
             "projected_decoder_out": {0: "N"},
         },
-    )
+    , **get_onnx_export_kwargs())
     logging.info(f"Saved to {decoder_proj_filename}")
 
 
@@ -496,7 +503,8 @@ def export_joiner_model_onnx_triton(
             "encoder_out": {0: "N"},
             "decoder_out": {0: "N"},
             "logit": {0: "N"},
-        },
+        },,
+        **get_onnx_export_kwargs(),
     )
     logging.info(f"Saved to {joiner_filename}")
 
@@ -513,7 +521,7 @@ def export_joiner_model_onnx_triton(
             "encoder_out": {0: "N"},
             "projected_encoder_out": {0: "N"},
         },
-    )
+    , **get_onnx_export_kwargs())
     logging.info(f"Saved to {encoder_proj_filename}")
 
     decoder_out = torch.rand(1, decoder_out_dim, dtype=torch.float32)
@@ -529,7 +537,7 @@ def export_joiner_model_onnx_triton(
             "decoder_out": {0: "N"},
             "projected_decoder_out": {0: "N"},
         },
-    )
+    , **get_onnx_export_kwargs())
     logging.info(f"Saved to {decoder_proj_filename}")
 
 
@@ -572,7 +580,8 @@ def export_lconv_onnx(
             "lconv_input": {0: "N", 1: "T"},
             "src_key_padding_mask": {0: "N", 1: "T"},
             "lconv_out": {0: "N", 1: "T"},
-        },
+        },,
+        **get_onnx_export_kwargs(),
     )
     logging.info(f"Saved to {lconv_filename}")
 
@@ -618,7 +627,8 @@ def export_lconv_onnx_triton(
             "lconv_input": {0: "N", 1: "T"},
             "lconv_input_lens": {0: "N"},
             "lconv_out": {0: "N", 1: "T"},
-        },
+        },,
+        **get_onnx_export_kwargs(),
     )
     logging.info(f"Saved to {lconv_filename}")
 
@@ -668,7 +678,8 @@ def export_frame_reducer_onnx(
             "ctc_output": {0: "N", 1: "T"},
             "out": {0: "N", 1: "T"},
             "out_lens": {0: "N"},
-        },
+        },,
+        **get_onnx_export_kwargs(),
     )
     logging.info(f"Saved to {frame_reducer_filename}")
 
@@ -709,7 +720,8 @@ def export_ctc_output_onnx(
         dynamic_axes={
             "encoder_out": {0: "N", 1: "T"},
             "ctc_output": {0: "N", 1: "T"},
-        },
+        },,
+        **get_onnx_export_kwargs(),
     )
     logging.info(f"Saved to {ctc_output_filename}")
 

--- a/egs/librispeech/ASR/pruned_transducer_stateless7_ctc_bs/jit_pretrained.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless7_ctc_bs/jit_pretrained.py
@@ -42,7 +42,7 @@ from typing import List
 import kaldifeat
 import sentencepiece as spm
 import torch
-import torchaudio
+import soundfile as sf
 from torch.nn.utils.rnn import pad_sequence
 
 
@@ -69,7 +69,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -91,7 +91,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"Expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/librispeech/ASR/pruned_transducer_stateless7_ctc_bs/jit_pretrained_ctc.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless7_ctc_bs/jit_pretrained_ctc.py
@@ -82,7 +82,7 @@ import k2
 import kaldifeat
 import sentencepiece as spm
 import torch
-import torchaudio
+import soundfile as sf
 from ctc_decode import get_decoding_params
 from torch.nn.utils.rnn import pad_sequence
 from train import get_params
@@ -220,7 +220,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -242,7 +242,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"Expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/librispeech/ASR/pruned_transducer_stateless7_ctc_bs/onnx_pretrained.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless7_ctc_bs/onnx_pretrained.py
@@ -51,7 +51,7 @@ import numpy as np
 import onnxruntime as ort
 import sentencepiece as spm
 import torch
-import torchaudio
+import soundfile as sf
 from torch.nn.utils.rnn import pack_padded_sequence, pad_sequence
 
 from icefall.utils import make_pad_mask
@@ -129,7 +129,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -165,7 +165,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/librispeech/ASR/pruned_transducer_stateless7_ctc_bs/pretrained.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless7_ctc_bs/pretrained.py
@@ -76,7 +76,7 @@ from typing import List
 import k2
 import kaldifeat
 import torch
-import torchaudio
+import soundfile as sf
 from beam_search import (
     beam_search,
     fast_beam_search_one_best,
@@ -127,7 +127,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -206,7 +206,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert sample_rate == expected_sample_rate, (
             f"expected sample rate: {expected_sample_rate}. " f"Given: {sample_rate}"
         )

--- a/egs/librispeech/ASR/pruned_transducer_stateless7_ctc_bs/pretrained_ctc.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless7_ctc_bs/pretrained_ctc.py
@@ -80,7 +80,7 @@ import k2
 import kaldifeat
 import sentencepiece as spm
 import torch
-import torchaudio
+import soundfile as sf
 from ctc_decode import get_decoding_params
 from torch.nn.utils.rnn import pad_sequence
 from train import add_model_arguments, get_params, get_transducer_model
@@ -227,7 +227,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -251,7 +251,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert sample_rate == expected_sample_rate, (
             f"expected sample rate: {expected_sample_rate}. " f"Given: {sample_rate}"
         )

--- a/egs/librispeech/ASR/pruned_transducer_stateless7_streaming/export-onnx-zh.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless7_streaming/export-onnx-zh.py
@@ -412,9 +412,9 @@ def export_encoder_model_onnx(
             **outputs,
         }
         if dynamic_batch
-        else {}
+        else {},
         **get_onnx_export_kwargs(),
-    )
+)
 
     add_meta_data(filename=encoder_filename, meta_data=meta_data)
 
@@ -467,7 +467,8 @@ def export_decoder_model_onnx(
         }
         if dynamic_batch
         else {},
-    , **get_onnx_export_kwargs())
+        **get_onnx_export_kwargs(),
+)
     meta_data = {
         "context_size": str(context_size),
         "vocab_size": str(vocab_size),
@@ -514,9 +515,9 @@ def export_joiner_model_onnx(
             "logit": {0: "N"},
         }
         if dynamic_batch
-        else {}
+        else {},
         **get_onnx_export_kwargs(),
-    )
+)
     meta_data = {
         "joiner_dim": str(joiner_dim),
     }

--- a/egs/librispeech/ASR/pruned_transducer_stateless7_streaming/export-onnx-zh.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless7_streaming/export-onnx-zh.py
@@ -412,7 +412,7 @@ def export_encoder_model_onnx(
             **outputs,
         }
         if dynamic_batch
-        else {},,
+        else {}
         **get_onnx_export_kwargs(),
     )
 
@@ -514,7 +514,7 @@ def export_joiner_model_onnx(
             "logit": {0: "N"},
         }
         if dynamic_batch
-        else {},,
+        else {}
         **get_onnx_export_kwargs(),
     )
     meta_data = {

--- a/egs/librispeech/ASR/pruned_transducer_stateless7_streaming/export-onnx-zh.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless7_streaming/export-onnx-zh.py
@@ -78,6 +78,7 @@ from icefall.checkpoint import (
     load_checkpoint,
 )
 from icefall.utils import num_tokens, setup_logger, str2bool
+from icefall.utils import get_onnx_export_kwargs
 
 
 def get_parser():
@@ -411,7 +412,8 @@ def export_encoder_model_onnx(
             **outputs,
         }
         if dynamic_batch
-        else {},
+        else {},,
+        **get_onnx_export_kwargs(),
     )
 
     add_meta_data(filename=encoder_filename, meta_data=meta_data)
@@ -465,7 +467,7 @@ def export_decoder_model_onnx(
         }
         if dynamic_batch
         else {},
-    )
+    , **get_onnx_export_kwargs())
     meta_data = {
         "context_size": str(context_size),
         "vocab_size": str(vocab_size),
@@ -512,7 +514,8 @@ def export_joiner_model_onnx(
             "logit": {0: "N"},
         }
         if dynamic_batch
-        else {},
+        else {},,
+        **get_onnx_export_kwargs(),
     )
     meta_data = {
         "joiner_dim": str(joiner_dim),

--- a/egs/librispeech/ASR/pruned_transducer_stateless7_streaming/export-onnx.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless7_streaming/export-onnx.py
@@ -368,9 +368,9 @@ def export_encoder_model_onnx(
             "encoder_out": {0: "N"},
             **inputs,
             **outputs,
-        }
+        },
         **get_onnx_export_kwargs(),
-    )
+)
 
     add_meta_data(filename=encoder_filename, meta_data=meta_data)
 
@@ -416,7 +416,8 @@ def export_decoder_model_onnx(
             "y": {0: "N"},
             "decoder_out": {0: "N"},
         },
-    , **get_onnx_export_kwargs())
+        **get_onnx_export_kwargs(),
+)
     meta_data = {
         "context_size": str(context_size),
         "vocab_size": str(vocab_size),
@@ -460,9 +461,9 @@ def export_joiner_model_onnx(
             "encoder_out": {0: "N"},
             "decoder_out": {0: "N"},
             "logit": {0: "N"},
-        }
+        },
         **get_onnx_export_kwargs(),
-    )
+)
     meta_data = {
         "joiner_dim": str(joiner_dim),
     }

--- a/egs/librispeech/ASR/pruned_transducer_stateless7_streaming/export-onnx.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless7_streaming/export-onnx.py
@@ -368,7 +368,7 @@ def export_encoder_model_onnx(
             "encoder_out": {0: "N"},
             **inputs,
             **outputs,
-        },,
+        }
         **get_onnx_export_kwargs(),
     )
 
@@ -460,7 +460,7 @@ def export_joiner_model_onnx(
             "encoder_out": {0: "N"},
             "decoder_out": {0: "N"},
             "logit": {0: "N"},
-        },,
+        }
         **get_onnx_export_kwargs(),
     )
     meta_data = {

--- a/egs/librispeech/ASR/pruned_transducer_stateless7_streaming/export-onnx.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless7_streaming/export-onnx.py
@@ -66,6 +66,7 @@ from icefall.checkpoint import (
     load_checkpoint,
 )
 from icefall.utils import num_tokens, setup_logger, str2bool
+from icefall.utils import get_onnx_export_kwargs
 
 
 def get_parser():
@@ -367,7 +368,8 @@ def export_encoder_model_onnx(
             "encoder_out": {0: "N"},
             **inputs,
             **outputs,
-        },
+        },,
+        **get_onnx_export_kwargs(),
     )
 
     add_meta_data(filename=encoder_filename, meta_data=meta_data)
@@ -414,7 +416,7 @@ def export_decoder_model_onnx(
             "y": {0: "N"},
             "decoder_out": {0: "N"},
         },
-    )
+    , **get_onnx_export_kwargs())
     meta_data = {
         "context_size": str(context_size),
         "vocab_size": str(vocab_size),
@@ -458,7 +460,8 @@ def export_joiner_model_onnx(
             "encoder_out": {0: "N"},
             "decoder_out": {0: "N"},
             "logit": {0: "N"},
-        },
+        },,
+        **get_onnx_export_kwargs(),
     )
     meta_data = {
         "joiner_dim": str(joiner_dim),

--- a/egs/librispeech/ASR/pruned_transducer_stateless7_streaming/export.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless7_streaming/export.py
@@ -155,7 +155,6 @@ from icefall.checkpoint import (
     load_checkpoint,
 )
 from icefall.utils import num_tokens, str2bool
-from icefall.utils import get_onnx_export_kwargs
 
 
 def get_parser():
@@ -329,9 +328,7 @@ def export_encoder_model_onnx(
     # submit a pull request on PyTorch GitHub.
     #
     # I cannot find which statement causes the above error.
-    # torch.onnx.export(,
-        **get_onnx_export_kwargs(),
-    ) will use torch.jit.trace() internally, which
+    # torch.onnx.export() will use torch.jit.trace() internally, which
     # works well for the current reworked model
     initial_states = [encoder_model.get_init_state() for _ in range(batch_size)]
     states = stack_states(initial_states)
@@ -405,8 +402,7 @@ def export_encoder_model_onnx(
             "new_avg_cache": {0: "N"},
             "new_attn_cache": {0: "N"},
             "new_cnn_cache": {0: "N"},
-        }
-        **get_onnx_export_kwargs(),
+        },
     )
     logging.info(f"Saved to {encoder_filename}")
 
@@ -480,8 +476,7 @@ def export_decoder_model_onnx(
         dynamic_axes={
             "y": {0: "N"},
             "decoder_out": {0: "N"},
-        }
-        **get_onnx_export_kwargs(),
+        },
     )
     logging.info(f"Saved to {decoder_filename}")
 
@@ -526,8 +521,7 @@ def export_decoder_model_onnx_triton(
         dynamic_axes={
             "y": {0: "N"},
             "decoder_out": {0: "N"},
-        }
-        **get_onnx_export_kwargs(),
+        },
     )
     logging.info(f"Saved to {decoder_filename}")
 
@@ -591,8 +585,7 @@ def export_joiner_model_onnx(
             "encoder_out": {0: "N"},
             "decoder_out": {0: "N"},
             "logit": {0: "N"},
-        }
-        **get_onnx_export_kwargs(),
+        },
     )
     logging.info(f"Saved to {joiner_filename}")
 
@@ -609,7 +602,7 @@ def export_joiner_model_onnx(
             "encoder_out": {0: "N"},
             "projected_encoder_out": {0: "N"},
         },
-    , **get_onnx_export_kwargs())
+    )
     logging.info(f"Saved to {encoder_proj_filename}")
 
     decoder_out = torch.rand(1, decoder_out_dim, dtype=torch.float32)
@@ -625,7 +618,7 @@ def export_joiner_model_onnx(
             "decoder_out": {0: "N"},
             "projected_decoder_out": {0: "N"},
         },
-    , **get_onnx_export_kwargs())
+    )
     logging.info(f"Saved to {decoder_proj_filename}")
 
 
@@ -663,8 +656,7 @@ def export_joiner_model_onnx_triton(
             "encoder_out": {0: "N"},
             "decoder_out": {0: "N"},
             "logit": {0: "N"},
-        }
-        **get_onnx_export_kwargs(),
+        },
     )
     logging.info(f"Saved to {joiner_filename}")
 

--- a/egs/librispeech/ASR/pruned_transducer_stateless7_streaming/export.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless7_streaming/export.py
@@ -155,6 +155,7 @@ from icefall.checkpoint import (
     load_checkpoint,
 )
 from icefall.utils import num_tokens, str2bool
+from icefall.utils import get_onnx_export_kwargs
 
 
 def get_parser():
@@ -328,7 +329,9 @@ def export_encoder_model_onnx(
     # submit a pull request on PyTorch GitHub.
     #
     # I cannot find which statement causes the above error.
-    # torch.onnx.export() will use torch.jit.trace() internally, which
+    # torch.onnx.export(,
+        **get_onnx_export_kwargs(),
+    ) will use torch.jit.trace() internally, which
     # works well for the current reworked model
     initial_states = [encoder_model.get_init_state() for _ in range(batch_size)]
     states = stack_states(initial_states)
@@ -402,7 +405,8 @@ def export_encoder_model_onnx(
             "new_avg_cache": {0: "N"},
             "new_attn_cache": {0: "N"},
             "new_cnn_cache": {0: "N"},
-        },
+        },,
+        **get_onnx_export_kwargs(),
     )
     logging.info(f"Saved to {encoder_filename}")
 
@@ -476,7 +480,8 @@ def export_decoder_model_onnx(
         dynamic_axes={
             "y": {0: "N"},
             "decoder_out": {0: "N"},
-        },
+        },,
+        **get_onnx_export_kwargs(),
     )
     logging.info(f"Saved to {decoder_filename}")
 
@@ -521,7 +526,8 @@ def export_decoder_model_onnx_triton(
         dynamic_axes={
             "y": {0: "N"},
             "decoder_out": {0: "N"},
-        },
+        },,
+        **get_onnx_export_kwargs(),
     )
     logging.info(f"Saved to {decoder_filename}")
 
@@ -585,7 +591,8 @@ def export_joiner_model_onnx(
             "encoder_out": {0: "N"},
             "decoder_out": {0: "N"},
             "logit": {0: "N"},
-        },
+        },,
+        **get_onnx_export_kwargs(),
     )
     logging.info(f"Saved to {joiner_filename}")
 
@@ -602,7 +609,7 @@ def export_joiner_model_onnx(
             "encoder_out": {0: "N"},
             "projected_encoder_out": {0: "N"},
         },
-    )
+    , **get_onnx_export_kwargs())
     logging.info(f"Saved to {encoder_proj_filename}")
 
     decoder_out = torch.rand(1, decoder_out_dim, dtype=torch.float32)
@@ -618,7 +625,7 @@ def export_joiner_model_onnx(
             "decoder_out": {0: "N"},
             "projected_decoder_out": {0: "N"},
         },
-    )
+    , **get_onnx_export_kwargs())
     logging.info(f"Saved to {decoder_proj_filename}")
 
 
@@ -656,7 +663,8 @@ def export_joiner_model_onnx_triton(
             "encoder_out": {0: "N"},
             "decoder_out": {0: "N"},
             "logit": {0: "N"},
-        },
+        },,
+        **get_onnx_export_kwargs(),
     )
     logging.info(f"Saved to {joiner_filename}")
 

--- a/egs/librispeech/ASR/pruned_transducer_stateless7_streaming/export.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless7_streaming/export.py
@@ -405,7 +405,7 @@ def export_encoder_model_onnx(
             "new_avg_cache": {0: "N"},
             "new_attn_cache": {0: "N"},
             "new_cnn_cache": {0: "N"},
-        },,
+        }
         **get_onnx_export_kwargs(),
     )
     logging.info(f"Saved to {encoder_filename}")
@@ -480,7 +480,7 @@ def export_decoder_model_onnx(
         dynamic_axes={
             "y": {0: "N"},
             "decoder_out": {0: "N"},
-        },,
+        }
         **get_onnx_export_kwargs(),
     )
     logging.info(f"Saved to {decoder_filename}")
@@ -526,7 +526,7 @@ def export_decoder_model_onnx_triton(
         dynamic_axes={
             "y": {0: "N"},
             "decoder_out": {0: "N"},
-        },,
+        }
         **get_onnx_export_kwargs(),
     )
     logging.info(f"Saved to {decoder_filename}")
@@ -591,7 +591,7 @@ def export_joiner_model_onnx(
             "encoder_out": {0: "N"},
             "decoder_out": {0: "N"},
             "logit": {0: "N"},
-        },,
+        }
         **get_onnx_export_kwargs(),
     )
     logging.info(f"Saved to {joiner_filename}")
@@ -663,7 +663,7 @@ def export_joiner_model_onnx_triton(
             "encoder_out": {0: "N"},
             "decoder_out": {0: "N"},
             "logit": {0: "N"},
-        },,
+        }
         **get_onnx_export_kwargs(),
     )
     logging.info(f"Saved to {joiner_filename}")

--- a/egs/librispeech/ASR/pruned_transducer_stateless7_streaming/jit_pretrained.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless7_streaming/jit_pretrained.py
@@ -43,7 +43,7 @@ from typing import List
 import kaldifeat
 import sentencepiece as spm
 import torch
-import torchaudio
+import soundfile as sf
 from torch.nn.utils.rnn import pad_sequence
 
 
@@ -70,7 +70,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -99,7 +99,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/librispeech/ASR/pruned_transducer_stateless7_streaming/jit_trace_pretrained.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless7_streaming/jit_trace_pretrained.py
@@ -47,7 +47,7 @@ from typing import List, Optional
 import kaldifeat
 import sentencepiece as spm
 import torch
-import torchaudio
+import soundfile as sf
 from kaldifeat import FbankOptions, OnlineFbank, OnlineFeature
 from torch.nn.utils.rnn import pad_sequence
 
@@ -102,7 +102,7 @@ def get_parser():
         "sound_file",
         type=str,
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -124,7 +124,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/librispeech/ASR/pruned_transducer_stateless7_streaming/onnx_pretrained.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless7_streaming/onnx_pretrained.py
@@ -61,7 +61,7 @@ import k2
 import numpy as np
 import onnxruntime as ort
 import torch
-import torchaudio
+import soundfile as sf
 from kaldifeat import FbankOptions, OnlineFbank, OnlineFeature
 
 
@@ -101,7 +101,7 @@ def get_parser():
         "sound_file",
         type=str,
         help="The input sound file to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -378,7 +378,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/librispeech/ASR/pruned_transducer_stateless7_streaming/pretrained.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless7_streaming/pretrained.py
@@ -76,7 +76,7 @@ from typing import List
 import k2
 import kaldifeat
 import torch
-import torchaudio
+import soundfile as sf
 from beam_search import (
     beam_search,
     fast_beam_search_one_best,
@@ -127,7 +127,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -206,7 +206,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/librispeech/ASR/pruned_transducer_stateless7_streaming/streaming-ncnn-decode.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless7_streaming/streaming-ncnn-decode.py
@@ -40,6 +40,7 @@ from typing import List, Optional, Tuple
 import k2
 import ncnn
 import torch
+import soundfile as sf
 import torchaudio
 from kaldifeat import FbankOptions, OnlineFbank, OnlineFeature
 from ncnn_custom_layer import RegisterCustomLayers
@@ -309,7 +310,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/librispeech/ASR/pruned_transducer_stateless8/export-onnx.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless8/export-onnx.py
@@ -66,6 +66,7 @@ from icefall.checkpoint import (
     load_checkpoint,
 )
 from icefall.utils import num_tokens, setup_logger, str2bool
+from icefall.utils import get_onnx_export_kwargs
 
 
 def get_parser():
@@ -288,7 +289,8 @@ def export_encoder_model_onnx(
             "x_lens": {0: "N"},
             "encoder_out": {0: "N", 1: "T"},
             "encoder_out_lens": {0: "N"},
-        },
+        },,
+        **get_onnx_export_kwargs(),
     )
 
     meta_data = {
@@ -342,7 +344,7 @@ def export_decoder_model_onnx(
             "y": {0: "N"},
             "decoder_out": {0: "N"},
         },
-    )
+    , **get_onnx_export_kwargs())
 
     meta_data = {
         "context_size": str(context_size),
@@ -387,7 +389,8 @@ def export_joiner_model_onnx(
             "encoder_out": {0: "N"},
             "decoder_out": {0: "N"},
             "logit": {0: "N"},
-        },
+        },,
+        **get_onnx_export_kwargs(),
     )
     meta_data = {
         "joiner_dim": str(joiner_dim),

--- a/egs/librispeech/ASR/pruned_transducer_stateless8/export-onnx.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless8/export-onnx.py
@@ -289,7 +289,7 @@ def export_encoder_model_onnx(
             "x_lens": {0: "N"},
             "encoder_out": {0: "N", 1: "T"},
             "encoder_out_lens": {0: "N"},
-        },,
+        }
         **get_onnx_export_kwargs(),
     )
 
@@ -389,7 +389,7 @@ def export_joiner_model_onnx(
             "encoder_out": {0: "N"},
             "decoder_out": {0: "N"},
             "logit": {0: "N"},
-        },,
+        }
         **get_onnx_export_kwargs(),
     )
     meta_data = {

--- a/egs/librispeech/ASR/pruned_transducer_stateless8/export-onnx.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless8/export-onnx.py
@@ -289,9 +289,9 @@ def export_encoder_model_onnx(
             "x_lens": {0: "N"},
             "encoder_out": {0: "N", 1: "T"},
             "encoder_out_lens": {0: "N"},
-        }
+        },
         **get_onnx_export_kwargs(),
-    )
+)
 
     meta_data = {
         "model_type": "zipformer",
@@ -344,7 +344,8 @@ def export_decoder_model_onnx(
             "y": {0: "N"},
             "decoder_out": {0: "N"},
         },
-    , **get_onnx_export_kwargs())
+        **get_onnx_export_kwargs(),
+)
 
     meta_data = {
         "context_size": str(context_size),
@@ -389,9 +390,9 @@ def export_joiner_model_onnx(
             "encoder_out": {0: "N"},
             "decoder_out": {0: "N"},
             "logit": {0: "N"},
-        }
+        },
         **get_onnx_export_kwargs(),
-    )
+)
     meta_data = {
         "joiner_dim": str(joiner_dim),
     }

--- a/egs/librispeech/ASR/pruned_transducer_stateless8/jit_pretrained.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless8/jit_pretrained.py
@@ -43,7 +43,7 @@ from typing import List
 import kaldifeat
 import sentencepiece as spm
 import torch
-import torchaudio
+import soundfile as sf
 from torch.nn.utils.rnn import pad_sequence
 
 
@@ -70,7 +70,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -92,7 +92,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/librispeech/ASR/pruned_transducer_stateless8/pretrained.py
+++ b/egs/librispeech/ASR/pruned_transducer_stateless8/pretrained.py
@@ -76,7 +76,7 @@ from typing import List
 import k2
 import kaldifeat
 import torch
-import torchaudio
+import soundfile as sf
 from beam_search import (
     beam_search,
     fast_beam_search_one_best,
@@ -127,7 +127,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -206,7 +206,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/librispeech/ASR/tdnn_lstm_ctc/pretrained.py
+++ b/egs/librispeech/ASR/tdnn_lstm_ctc/pretrained.py
@@ -25,7 +25,7 @@ from typing import List
 import k2
 import kaldifeat
 import torch
-import torchaudio
+import soundfile as sf
 from model import TdnnLstm
 from torch.nn.utils.rnn import pad_sequence
 
@@ -98,7 +98,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -137,7 +137,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/librispeech/ASR/tiny_transducer_ctc/jit_pretrained.py
+++ b/egs/librispeech/ASR/tiny_transducer_ctc/jit_pretrained.py
@@ -42,7 +42,7 @@ from typing import List
 import kaldifeat
 import sentencepiece as spm
 import torch
-import torchaudio
+import soundfile as sf
 from torch.nn.utils.rnn import pad_sequence
 
 
@@ -69,7 +69,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -91,7 +91,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"Expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/librispeech/ASR/tiny_transducer_ctc/jit_pretrained_ctc.py
+++ b/egs/librispeech/ASR/tiny_transducer_ctc/jit_pretrained_ctc.py
@@ -82,7 +82,7 @@ import k2
 import kaldifeat
 import sentencepiece as spm
 import torch
-import torchaudio
+import soundfile as sf
 from ctc_decode import get_decoding_params
 from torch.nn.utils.rnn import pad_sequence
 from train import get_params
@@ -220,7 +220,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -242,7 +242,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"Expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/librispeech/ASR/tiny_transducer_ctc/pretrained.py
+++ b/egs/librispeech/ASR/tiny_transducer_ctc/pretrained.py
@@ -77,7 +77,7 @@ import k2
 import kaldifeat
 import sentencepiece as spm
 import torch
-import torchaudio
+import soundfile as sf
 from beam_search import (
     beam_search,
     fast_beam_search_one_best,
@@ -130,7 +130,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -209,7 +209,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"Expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/librispeech/ASR/tiny_transducer_ctc/pretrained_ctc.py
+++ b/egs/librispeech/ASR/tiny_transducer_ctc/pretrained_ctc.py
@@ -80,7 +80,7 @@ import k2
 import kaldifeat
 import sentencepiece as spm
 import torch
-import torchaudio
+import soundfile as sf
 from ctc_decode import get_decoding_params
 from torch.nn.utils.rnn import pad_sequence
 from train import add_model_arguments, get_params, get_transducer_model
@@ -227,7 +227,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -251,7 +251,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert sample_rate == expected_sample_rate, (
             f"expected sample rate: {expected_sample_rate}. " f"Given: {sample_rate}"
         )

--- a/egs/librispeech/ASR/transducer/pretrained.py
+++ b/egs/librispeech/ASR/transducer/pretrained.py
@@ -39,7 +39,7 @@ from typing import List
 import k2
 import kaldifeat
 import torch
-import torchaudio
+import soundfile as sf
 from beam_search import beam_search, greedy_search
 from conformer import Conformer
 from decoder import Decoder
@@ -86,7 +86,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -185,7 +185,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/librispeech/ASR/transducer_stateless/pretrained.py
+++ b/egs/librispeech/ASR/transducer_stateless/pretrained.py
@@ -68,7 +68,7 @@ from typing import List
 import k2
 import kaldifeat
 import torch
-import torchaudio
+import soundfile as sf
 from beam_search import (
     beam_search,
     fast_beam_search_one_best,
@@ -119,7 +119,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -196,7 +196,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/librispeech/ASR/transducer_stateless2/pretrained.py
+++ b/egs/librispeech/ASR/transducer_stateless2/pretrained.py
@@ -68,7 +68,7 @@ from typing import List
 import k2
 import kaldifeat
 import torch
-import torchaudio
+import soundfile as sf
 from beam_search import (
     beam_search,
     fast_beam_search_one_best,
@@ -119,7 +119,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -196,7 +196,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/librispeech/ASR/transducer_stateless_multi_datasets/pretrained.py
+++ b/egs/librispeech/ASR/transducer_stateless_multi_datasets/pretrained.py
@@ -68,7 +68,7 @@ from typing import List
 import k2
 import kaldifeat
 import torch
-import torchaudio
+import soundfile as sf
 from beam_search import (
     beam_search,
     fast_beam_search_one_best,
@@ -119,7 +119,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -196,7 +196,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/librispeech/ASR/zipformer/export-onnx-ctc.py
+++ b/egs/librispeech/ASR/zipformer/export-onnx-ctc.py
@@ -283,7 +283,7 @@ def export_ctc_model_onnx(
             "x_lens": {0: "N"},
             "log_probs": {0: "N", 1: "T"},
             "log_probs_len": {0: "N"},
-        },,
+        }
         **get_onnx_export_kwargs(),
     )
 

--- a/egs/librispeech/ASR/zipformer/export-onnx-ctc.py
+++ b/egs/librispeech/ASR/zipformer/export-onnx-ctc.py
@@ -84,6 +84,7 @@ from icefall.checkpoint import (
     load_checkpoint,
 )
 from icefall.utils import make_pad_mask, num_tokens, str2bool
+from icefall.utils import get_onnx_export_kwargs
 
 
 def get_parser():
@@ -282,7 +283,8 @@ def export_ctc_model_onnx(
             "x_lens": {0: "N"},
             "log_probs": {0: "N", 1: "T"},
             "log_probs_len": {0: "N"},
-        },
+        },,
+        **get_onnx_export_kwargs(),
     )
 
     meta_data = {

--- a/egs/librispeech/ASR/zipformer/export-onnx-ctc.py
+++ b/egs/librispeech/ASR/zipformer/export-onnx-ctc.py
@@ -283,9 +283,9 @@ def export_ctc_model_onnx(
             "x_lens": {0: "N"},
             "log_probs": {0: "N", 1: "T"},
             "log_probs_len": {0: "N"},
-        }
+        },
         **get_onnx_export_kwargs(),
-    )
+)
 
     meta_data = {
         "model_type": "zipformer2_ctc",

--- a/egs/librispeech/ASR/zipformer/export-onnx-streaming-ctc.py
+++ b/egs/librispeech/ASR/zipformer/export-onnx-streaming-ctc.py
@@ -488,7 +488,7 @@ def export_streaming_ctc_model_onnx(
             **outputs,
         }
         if dynamic_batch
-        else {},,
+        else {}
         **get_onnx_export_kwargs(),
     )
 

--- a/egs/librispeech/ASR/zipformer/export-onnx-streaming-ctc.py
+++ b/egs/librispeech/ASR/zipformer/export-onnx-streaming-ctc.py
@@ -488,9 +488,9 @@ def export_streaming_ctc_model_onnx(
             **outputs,
         }
         if dynamic_batch
-        else {}
+        else {},
         **get_onnx_export_kwargs(),
-    )
+)
 
     add_meta_data(
         filename=encoder_filename,

--- a/egs/librispeech/ASR/zipformer/export-onnx-streaming-ctc.py
+++ b/egs/librispeech/ASR/zipformer/export-onnx-streaming-ctc.py
@@ -67,6 +67,7 @@ from icefall.checkpoint import (
     load_checkpoint,
 )
 from icefall.utils import num_tokens, str2bool
+from icefall.utils import get_onnx_export_kwargs
 
 
 def get_parser():
@@ -487,7 +488,8 @@ def export_streaming_ctc_model_onnx(
             **outputs,
         }
         if dynamic_batch
-        else {},
+        else {},,
+        **get_onnx_export_kwargs(),
     )
 
     add_meta_data(

--- a/egs/librispeech/ASR/zipformer/export-onnx-streaming.py
+++ b/egs/librispeech/ASR/zipformer/export-onnx-streaming.py
@@ -569,7 +569,7 @@ def export_encoder_model_onnx(
             **outputs,
         }
         if dynamic_batch
-        else {},,
+        else {}
         **get_onnx_export_kwargs(),
     )
 
@@ -676,7 +676,7 @@ def export_joiner_model_onnx(
             "logit": {0: "N"},
         }
         if dynamic_batch
-        else {},,
+        else {}
         **get_onnx_export_kwargs(),
     )
     meta_data = {

--- a/egs/librispeech/ASR/zipformer/export-onnx-streaming.py
+++ b/egs/librispeech/ASR/zipformer/export-onnx-streaming.py
@@ -86,6 +86,7 @@ from icefall.checkpoint import (
     load_checkpoint,
 )
 from icefall.utils import num_tokens, str2bool
+from icefall.utils import get_onnx_export_kwargs
 
 
 def get_parser():
@@ -568,7 +569,8 @@ def export_encoder_model_onnx(
             **outputs,
         }
         if dynamic_batch
-        else {},
+        else {},,
+        **get_onnx_export_kwargs(),
     )
 
     add_meta_data(
@@ -626,7 +628,7 @@ def export_decoder_model_onnx(
         }
         if dynamic_batch
         else {},
-    )
+    , **get_onnx_export_kwargs())
 
     meta_data = {
         "context_size": str(context_size),
@@ -674,7 +676,8 @@ def export_joiner_model_onnx(
             "logit": {0: "N"},
         }
         if dynamic_batch
-        else {},
+        else {},,
+        **get_onnx_export_kwargs(),
     )
     meta_data = {
         "joiner_dim": str(joiner_dim),

--- a/egs/librispeech/ASR/zipformer/export-onnx-streaming.py
+++ b/egs/librispeech/ASR/zipformer/export-onnx-streaming.py
@@ -569,9 +569,9 @@ def export_encoder_model_onnx(
             **outputs,
         }
         if dynamic_batch
-        else {}
+        else {},
         **get_onnx_export_kwargs(),
-    )
+)
 
     add_meta_data(
         filename=encoder_filename,
@@ -628,7 +628,8 @@ def export_decoder_model_onnx(
         }
         if dynamic_batch
         else {},
-    , **get_onnx_export_kwargs())
+        **get_onnx_export_kwargs(),
+)
 
     meta_data = {
         "context_size": str(context_size),
@@ -676,9 +677,9 @@ def export_joiner_model_onnx(
             "logit": {0: "N"},
         }
         if dynamic_batch
-        else {}
+        else {},
         **get_onnx_export_kwargs(),
-    )
+)
     meta_data = {
         "joiner_dim": str(joiner_dim),
     }

--- a/egs/librispeech/ASR/zipformer/export-onnx.py
+++ b/egs/librispeech/ASR/zipformer/export-onnx.py
@@ -531,7 +531,7 @@ def export_joiner_model_onnx(
             "logit": {0: "N"},
         }
         if dynamic_axes
-        else {},,
+        else {}
         **get_onnx_export_kwargs(),
     )
     meta_data = {

--- a/egs/librispeech/ASR/zipformer/export-onnx.py
+++ b/egs/librispeech/ASR/zipformer/export-onnx.py
@@ -422,7 +422,8 @@ def export_encoder_model_onnx(
         input_names=input_names,
         output_names=output_names,
         dynamic_axes=dynamic_axes_dict if dynamic_axes else {},
-    , **get_onnx_export_kwargs())
+        **get_onnx_export_kwargs(),
+)
 
     meta_data = {
         "model_type": "zipformer2",
@@ -483,7 +484,8 @@ def export_decoder_model_onnx(
         }
         if dynamic_axes
         else {},
-    , **get_onnx_export_kwargs())
+        **get_onnx_export_kwargs(),
+)
 
     meta_data = {
         "context_size": str(context_size),
@@ -531,9 +533,9 @@ def export_joiner_model_onnx(
             "logit": {0: "N"},
         }
         if dynamic_axes
-        else {}
+        else {},
         **get_onnx_export_kwargs(),
-    )
+)
     meta_data = {
         "joiner_dim": str(joiner_dim),
     }

--- a/egs/librispeech/ASR/zipformer/export-onnx.py
+++ b/egs/librispeech/ASR/zipformer/export-onnx.py
@@ -82,6 +82,7 @@ from icefall.checkpoint import (
     load_checkpoint,
 )
 from icefall.utils import make_pad_mask, num_tokens, str2bool
+from icefall.utils import get_onnx_export_kwargs
 
 
 def get_parser():
@@ -421,7 +422,7 @@ def export_encoder_model_onnx(
         input_names=input_names,
         output_names=output_names,
         dynamic_axes=dynamic_axes_dict if dynamic_axes else {},
-    )
+    , **get_onnx_export_kwargs())
 
     meta_data = {
         "model_type": "zipformer2",
@@ -482,7 +483,7 @@ def export_decoder_model_onnx(
         }
         if dynamic_axes
         else {},
-    )
+    , **get_onnx_export_kwargs())
 
     meta_data = {
         "context_size": str(context_size),
@@ -530,7 +531,8 @@ def export_joiner_model_onnx(
             "logit": {0: "N"},
         }
         if dynamic_axes
-        else {},
+        else {},,
+        **get_onnx_export_kwargs(),
     )
     meta_data = {
         "joiner_dim": str(joiner_dim),

--- a/egs/librispeech/ASR/zipformer/export-streaming-as-non-streaming-onnx.py
+++ b/egs/librispeech/ASR/zipformer/export-streaming-as-non-streaming-onnx.py
@@ -74,6 +74,7 @@ from icefall.checkpoint import (
     load_checkpoint,
 )
 from icefall.utils import make_pad_mask, num_tokens, str2bool
+from icefall.utils import get_onnx_export_kwargs
 
 
 def get_parser():
@@ -393,7 +394,7 @@ def export_encoder_model_onnx(
         input_names=input_names,
         output_names=output_names,
         dynamic_axes=dynamic_axes_dict if dynamic_axes else {},
-    )
+    , **get_onnx_export_kwargs())
 
     meta_data = {
         "model_type": "zipformer2",
@@ -454,7 +455,7 @@ def export_decoder_model_onnx(
         }
         if dynamic_axes
         else {},
-    )
+    , **get_onnx_export_kwargs())
 
     meta_data = {
         "context_size": str(context_size),
@@ -502,7 +503,8 @@ def export_joiner_model_onnx(
             "logit": {0: "N"},
         }
         if dynamic_axes
-        else {},
+        else {},,
+        **get_onnx_export_kwargs(),
     )
     meta_data = {
         "joiner_dim": str(joiner_dim),

--- a/egs/librispeech/ASR/zipformer/export-streaming-as-non-streaming-onnx.py
+++ b/egs/librispeech/ASR/zipformer/export-streaming-as-non-streaming-onnx.py
@@ -394,7 +394,8 @@ def export_encoder_model_onnx(
         input_names=input_names,
         output_names=output_names,
         dynamic_axes=dynamic_axes_dict if dynamic_axes else {},
-    , **get_onnx_export_kwargs())
+        **get_onnx_export_kwargs(),
+)
 
     meta_data = {
         "model_type": "zipformer2",
@@ -455,7 +456,8 @@ def export_decoder_model_onnx(
         }
         if dynamic_axes
         else {},
-    , **get_onnx_export_kwargs())
+        **get_onnx_export_kwargs(),
+)
 
     meta_data = {
         "context_size": str(context_size),
@@ -503,9 +505,9 @@ def export_joiner_model_onnx(
             "logit": {0: "N"},
         }
         if dynamic_axes
-        else {}
+        else {},
         **get_onnx_export_kwargs(),
-    )
+)
     meta_data = {
         "joiner_dim": str(joiner_dim),
     }

--- a/egs/librispeech/ASR/zipformer/export-streaming-as-non-streaming-onnx.py
+++ b/egs/librispeech/ASR/zipformer/export-streaming-as-non-streaming-onnx.py
@@ -503,7 +503,7 @@ def export_joiner_model_onnx(
             "logit": {0: "N"},
         }
         if dynamic_axes
-        else {},,
+        else {}
         **get_onnx_export_kwargs(),
     )
     meta_data = {

--- a/egs/librispeech/ASR/zipformer/jit_pretrained.py
+++ b/egs/librispeech/ASR/zipformer/jit_pretrained.py
@@ -43,7 +43,7 @@ from typing import List
 import k2
 import kaldifeat
 import torch
-import torchaudio
+import soundfile as sf
 from torch.nn.utils.rnn import pad_sequence
 
 
@@ -70,7 +70,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -92,7 +92,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/librispeech/ASR/zipformer/jit_pretrained_ctc.py
+++ b/egs/librispeech/ASR/zipformer/jit_pretrained_ctc.py
@@ -92,7 +92,7 @@ from typing import List
 import k2
 import kaldifeat
 import torch
-import torchaudio
+import soundfile as sf
 from ctc_decode import get_decoding_params
 from export import num_tokens
 from torch.nn.utils.rnn import pad_sequence
@@ -222,7 +222,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -244,7 +244,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"Expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/librispeech/ASR/zipformer/jit_pretrained_streaming.py
+++ b/egs/librispeech/ASR/zipformer/jit_pretrained_streaming.py
@@ -44,7 +44,7 @@ from typing import List, Optional
 
 import k2
 import torch
-import torchaudio
+import soundfile as sf
 from kaldifeat import FbankOptions, OnlineFbank, OnlineFeature
 
 
@@ -77,7 +77,7 @@ def get_parser():
         "sound_file",
         type=str,
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -99,7 +99,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/librispeech/ASR/zipformer/onnx_pretrained-streaming-ctc.py
+++ b/egs/librispeech/ASR/zipformer/onnx_pretrained-streaming-ctc.py
@@ -63,7 +63,7 @@ from typing import Dict, List, Tuple
 import numpy as np
 import onnxruntime as ort
 import torch
-import torchaudio
+import soundfile as sf
 from kaldifeat import FbankOptions, OnlineFbank, OnlineFeature
 
 
@@ -89,7 +89,7 @@ def get_parser():
         "sound_file",
         type=str,
         help="The input sound file to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -293,7 +293,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/librispeech/ASR/zipformer/onnx_pretrained-streaming.py
+++ b/egs/librispeech/ASR/zipformer/onnx_pretrained-streaming.py
@@ -77,7 +77,7 @@ import k2
 import numpy as np
 import onnxruntime as ort
 import torch
-import torchaudio
+import soundfile as sf
 from kaldifeat import FbankOptions, OnlineFbank, OnlineFeature
 
 
@@ -117,7 +117,7 @@ def get_parser():
         "sound_file",
         type=str,
         help="The input sound file to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -388,7 +388,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/librispeech/ASR/zipformer/onnx_pretrained.py
+++ b/egs/librispeech/ASR/zipformer/onnx_pretrained.py
@@ -74,7 +74,7 @@ import k2
 import kaldifeat
 import onnxruntime as ort
 import torch
-import torchaudio
+import soundfile as sf
 from torch.nn.utils.rnn import pad_sequence
 
 
@@ -115,7 +115,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -261,7 +261,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/librispeech/ASR/zipformer/onnx_pretrained_ctc.py
+++ b/egs/librispeech/ASR/zipformer/onnx_pretrained_ctc.py
@@ -29,7 +29,7 @@ import k2
 import kaldifeat
 import onnxruntime as ort
 import torch
-import torchaudio
+import soundfile as sf
 from torch.nn.utils.rnn import pad_sequence
 
 
@@ -56,7 +56,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -136,7 +136,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/librispeech/ASR/zipformer/onnx_pretrained_ctc_H.py
+++ b/egs/librispeech/ASR/zipformer/onnx_pretrained_ctc_H.py
@@ -34,7 +34,7 @@ import kaldifeat
 import kaldifst
 import onnxruntime as ort
 import torch
-import torchaudio
+import soundfile as sf
 from kaldi_decoder import DecodableCtc, FasterDecoder, FasterDecoderOptions
 from torch.nn.utils.rnn import pad_sequence
 
@@ -68,7 +68,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -148,7 +148,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/librispeech/ASR/zipformer/onnx_pretrained_ctc_HL.py
+++ b/egs/librispeech/ASR/zipformer/onnx_pretrained_ctc_HL.py
@@ -34,7 +34,7 @@ import kaldifeat
 import kaldifst
 import onnxruntime as ort
 import torch
-import torchaudio
+import soundfile as sf
 from kaldi_decoder import DecodableCtc, FasterDecoder, FasterDecoderOptions
 from torch.nn.utils.rnn import pad_sequence
 
@@ -68,7 +68,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -148,7 +148,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/librispeech/ASR/zipformer/onnx_pretrained_ctc_HLG.py
+++ b/egs/librispeech/ASR/zipformer/onnx_pretrained_ctc_HLG.py
@@ -34,7 +34,7 @@ import kaldifeat
 import kaldifst
 import onnxruntime as ort
 import torch
-import torchaudio
+import soundfile as sf
 from kaldi_decoder import DecodableCtc, FasterDecoder, FasterDecoderOptions
 from torch.nn.utils.rnn import pad_sequence
 
@@ -68,7 +68,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -148,7 +148,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/librispeech/ASR/zipformer/onnx_pretrained_ctc_HLG_streaming.py
+++ b/egs/librispeech/ASR/zipformer/onnx_pretrained_ctc_HLG_streaming.py
@@ -71,6 +71,7 @@ import kaldifst
 import numpy as np
 import onnxruntime as ort
 import torch
+import soundfile as sf
 import torchaudio
 from kaldi_decoder import DecodableCtc, FasterDecoder, FasterDecoderOptions
 from kaldifeat import FbankOptions, OnlineFbank, OnlineFeature
@@ -106,7 +107,7 @@ def get_parser():
         "sound_file",
         type=str,
         help="The input sound file to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. ",
     )
 
@@ -309,7 +310,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         if sample_rate != expected_sample_rate:
             logging.info(f"Resample {sample_rate} to {expected_sample_rate}")
             wave = torchaudio.functional.resample(

--- a/egs/librispeech/ASR/zipformer/pretrained.py
+++ b/egs/librispeech/ASR/zipformer/pretrained.py
@@ -116,7 +116,7 @@ from typing import List
 import k2
 import kaldifeat
 import torch
-import torchaudio
+import soundfile as sf
 from beam_search import (
     fast_beam_search_one_best,
     greedy_search_batch,
@@ -163,7 +163,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -243,7 +243,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/librispeech/ASR/zipformer/pretrained_ctc.py
+++ b/egs/librispeech/ASR/zipformer/pretrained_ctc.py
@@ -100,7 +100,7 @@ from typing import List
 import k2
 import kaldifeat
 import torch
-import torchaudio
+import soundfile as sf
 from ctc_decode import get_decoding_params
 from export import num_tokens
 from torch.nn.utils.rnn import pad_sequence
@@ -242,7 +242,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -266,7 +266,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert sample_rate == expected_sample_rate, (
             f"expected sample rate: {expected_sample_rate}. " f"Given: {sample_rate}"
         )

--- a/egs/librispeech/ASR/zipformer_adapter/export-onnx.py
+++ b/egs/librispeech/ASR/zipformer_adapter/export-onnx.py
@@ -84,6 +84,7 @@ from icefall.checkpoint import (
     load_checkpoint,
 )
 from icefall.utils import make_pad_mask, num_tokens, str2bool
+from icefall.utils import get_onnx_export_kwargs
 
 
 def get_parser():
@@ -315,7 +316,8 @@ def export_encoder_model_onnx(
             "x_lens": {0: "N"},
             "encoder_out": {0: "N", 1: "T"},
             "encoder_out_lens": {0: "N"},
-        },
+        },,
+        **get_onnx_export_kwargs(),
     )
 
     meta_data = {
@@ -369,7 +371,7 @@ def export_decoder_model_onnx(
             "y": {0: "N"},
             "decoder_out": {0: "N"},
         },
-    )
+    , **get_onnx_export_kwargs())
 
     meta_data = {
         "context_size": str(context_size),
@@ -414,7 +416,8 @@ def export_joiner_model_onnx(
             "encoder_out": {0: "N"},
             "decoder_out": {0: "N"},
             "logit": {0: "N"},
-        },
+        },,
+        **get_onnx_export_kwargs(),
     )
     meta_data = {
         "joiner_dim": str(joiner_dim),

--- a/egs/librispeech/ASR/zipformer_adapter/export-onnx.py
+++ b/egs/librispeech/ASR/zipformer_adapter/export-onnx.py
@@ -316,7 +316,7 @@ def export_encoder_model_onnx(
             "x_lens": {0: "N"},
             "encoder_out": {0: "N", 1: "T"},
             "encoder_out_lens": {0: "N"},
-        },,
+        }
         **get_onnx_export_kwargs(),
     )
 
@@ -416,7 +416,7 @@ def export_joiner_model_onnx(
             "encoder_out": {0: "N"},
             "decoder_out": {0: "N"},
             "logit": {0: "N"},
-        },,
+        }
         **get_onnx_export_kwargs(),
     )
     meta_data = {

--- a/egs/librispeech/ASR/zipformer_adapter/export-onnx.py
+++ b/egs/librispeech/ASR/zipformer_adapter/export-onnx.py
@@ -316,9 +316,9 @@ def export_encoder_model_onnx(
             "x_lens": {0: "N"},
             "encoder_out": {0: "N", 1: "T"},
             "encoder_out_lens": {0: "N"},
-        }
+        },
         **get_onnx_export_kwargs(),
-    )
+)
 
     meta_data = {
         "model_type": "zipformer2",
@@ -371,7 +371,8 @@ def export_decoder_model_onnx(
             "y": {0: "N"},
             "decoder_out": {0: "N"},
         },
-    , **get_onnx_export_kwargs())
+        **get_onnx_export_kwargs(),
+)
 
     meta_data = {
         "context_size": str(context_size),
@@ -416,9 +417,9 @@ def export_joiner_model_onnx(
             "encoder_out": {0: "N"},
             "decoder_out": {0: "N"},
             "logit": {0: "N"},
-        }
+        },
         **get_onnx_export_kwargs(),
-    )
+)
     meta_data = {
         "joiner_dim": str(joiner_dim),
     }

--- a/egs/librispeech/ASR/zipformer_mmi/jit_pretrained.py
+++ b/egs/librispeech/ASR/zipformer_mmi/jit_pretrained.py
@@ -80,7 +80,7 @@ import k2
 import kaldifeat
 import sentencepiece as spm
 import torch
-import torchaudio
+import soundfile as sf
 from decode import get_decoding_params
 from torch.nn.utils.rnn import pad_sequence
 from train import get_params
@@ -197,7 +197,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -219,7 +219,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/librispeech/ASR/zipformer_mmi/pretrained.py
+++ b/egs/librispeech/ASR/zipformer_mmi/pretrained.py
@@ -84,7 +84,7 @@ from typing import List
 import k2
 import kaldifeat
 import torch
-import torchaudio
+import soundfile as sf
 from decode import get_decoding_params
 from torch.nn.utils.rnn import pad_sequence
 from train import add_model_arguments, get_ctc_model, get_params
@@ -203,7 +203,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -227,7 +227,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/ljspeech/TTS/matcha/export_onnx.py
+++ b/egs/ljspeech/TTS/matcha/export_onnx.py
@@ -169,9 +169,9 @@ def main():
                 "x": {0: "N", 1: "L"},
                 "x_length": {0: "N"},
                 "mel": {0: "N", 2: "L"},
-            }
-        **get_onnx_export_kwargs(),
-    )
+            },
+            **get_onnx_export_kwargs(),
+)
 
         meta_data = {
             "model_type": "matcha-tts",

--- a/egs/ljspeech/TTS/matcha/export_onnx.py
+++ b/egs/ljspeech/TTS/matcha/export_onnx.py
@@ -19,6 +19,7 @@ from tokenizer import Tokenizer
 from train import get_model, get_params
 
 from icefall.checkpoint import load_checkpoint
+from icefall.utils import get_onnx_export_kwargs
 
 
 def get_parser():
@@ -168,8 +169,9 @@ def main():
                 "x": {0: "N", 1: "L"},
                 "x_length": {0: "N"},
                 "mel": {0: "N", 2: "L"},
-            },
-        )
+            },,
+        **get_onnx_export_kwargs(),
+    )
 
         meta_data = {
             "model_type": "matcha-tts",

--- a/egs/ljspeech/TTS/matcha/export_onnx.py
+++ b/egs/ljspeech/TTS/matcha/export_onnx.py
@@ -169,7 +169,7 @@ def main():
                 "x": {0: "N", 1: "L"},
                 "x_length": {0: "N"},
                 "mel": {0: "N", 2: "L"},
-            },,
+            }
         **get_onnx_export_kwargs(),
     )
 

--- a/egs/ljspeech/TTS/matcha/export_onnx_hifigan.py
+++ b/egs/ljspeech/TTS/matcha/export_onnx_hifigan.py
@@ -87,7 +87,8 @@ def main():
                 "mel": {0: "N", 2: "L"},
                 "audio": {0: "N", 1: "L"},
             },
-        , **get_onnx_export_kwargs())
+            **get_onnx_export_kwargs(),
+)
 
         meta_data = {
             "model_type": "hifigan",

--- a/egs/ljspeech/TTS/matcha/export_onnx_hifigan.py
+++ b/egs/ljspeech/TTS/matcha/export_onnx_hifigan.py
@@ -7,6 +7,7 @@ from typing import Any, Dict
 
 import onnx
 import torch
+from icefall.utils import get_onnx_export_kwargs
 from infer import load_vocoder
 
 
@@ -86,7 +87,7 @@ def main():
                 "mel": {0: "N", 2: "L"},
                 "audio": {0: "N", 1: "L"},
             },
-        )
+        , **get_onnx_export_kwargs())
 
         meta_data = {
             "model_type": "hifigan",

--- a/egs/ljspeech/TTS/vits/export-onnx.py
+++ b/egs/ljspeech/TTS/vits/export-onnx.py
@@ -204,9 +204,9 @@ def export_model_onnx(
             "tokens": {0: "N", 1: "T"},
             "tokens_lens": {0: "N"},
             "audio": {0: "N", 1: "T"},
-        }
+        },
         **get_onnx_export_kwargs(),
-    )
+)
 
     if model.model.spks is None:
         num_speakers = 1

--- a/egs/ljspeech/TTS/vits/export-onnx.py
+++ b/egs/ljspeech/TTS/vits/export-onnx.py
@@ -204,7 +204,7 @@ def export_model_onnx(
             "tokens": {0: "N", 1: "T"},
             "tokens_lens": {0: "N"},
             "audio": {0: "N", 1: "T"},
-        },,
+        }
         **get_onnx_export_kwargs(),
     )
 

--- a/egs/ljspeech/TTS/vits/export-onnx.py
+++ b/egs/ljspeech/TTS/vits/export-onnx.py
@@ -43,6 +43,7 @@ from tokenizer import Tokenizer
 from train import get_model, get_params
 
 from icefall.checkpoint import load_checkpoint
+from icefall.utils import get_onnx_export_kwargs
 
 
 def get_parser():
@@ -203,7 +204,8 @@ def export_model_onnx(
             "tokens": {0: "N", 1: "T"},
             "tokens_lens": {0: "N"},
             "audio": {0: "N", 1: "T"},
-        },
+        },,
+        **get_onnx_export_kwargs(),
     )
 
     if model.model.spks is None:

--- a/egs/mgb2/ASR/conformer_ctc/pretrained.py
+++ b/egs/mgb2/ASR/conformer_ctc/pretrained.py
@@ -26,7 +26,7 @@ import k2
 import kaldifeat
 import sentencepiece as spm
 import torch
-import torchaudio
+import soundfile as sf
 from conformer import Conformer
 from torch.nn.utils.rnn import pad_sequence
 
@@ -190,7 +190,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -235,7 +235,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert sample_rate == expected_sample_rate, (
             f"expected sample rate: {expected_sample_rate}. " f"Given: {sample_rate}"
         )

--- a/egs/mgb2/ASR/pruned_transducer_stateless5/pretrained.py
+++ b/egs/mgb2/ASR/pruned_transducer_stateless5/pretrained.py
@@ -68,7 +68,7 @@ import k2
 import kaldifeat
 import sentencepiece as spm
 import torch
-import torchaudio
+import soundfile as sf
 from beam_search import (
     beam_search,
     fast_beam_search_one_best,
@@ -117,7 +117,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -196,7 +196,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert sample_rate == expected_sample_rate, (
             f"expected sample rate: {expected_sample_rate}. " f"Given: {sample_rate}"
         )

--- a/egs/multi_conv_zh_es_ta/ST/zipformer_multijoiner_st/pretrained.py
+++ b/egs/multi_conv_zh_es_ta/ST/zipformer_multijoiner_st/pretrained.py
@@ -116,7 +116,7 @@ from typing import List
 import k2
 import kaldifeat
 import torch
-import torchaudio
+import soundfile as sf
 from beam_search import (
     fast_beam_search_one_best,
     greedy_search_batch,
@@ -165,7 +165,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -245,7 +245,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/multi_zh-hans/ASR/zipformer/pretrained.py
+++ b/egs/multi_zh-hans/ASR/zipformer/pretrained.py
@@ -116,7 +116,7 @@ from typing import List
 import k2
 import kaldifeat
 import torch
-import torchaudio
+import soundfile as sf
 from beam_search import (
     fast_beam_search_one_best,
     greedy_search_batch,
@@ -165,7 +165,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -245,7 +245,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/multi_zh_en/ASR/zipformer/pretrained.py
+++ b/egs/multi_zh_en/ASR/zipformer/pretrained.py
@@ -117,7 +117,7 @@ import k2
 import kaldifeat
 import sentencepiece as spm
 import torch
-import torchaudio
+import soundfile as sf
 from beam_search import (
     fast_beam_search_one_best,
     greedy_search_batch,
@@ -166,7 +166,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -246,7 +246,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/spgispeech/ASR/zipformer/pretrained.py
+++ b/egs/spgispeech/ASR/zipformer/pretrained.py
@@ -116,7 +116,7 @@ from typing import List
 import k2
 import kaldifeat
 import torch
-import torchaudio
+import soundfile as sf
 from beam_search import (
     fast_beam_search_one_best,
     greedy_search_batch,
@@ -165,7 +165,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -245,7 +245,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/tal_csasr/ASR/pruned_transducer_stateless5/pretrained.py
+++ b/egs/tal_csasr/ASR/pruned_transducer_stateless5/pretrained.py
@@ -61,7 +61,7 @@ import k2
 import kaldifeat
 import sentencepiece as spm
 import torch
-import torchaudio
+import soundfile as sf
 from beam_search import (
     beam_search,
     fast_beam_search_one_best,
@@ -116,7 +116,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -195,7 +195,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/tal_csasr/ASR/pruned_transducer_stateless7_bbpe/jit_pretrained.py
+++ b/egs/tal_csasr/ASR/pruned_transducer_stateless7_bbpe/jit_pretrained.py
@@ -43,7 +43,7 @@ from typing import List
 import kaldifeat
 import sentencepiece as spm
 import torch
-import torchaudio
+import soundfile as sf
 from torch.nn.utils.rnn import pad_sequence
 
 from icefall import smart_byte_decode
@@ -72,7 +72,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -94,7 +94,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/tal_csasr/ASR/pruned_transducer_stateless7_bbpe/pretrained.py
+++ b/egs/tal_csasr/ASR/pruned_transducer_stateless7_bbpe/pretrained.py
@@ -77,7 +77,7 @@ import k2
 import kaldifeat
 import sentencepiece as spm
 import torch
-import torchaudio
+import soundfile as sf
 from beam_search import (
     beam_search,
     fast_beam_search_one_best,
@@ -129,7 +129,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -208,7 +208,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/tedlium3/ASR/pruned_transducer_stateless/pretrained.py
+++ b/egs/tedlium3/ASR/pruned_transducer_stateless/pretrained.py
@@ -72,7 +72,7 @@ import k2
 import kaldifeat
 import sentencepiece as spm
 import torch
-import torchaudio
+import soundfile as sf
 from beam_search import (
     beam_search,
     fast_beam_search_one_best,
@@ -123,7 +123,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -201,7 +201,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/tedlium3/ASR/transducer_stateless/pretrained.py
+++ b/egs/tedlium3/ASR/transducer_stateless/pretrained.py
@@ -60,8 +60,8 @@ from typing import List
 import kaldifeat
 import sentencepiece as spm
 import torch
+import soundfile as sf
 import torch.nn as nn
-import torchaudio
 from beam_search import beam_search, greedy_search, modified_beam_search
 from conformer import Conformer
 from decoder import Decoder
@@ -111,7 +111,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -220,7 +220,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/timit/ASR/tdnn_ligru_ctc/pretrained.py
+++ b/egs/timit/ASR/tdnn_ligru_ctc/pretrained.py
@@ -25,7 +25,7 @@ from typing import List
 import k2
 import kaldifeat
 import torch
-import torchaudio
+import soundfile as sf
 from model import TdnnLiGRU
 from torch.nn.utils.rnn import pad_sequence
 
@@ -98,7 +98,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -137,7 +137,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/timit/ASR/tdnn_lstm_ctc/pretrained.py
+++ b/egs/timit/ASR/tdnn_lstm_ctc/pretrained.py
@@ -25,7 +25,7 @@ from typing import List
 import k2
 import kaldifeat
 import torch
-import torchaudio
+import soundfile as sf
 from model import TdnnLstm
 from torch.nn.utils.rnn import pad_sequence
 
@@ -98,7 +98,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -137,7 +137,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/vctk/TTS/vits/export-onnx.py
+++ b/egs/vctk/TTS/vits/export-onnx.py
@@ -46,6 +46,7 @@ from tokenizer import Tokenizer
 from train import get_model, get_params
 
 from icefall.checkpoint import load_checkpoint
+from icefall.utils import get_onnx_export_kwargs
 
 
 def get_parser():
@@ -210,7 +211,8 @@ def export_model_onnx(
             "tokens_lens": {0: "N"},
             "audio": {0: "N", 1: "T"},
             "speaker": {0: "N"},
-        },
+        },,
+        **get_onnx_export_kwargs(),
     )
 
     meta_data = {

--- a/egs/vctk/TTS/vits/export-onnx.py
+++ b/egs/vctk/TTS/vits/export-onnx.py
@@ -211,7 +211,7 @@ def export_model_onnx(
             "tokens_lens": {0: "N"},
             "audio": {0: "N", 1: "T"},
             "speaker": {0: "N"},
-        },,
+        }
         **get_onnx_export_kwargs(),
     )
 

--- a/egs/vctk/TTS/vits/export-onnx.py
+++ b/egs/vctk/TTS/vits/export-onnx.py
@@ -211,9 +211,9 @@ def export_model_onnx(
             "tokens_lens": {0: "N"},
             "audio": {0: "N", 1: "T"},
             "speaker": {0: "N"},
-        }
+        },
         **get_onnx_export_kwargs(),
-    )
+)
 
     meta_data = {
         "model_type": "vits",

--- a/egs/wenetspeech/ASR/pruned_transducer_stateless2/export-onnx.py
+++ b/egs/wenetspeech/ASR/pruned_transducer_stateless2/export-onnx.py
@@ -60,6 +60,7 @@ from train import get_params, get_transducer_model
 
 from icefall.checkpoint import average_checkpoints, load_checkpoint
 from icefall.utils import num_tokens, setup_logger, str2bool
+from icefall.utils import get_onnx_export_kwargs
 
 
 def get_parser():
@@ -269,7 +270,8 @@ def export_encoder_model_onnx(
             "x_lens": {0: "N"},
             "encoder_out": {0: "N", 1: "T"},
             "encoder_out_lens": {0: "N"},
-        },
+        },,
+        **get_onnx_export_kwargs(),
     )
 
     meta_data = {
@@ -323,7 +325,7 @@ def export_decoder_model_onnx(
             "y": {0: "N"},
             "decoder_out": {0: "N"},
         },
-    )
+    , **get_onnx_export_kwargs())
 
     meta_data = {
         "context_size": str(context_size),
@@ -368,7 +370,8 @@ def export_joiner_model_onnx(
             "encoder_out": {0: "N"},
             "decoder_out": {0: "N"},
             "logit": {0: "N"},
-        },
+        },,
+        **get_onnx_export_kwargs(),
     )
     meta_data = {
         "joiner_dim": str(joiner_dim),

--- a/egs/wenetspeech/ASR/pruned_transducer_stateless2/export-onnx.py
+++ b/egs/wenetspeech/ASR/pruned_transducer_stateless2/export-onnx.py
@@ -270,9 +270,9 @@ def export_encoder_model_onnx(
             "x_lens": {0: "N"},
             "encoder_out": {0: "N", 1: "T"},
             "encoder_out_lens": {0: "N"},
-        }
+        },
         **get_onnx_export_kwargs(),
-    )
+)
 
     meta_data = {
         "model_type": "conformer",
@@ -325,7 +325,8 @@ def export_decoder_model_onnx(
             "y": {0: "N"},
             "decoder_out": {0: "N"},
         },
-    , **get_onnx_export_kwargs())
+        **get_onnx_export_kwargs(),
+)
 
     meta_data = {
         "context_size": str(context_size),
@@ -370,9 +371,9 @@ def export_joiner_model_onnx(
             "encoder_out": {0: "N"},
             "decoder_out": {0: "N"},
             "logit": {0: "N"},
-        }
+        },
         **get_onnx_export_kwargs(),
-    )
+)
     meta_data = {
         "joiner_dim": str(joiner_dim),
     }

--- a/egs/wenetspeech/ASR/pruned_transducer_stateless2/export-onnx.py
+++ b/egs/wenetspeech/ASR/pruned_transducer_stateless2/export-onnx.py
@@ -270,7 +270,7 @@ def export_encoder_model_onnx(
             "x_lens": {0: "N"},
             "encoder_out": {0: "N", 1: "T"},
             "encoder_out_lens": {0: "N"},
-        },,
+        }
         **get_onnx_export_kwargs(),
     )
 
@@ -370,7 +370,7 @@ def export_joiner_model_onnx(
             "encoder_out": {0: "N"},
             "decoder_out": {0: "N"},
             "logit": {0: "N"},
-        },,
+        }
         **get_onnx_export_kwargs(),
     )
     meta_data = {

--- a/egs/wenetspeech/ASR/pruned_transducer_stateless2/jit_pretrained.py
+++ b/egs/wenetspeech/ASR/pruned_transducer_stateless2/jit_pretrained.py
@@ -67,7 +67,7 @@ from typing import List
 import k2
 import kaldifeat
 import torch
-import torchaudio
+import soundfile as sf
 from torch.nn.utils.rnn import pad_sequence
 
 
@@ -108,7 +108,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -144,7 +144,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/wenetspeech/ASR/pruned_transducer_stateless2/pretrained.py
+++ b/egs/wenetspeech/ASR/pruned_transducer_stateless2/pretrained.py
@@ -57,7 +57,7 @@ from typing import List
 import k2
 import kaldifeat
 import torch
-import torchaudio
+import soundfile as sf
 from beam_search import (
     beam_search,
     fast_beam_search_one_best,
@@ -108,7 +108,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -187,7 +187,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/wenetspeech/ASR/pruned_transducer_stateless5/export-onnx-streaming.py
+++ b/egs/wenetspeech/ASR/pruned_transducer_stateless5/export-onnx-streaming.py
@@ -356,9 +356,9 @@ def export_encoder_model_onnx(
             "encoder_out": {0: "N"},
             "new_cached_attn": {2: "N"},
             "new_cached_conv": {2: "N"},
-        }
+        },
         **get_onnx_export_kwargs(),
-    )
+)
 
     meta_data = {
         "model_type": "conformer",
@@ -420,7 +420,8 @@ def export_decoder_model_onnx(
             "y": {0: "N"},
             "decoder_out": {0: "N"},
         },
-    , **get_onnx_export_kwargs())
+        **get_onnx_export_kwargs(),
+)
 
     meta_data = {
         "context_size": str(context_size),
@@ -465,9 +466,9 @@ def export_joiner_model_onnx(
             "encoder_out": {0: "N"},
             "decoder_out": {0: "N"},
             "logit": {0: "N"},
-        }
+        },
         **get_onnx_export_kwargs(),
-    )
+)
     meta_data = {
         "joiner_dim": str(joiner_dim),
     }

--- a/egs/wenetspeech/ASR/pruned_transducer_stateless5/export-onnx-streaming.py
+++ b/egs/wenetspeech/ASR/pruned_transducer_stateless5/export-onnx-streaming.py
@@ -356,7 +356,7 @@ def export_encoder_model_onnx(
             "encoder_out": {0: "N"},
             "new_cached_attn": {2: "N"},
             "new_cached_conv": {2: "N"},
-        },,
+        }
         **get_onnx_export_kwargs(),
     )
 
@@ -465,7 +465,7 @@ def export_joiner_model_onnx(
             "encoder_out": {0: "N"},
             "decoder_out": {0: "N"},
             "logit": {0: "N"},
-        },,
+        }
         **get_onnx_export_kwargs(),
     )
     meta_data = {

--- a/egs/wenetspeech/ASR/pruned_transducer_stateless5/export-onnx-streaming.py
+++ b/egs/wenetspeech/ASR/pruned_transducer_stateless5/export-onnx-streaming.py
@@ -76,6 +76,7 @@ from icefall.checkpoint import (
 )
 from icefall.lexicon import Lexicon
 from icefall.utils import num_tokens, setup_logger, str2bool
+from icefall.utils import get_onnx_export_kwargs
 
 
 def get_parser():
@@ -355,7 +356,8 @@ def export_encoder_model_onnx(
             "encoder_out": {0: "N"},
             "new_cached_attn": {2: "N"},
             "new_cached_conv": {2: "N"},
-        },
+        },,
+        **get_onnx_export_kwargs(),
     )
 
     meta_data = {
@@ -418,7 +420,7 @@ def export_decoder_model_onnx(
             "y": {0: "N"},
             "decoder_out": {0: "N"},
         },
-    )
+    , **get_onnx_export_kwargs())
 
     meta_data = {
         "context_size": str(context_size),
@@ -463,7 +465,8 @@ def export_joiner_model_onnx(
             "encoder_out": {0: "N"},
             "decoder_out": {0: "N"},
             "logit": {0: "N"},
-        },
+        },,
+        **get_onnx_export_kwargs(),
     )
     meta_data = {
         "joiner_dim": str(joiner_dim),

--- a/egs/wenetspeech/ASR/pruned_transducer_stateless5/export-onnx.py
+++ b/egs/wenetspeech/ASR/pruned_transducer_stateless5/export-onnx.py
@@ -295,7 +295,7 @@ def export_encoder_model_onnx(
             "x_lens": {0: "N"},
             "encoder_out": {0: "N", 1: "T"},
             "encoder_out_lens": {0: "N"},
-        },,
+        }
         **get_onnx_export_kwargs(),
     )
 
@@ -395,7 +395,7 @@ def export_joiner_model_onnx(
             "encoder_out": {0: "N"},
             "decoder_out": {0: "N"},
             "logit": {0: "N"},
-        },,
+        }
         **get_onnx_export_kwargs(),
     )
     meta_data = {

--- a/egs/wenetspeech/ASR/pruned_transducer_stateless5/export-onnx.py
+++ b/egs/wenetspeech/ASR/pruned_transducer_stateless5/export-onnx.py
@@ -295,9 +295,9 @@ def export_encoder_model_onnx(
             "x_lens": {0: "N"},
             "encoder_out": {0: "N", 1: "T"},
             "encoder_out_lens": {0: "N"},
-        }
+        },
         **get_onnx_export_kwargs(),
-    )
+)
 
     meta_data = {
         "model_type": "conformer",
@@ -350,7 +350,8 @@ def export_decoder_model_onnx(
             "y": {0: "N"},
             "decoder_out": {0: "N"},
         },
-    , **get_onnx_export_kwargs())
+        **get_onnx_export_kwargs(),
+)
 
     meta_data = {
         "context_size": str(context_size),
@@ -395,9 +396,9 @@ def export_joiner_model_onnx(
             "encoder_out": {0: "N"},
             "decoder_out": {0: "N"},
             "logit": {0: "N"},
-        }
+        },
         **get_onnx_export_kwargs(),
-    )
+)
     meta_data = {
         "joiner_dim": str(joiner_dim),
     }

--- a/egs/wenetspeech/ASR/pruned_transducer_stateless5/export-onnx.py
+++ b/egs/wenetspeech/ASR/pruned_transducer_stateless5/export-onnx.py
@@ -72,6 +72,7 @@ from icefall.checkpoint import (
     load_checkpoint,
 )
 from icefall.utils import num_tokens, setup_logger, str2bool
+from icefall.utils import get_onnx_export_kwargs
 
 
 def get_parser():
@@ -294,7 +295,8 @@ def export_encoder_model_onnx(
             "x_lens": {0: "N"},
             "encoder_out": {0: "N", 1: "T"},
             "encoder_out_lens": {0: "N"},
-        },
+        },,
+        **get_onnx_export_kwargs(),
     )
 
     meta_data = {
@@ -348,7 +350,7 @@ def export_decoder_model_onnx(
             "y": {0: "N"},
             "decoder_out": {0: "N"},
         },
-    )
+    , **get_onnx_export_kwargs())
 
     meta_data = {
         "context_size": str(context_size),
@@ -393,7 +395,8 @@ def export_joiner_model_onnx(
             "encoder_out": {0: "N"},
             "decoder_out": {0: "N"},
             "logit": {0: "N"},
-        },
+        },,
+        **get_onnx_export_kwargs(),
     )
     meta_data = {
         "joiner_dim": str(joiner_dim),

--- a/egs/wenetspeech/ASR/pruned_transducer_stateless5/onnx_pretrained-streaming.py
+++ b/egs/wenetspeech/ASR/pruned_transducer_stateless5/onnx_pretrained-streaming.py
@@ -70,7 +70,7 @@ import k2
 import numpy as np
 import onnxruntime as ort
 import torch
-import torchaudio
+import soundfile as sf
 from kaldifeat import FbankOptions, OnlineFbank, OnlineFeature
 
 
@@ -110,7 +110,7 @@ def get_parser():
         "sound_file",
         type=str,
         help="The input sound file to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -302,7 +302,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/wenetspeech/ASR/pruned_transducer_stateless5/onnx_pretrained.py
+++ b/egs/wenetspeech/ASR/pruned_transducer_stateless5/onnx_pretrained.py
@@ -81,7 +81,7 @@ import k2
 import kaldifeat
 import onnxruntime as ort
 import torch
-import torchaudio
+import soundfile as sf
 from torch.nn.utils.rnn import pad_sequence
 
 
@@ -122,7 +122,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -267,7 +267,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/wenetspeech/ASR/pruned_transducer_stateless5/pretrained.py
+++ b/egs/wenetspeech/ASR/pruned_transducer_stateless5/pretrained.py
@@ -57,7 +57,7 @@ from typing import List
 import k2
 import kaldifeat
 import torch
-import torchaudio
+import soundfile as sf
 from beam_search import (
     beam_search,
     fast_beam_search_one_best,
@@ -108,7 +108,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -187,7 +187,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/wenetspeech4tts/TTS/f5-tts/infer.py
+++ b/egs/wenetspeech4tts/TTS/f5-tts/infer.py
@@ -31,6 +31,7 @@ from pathlib import Path
 
 import datasets
 import torch
+import soundfile as sf
 import torch.nn.functional as F
 import torchaudio
 from accelerate import Accelerator
@@ -168,7 +169,13 @@ def get_inference_prompt(
         metainfo, desc="Processing prompts..."
     ):
         # Audio
-        ref_audio, ref_sr = torchaudio.load(prompt_wav)
+        data, ref_sr = sf.read(prompt_wav, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        ref_audio = torch.from_numpy(data.T)  # [channel, time]
         ref_rms = torch.sqrt(torch.mean(torch.square(ref_audio)))
         if ref_rms < target_rms:
             ref_audio = ref_audio * target_rms / ref_rms
@@ -191,7 +198,13 @@ def get_inference_prompt(
         # Duration, mel frame length
         ref_mel_len = ref_audio.shape[-1] // hop_length
         if use_truth_duration:
-            gt_audio, gt_sr = torchaudio.load(gt_wav)
+            data, gt_sr = sf.read(gt_wav, dtype='float32')
+
+            if len(data.shape) == 1:
+
+                data = data[:, None]
+
+            gt_audio = torch.from_numpy(data.T)  # [channel, time]
             if gt_sr != target_sample_rate:
                 resampler = torchaudio.transforms.Resample(gt_sr, target_sample_rate)
                 gt_audio = resampler(gt_audio)
@@ -522,7 +535,13 @@ def get_inference_prompt_cosy_voice(
         metainfo, desc="Processing prompts..."
     ):
         # Audio
-        ref_audio_org, ref_sr = torchaudio.load(prompt_wav)
+        data, ref_sr = sf.read(prompt_wav, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        ref_audio_org = torch.from_numpy(data.T)  # [channel, time]
 
         # cosy voice
         if ref_sr != 16000:
@@ -570,7 +589,13 @@ def get_inference_prompt_cosy_voice(
         # Duration, mel frame length
         ref_mel_len = ref_audio.shape[-1] // hop_length
         if use_truth_duration:
-            gt_audio, gt_sr = torchaudio.load(gt_wav)
+            data, gt_sr = sf.read(gt_wav, dtype='float32')
+
+            if len(data.shape) == 1:
+
+                data = data[:, None]
+
+            gt_audio = torch.from_numpy(data.T)  # [channel, time]
             if gt_sr != target_sample_rate:
                 resampler = torchaudio.transforms.Resample(gt_sr, target_sample_rate)
                 gt_audio = resampler(gt_audio)

--- a/egs/wenetspeech4tts/TTS/valle/infer.py
+++ b/egs/wenetspeech4tts/TTS/valle/infer.py
@@ -38,6 +38,7 @@ from pathlib import Path
 os.environ["PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION"] = "python"
 
 import torch
+import soundfile as sf
 import torchaudio
 from compute_neural_codec_and_prepare_text_tokens import (
     AudioTokenizer,
@@ -160,7 +161,13 @@ def load_model(checkpoint, device):
 
 def tokenize_audio(tokenizer: AudioTokenizer, audio_path: str):
     # Load and pre-process the audio waveform
-    wav, sr = torchaudio.load(audio_path)
+    data, sr = sf.read(audio_path, dtype='float32')
+
+    if len(data.shape) == 1:
+
+        data = data[:, None]
+
+    wav = torch.from_numpy(data.T)  # [channel, time]
     wav = convert_audio(wav, sr, tokenizer.sample_rate, tokenizer.channels)
     wav = wav.unsqueeze(0)
 

--- a/egs/xbmu_amdo31/ASR/pruned_transducer_stateless5/pretrained.py
+++ b/egs/xbmu_amdo31/ASR/pruned_transducer_stateless5/pretrained.py
@@ -68,7 +68,7 @@ import k2
 import kaldifeat
 import sentencepiece as spm
 import torch
-import torchaudio
+import soundfile as sf
 from beam_search import (
     beam_search,
     fast_beam_search_one_best,
@@ -117,7 +117,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -196,7 +196,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/xbmu_amdo31/ASR/pruned_transducer_stateless7/pretrained.py
+++ b/egs/xbmu_amdo31/ASR/pruned_transducer_stateless7/pretrained.py
@@ -77,7 +77,7 @@ import k2
 import kaldifeat
 import sentencepiece as spm
 import torch
-import torchaudio
+import soundfile as sf
 from beam_search import (
     beam_search,
     fast_beam_search_one_best,
@@ -128,7 +128,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. "
         "The sample rate has to be 16kHz.",
     )
@@ -207,7 +207,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         assert (
             sample_rate == expected_sample_rate
         ), f"expected sample rate: {expected_sample_rate}. Given: {sample_rate}"

--- a/egs/yesno/ASR/tdnn/export_onnx.py
+++ b/egs/yesno/ASR/tdnn/export_onnx.py
@@ -28,6 +28,7 @@ from train import get_params
 
 from icefall.checkpoint import average_checkpoints, load_checkpoint
 from icefall.lexicon import Lexicon
+from icefall.utils import get_onnx_export_kwargs
 
 
 def get_parser():
@@ -122,7 +123,7 @@ def main():
             "x": {0: "N", 1: "T"},
             "log_prob": {0: "N", 1: "T"},
         },
-    )
+    , **get_onnx_export_kwargs())
 
     logging.info(f"Saved to {onnx_filename}")
     meta_data = {

--- a/egs/yesno/ASR/tdnn/export_onnx.py
+++ b/egs/yesno/ASR/tdnn/export_onnx.py
@@ -123,7 +123,8 @@ def main():
             "x": {0: "N", 1: "T"},
             "log_prob": {0: "N", 1: "T"},
         },
-    , **get_onnx_export_kwargs())
+        **get_onnx_export_kwargs(),
+)
 
     logging.info(f"Saved to {onnx_filename}")
     meta_data = {

--- a/egs/yesno/ASR/tdnn/jit_pretrained.py
+++ b/egs/yesno/ASR/tdnn/jit_pretrained.py
@@ -24,6 +24,7 @@ from typing import List
 import k2
 import kaldifeat
 import torch
+import soundfile as sf
 import torchaudio
 from torch.nn.utils.rnn import pad_sequence
 
@@ -60,7 +61,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. ",
     )
 
@@ -97,7 +98,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         if sample_rate != expected_sample_rate:
             wave = torchaudio.functional.resample(
                 wave,

--- a/egs/yesno/ASR/tdnn/jit_pretrained_decode_with_H.py
+++ b/egs/yesno/ASR/tdnn/jit_pretrained_decode_with_H.py
@@ -27,6 +27,7 @@ from typing import Dict, List
 import kaldifeat
 import kaldifst
 import torch
+import soundfile as sf
 import torchaudio
 from kaldi_decoder import DecodableCtc, FasterDecoder, FasterDecoderOptions
 from torch.nn.utils.rnn import pad_sequence
@@ -61,7 +62,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. ",
     )
 
@@ -92,7 +93,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         if sample_rate != expected_sample_rate:
             wave = torchaudio.functional.resample(
                 wave,

--- a/egs/yesno/ASR/tdnn/jit_pretrained_decode_with_HL.py
+++ b/egs/yesno/ASR/tdnn/jit_pretrained_decode_with_HL.py
@@ -27,6 +27,7 @@ from typing import Dict, List
 import kaldifeat
 import kaldifst
 import torch
+import soundfile as sf
 import torchaudio
 from kaldi_decoder import DecodableCtc, FasterDecoder, FasterDecoderOptions
 from torch.nn.utils.rnn import pad_sequence
@@ -61,7 +62,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. ",
     )
 
@@ -92,7 +93,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         if sample_rate != expected_sample_rate:
             wave = torchaudio.functional.resample(
                 wave,

--- a/egs/yesno/ASR/tdnn/onnx_pretrained.py
+++ b/egs/yesno/ASR/tdnn/onnx_pretrained.py
@@ -37,6 +37,7 @@ import k2
 import kaldifeat
 import onnxruntime as ort
 import torch
+import soundfile as sf
 import torchaudio
 from torch.nn.utils.rnn import pad_sequence
 
@@ -111,7 +112,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. ",
     )
 
@@ -132,7 +133,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         if sample_rate != expected_sample_rate:
             wave = torchaudio.functional.resample(
                 wave,

--- a/egs/yesno/ASR/tdnn/pretrained.py
+++ b/egs/yesno/ASR/tdnn/pretrained.py
@@ -39,6 +39,7 @@ from typing import List
 import k2
 import kaldifeat
 import torch
+import soundfile as sf
 import torchaudio
 from model import Tdnn
 from torch.nn.utils.rnn import pad_sequence
@@ -76,7 +77,7 @@ def get_parser():
         type=str,
         nargs="+",
         help="The input sound file(s) to transcribe. "
-        "Supported formats are those supported by torchaudio.load(). "
+        "Supported formats include wav, flac, and other formats supported by soundfile. "
         "For example, wav and flac are supported. ",
     )
 
@@ -113,7 +114,13 @@ def read_sound_files(
     """
     ans = []
     for f in filenames:
-        wave, sample_rate = torchaudio.load(f)
+        data, sample_rate = sf.read(f, dtype='float32')
+
+        if len(data.shape) == 1:
+
+            data = data[:, None]
+
+        wave = torch.from_numpy(data.T)  # [channel, time]
         if sample_rate != expected_sample_rate:
             wave = torchaudio.functional.resample(
                 wave,

--- a/icefall/utils.py
+++ b/icefall/utils.py
@@ -2457,3 +2457,28 @@ def time_warp(
             )
 
     return features
+
+
+def get_onnx_export_kwargs():
+    """Return extra kwargs for torch.onnx.export for backward compatibility.
+
+    Newer versions of PyTorch (>= 2.9.0) default to dynamo-based ONNX export,
+    which doesn't support ``dynamic_axes``. This function checks whether the
+    current torch version supports the ``dynamo`` parameter and returns
+    ``dynamo=False`` if so, falling back to the legacy export path.
+
+    Returns:
+        A dict of keyword arguments to pass to ``torch.onnx.export``.
+    """
+    import inspect as _inspect
+
+    kwargs = dict()
+    try:
+        export_sig = _inspect.signature(torch.onnx.export)
+        if "dynamo" in export_sig.parameters:
+            kwargs["dynamo"] = False
+        if "external_data" in export_sig.parameters:
+            kwargs["external_data"] = False
+    except (ValueError, TypeError):
+        pass
+    return kwargs


### PR DESCRIPTION
There are lots of CI failures. This PR first fixes the failures related to the `yesno` recipe and gigaspeech recipe.
Later PRs will fix more CI failures.

Note that it tests only `torch>=2.2.0` since
- In torch < 2.2.0, `Sampler.__init__()` requires data_source as a positional argument
- lhotse's `CutSampler.__init__()` calls `super().__init__()` without arguments
- This causes `TypeError: Sampler.__init__()` missing 1 required positional argument: 'data_source'
- PyTorch 2.2.0 changed data_source to be optional (default None), fixing the issue